### PR TITLE
Add music provider comparison table

### DIFF
--- a/docs/music-providers/index.md
+++ b/docs/music-providers/index.md
@@ -15,3 +15,14 @@ General Notes:
     If a problem occurs the automatic linking process may need to be initiated again. If what appears to be identical albums or tracks are seen then navigate to the album or track and using the ⋮ menu in the banner at the top of the view select "Refresh Item". This will trigger the linking process and should result in the same albums and tracks being collapsed together. Submit an issue report if this is required so that it can be investigated.
 
 ![image](../assets/screenshots/add-music-provider.png)
+
+## Music provider overview
+Not all music providers have been compared. Please refer to the relevant provider's page.
+| Provider      | Artists | Albums  | Tracks | Playlists | Radio | Max quality                |
+| ------------- | ------- | ------- | ------ | --------- | ----- | -------------------------- |
+| Apple music   | Yes     | Yes     | Yes    | Yes       | Yes   | Lossless (24-bit/192 kHz)  |
+| Spotify       | Yes     | Yes     | Yes    | Yes       | Yes   | Lossy (320kbps)            |
+| Tidal         | Yes     | Yes     | Yes    | Yes       | Yes   | Lossless (24-bit/192kHz)   |
+| Qobuz         | Yes     | Yes     | Yes    | Yes       | No    | Lossless (24-bit/192kHz)   |
+| Youtube Music | Yes     | Sort of | Yes    | Yes       | Yes   | Lossy (256kbps)            |
+| Deezer        | Yes     | Yes     | Yes    | Yes       | Yes   | Lossless (16-Bit/44.1 kHz) |


### PR DESCRIPTION
Hi,

My music subscription is due to expire and I'm exploring options, so I thought I'd compare them in a table. In doing so I've tried to add some features from Music Assistant (so I don't have to flip between pages to compare).

The quality column was generated by Ai so I cannot be certain it is correct, but it looks right to me.

I thought maybe we could add another column to show support level (i.e. complexity of using with Music Assistant) but wasn't sure if you'd want that.

Maybe this table will help others.

Thanks!