### PR TITLE
Fix companion app download links for Linux

### DIFF
--- a/docs/companion-app.md
+++ b/docs/companion-app.md
@@ -9,7 +9,7 @@
 
 The desktop companion app for Music Assistant!
 
-**Download for** macOS ([Apple Silicon](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_aarch64.dmg) | [Intel](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_x64.dmg)) · [Windows](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_x64_en-US.msi) · Linux ([Debian](https://github.com/music-assistant/companion/releases/download/v0.0.73/music-assistant-companion_0.0.73_amd64.deb) | [Other](https://github.com/music-assistant/companion/releases/download/v0.0.73/music-assistant-companion_0.0.73_amd64.AppImage))
+**Download for** macOS ([Apple Silicon](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_aarch64.dmg) | [Intel](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_x64.dmg)) · [Windows](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_x64_en-US.msi) · Linux ([Debian](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_amd64.deb) | [Other](https://github.com/music-assistant/companion/releases/download/v0.0.73/Music.Assistant.Companion_0.0.73_amd64.AppImage))
 
 !!! tip "This is still in very early alpha. Bugs *will* be present."
     Please help finding them. You can report any bugs on the [Discord server](https://discord.gg/kaVm8hGpne) or in the [repo issues](https://github.com/music-assistant/companion/issues)


### PR DESCRIPTION
When attempting to download the Linux releases from the Companion App doc, I
ended up on 404 pages: the links were wrong.

This PR fixes them
