### PR TITLE
Update installation.md - add multicast group limit info

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -76,6 +76,14 @@ If you may run into any issues when using a docker install vs the recommended/st
 
 - Because the server heavily relies on multicast techniques like mDNS and uPnP to discover players in your network it MUST be run in the same Layer 2 network as your player devices.
 
+- if you see errors such as the following in the log files,
+  ```
+  File "/app/venv/lib/python3.12/site-packages/zeroconf/_utils/net.py", line 293, in add_multicast_member
+      listen_socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, _value)
+  OSError: [Errno 105] No buffer space available
+  ```
+  this is likely to be due to hitting the multicast group limit on your system. See https://unix.stackexchange.com/questions/23832/is-there-a-way-to-increase-the-20-multicast-group-limit-per-socket for more info
+
 - The server itself hosts a webserver to stream audio to devices. This webinterface must be accessible via HTTP by IP-address from local players. See the server's logging at startup to see if the server has correctly auto-detected the local IP.
 
 - The webinterface of the server can be reached on TCP port 8095 if enabled in the settings. By default, on HAOS based installations, the webserver is internal only and not exposed to the outside world. It is protected by HA authentication using the Ingress feature of Home Assistant (you also get the sidepanel shortcut for free!)


### PR DESCRIPTION
Adds info about multicast group limit to installation documentation.

Not sure if this should be added or not - the issue was raised as a ticket in the past https://github.com/music-assistant/support/issues/3124 and I've just hit it. 