### PR TITLE
Add subsonic scrobbler documentation

### DIFF
--- a/docs/plugins/subsonic_scrobble.md
+++ b/docs/plugins/subsonic_scrobble.md
@@ -1,0 +1,21 @@
+---
+title: Subsonic Scrobbler Plugin
+description: Scrobbles back playback to your Subsonic media server
+---
+
+# Subsonic Scrobbler ![Preview image](../assets/icons/subsonic_icon.png){ width=70 align=right }
+
+Music Assistant has the ability to report your music playback back to your Subsonic media server [Subsonic music provider](/music-providers/subsonic/). Contributed and maintained by [Clusters](https://github.com/clusters)
+
+## Features
+
+- Report your music playbacks back to your Subsonic media server. Useful if you keep track of your play count or play history on your Subsonic media server.
+- Now playing feature is supported
+
+## Configuration
+
+- No plugin specific configuration necessary, but an Subsonic music provider must be configured in order to have the plugin working.
+
+## Known Issues / Notes
+
+- Currently songs will only get reported as played when they're fully played (90+%)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - Home Assistant Plugin: ha-plugin.md
     - LastFM Scrobbler: plugins/lastfm_scrobble.md
     - Listenbrainz Scrobbler: plugins/listenbrainz_scrobble.md
+    - Subsonic Scrobbler: plugins/subsonic_scrobble.md
     - plugins/spotify-connect.md
   - Community Extensions: community-extensions.md
   - Support: support.md


### PR DESCRIPTION
Just a small documentation page for the subsonic scrobbler plugin https://github.com/music-assistant/server/pull/2168