### PR TITLE
Fix internal 404 links, wrong anchors, and mkdocs build warning

### DIFF
--- a/docs/audiopipeline.md
+++ b/docs/audiopipeline.md
@@ -27,7 +27,7 @@ The maximum sample rate that can be expected can be found in the [Player Provide
 ## Digital Signal Processing
 ![image](assets/screenshots/audiopipeline-dsp.png){ width=500 }
 
-In this example [DSP](player-support/index.md/#dsp-settings) has been enabled. High level information about the DSP filters which have been applied are shown. A tooltip is available to explain why the DSP is not supported if that is the case (See the example below in [Groups](#groups)).
+In this example [DSP](settings/individual-player.md/#dsp-settings) has been enabled. High level information about the DSP filters which have been applied are shown. A tooltip is available to explain why the DSP is not supported if that is the case (See the example below in [Groups](#groups)).
 
 Also of note in this example is the icon shown in the input section where the codec icon is normally. This icon will be displayed when MA cannot determine the codec and can occur with container formats such as [wavpack](https://www.wavpack.com/), [m4a](https://cloudinary.com/guides/video-formats/what-is-the-m4a-format-understanding-the-difference-between-m4a-mp3-and-wav) or [DSD64](https://en.wikipedia.org/wiki/Direct_Stream_Digital).
 

--- a/docs/faq/groups.md
+++ b/docs/faq/groups.md
@@ -10,7 +10,7 @@ description: Player Grouping Functionality in Music Assistant
 
 Music Assistant uses four types of groups (these are outlined in the [Grouping Players](../ui.md#grouping-players) section and three of the types are described in detail below) which provides a flexible way to combine players together. When a group is powered on then playback to individual members of the group is no longer possible. To play to an individual member, the group must be powered off or the individal player must be removed from the group. If the group is still powered on then players can only be removed from [Temporary Sync Groups](#temporary-sync-group), or from [Sync Groups](#sync-groups) and [Universal Groups](#universal-groups) which have the dynamic member option enabled. When allowable, players can be removed by using the checkboxes in the [Player List](../ui.md#player-list) or by using the [HA media_player.unjoin action](https://www.home-assistant.io/integrations/media_player/#media-control-actions).
 
-See also the section on Announcements [Group Behaviour](../integration/announcements/#group-behaviour).
+See also the section on Announcements [Group Behaviour](../integration/announcements.md#group-behaviour).
 
 ## Temporary Sync Group
 

--- a/docs/faq/groups.md
+++ b/docs/faq/groups.md
@@ -10,7 +10,7 @@ description: Player Grouping Functionality in Music Assistant
 
 Music Assistant uses four types of groups (these are outlined in the [Grouping Players](../ui.md#grouping-players) section and three of the types are described in detail below) which provides a flexible way to combine players together. When a group is powered on then playback to individual members of the group is no longer possible. To play to an individual member, the group must be powered off or the individal player must be removed from the group. If the group is still powered on then players can only be removed from [Temporary Sync Groups](#temporary-sync-group), or from [Sync Groups](#sync-groups) and [Universal Groups](#universal-groups) which have the dynamic member option enabled. When allowable, players can be removed by using the checkboxes in the [Player List](../ui.md#player-list) or by using the [HA media_player.unjoin action](https://www.home-assistant.io/integrations/media_player/#media-control-actions).
 
-See also the section on Announcements [Group Behaviour](../integration/announcements.md#group-behaviour).
+See also the section on Announcements [Group Behaviour](../integration/announcements.md/#group-behaviour).
 
 ## Temporary Sync Group
 

--- a/docs/faq/troubleshooting.md
+++ b/docs/faq/troubleshooting.md
@@ -110,7 +110,7 @@ For the iOS app see [here](https://community.home-assistant.io/t/anyone-know-how
 
 MA is an INPUT to your amplifier. So you need to power on your amplifier and then select the INPUT that MA is streaming to (e.g. AirPlay, DLNA, Chromecast). For this reason MA does not see the amplifier zones it only sees the compatible inputs of the amplifier. 
 
-Some amplifiers may auto turn on when a signal is detected so check the amplifier options. If this functionality is not available then you will need to power on the amplifier via another means which could be by [assigning a HA entity to the player control](../player-support/index.md#player-controls). 
+Some amplifiers may auto turn on when a signal is detected so check the amplifier options. If this functionality is not available then you will need to power on the amplifier via another means which could be by [assigning a HA entity to the player control](../settings/individual-player.md/#player-controls). 
 
 # My local music isn’t being imported or I’m seeing missing ID3 tag warnings in the logs
 

--- a/docs/music-providers/apple-music.md
+++ b/docs/music-providers/apple-music.md
@@ -16,7 +16,7 @@ Music Assistant has support for [Apple Music](https://music.apple.com/)! Contrib
 | [Recommendations](../ui.md#view-home) Supported | No |
 | Lyrics Supported | No |
 | [Radio Mode](../ui.md#track-menu) | Yes |
-| Maximum Stream Quality | [Lossy AAC (256kbps)](#known-issues--notes) |
+| Maximum Stream Quality | [Lossy AAC (256kbps)](#known-issues-notes) |
 | Login Method | Cookie |
 
 ### Other

--- a/docs/music-providers/builtin.md
+++ b/docs/music-providers/builtin.md
@@ -1,6 +1,6 @@
 # Builtin Provider  ![Preview image](../assets/icon.png){ width=70 align=right }
 
-The Builtin provider supports manually adding track and radio station URLs to the database and it also generates various [Playlists](../usage/#playlists).
+The Builtin provider supports manually adding track and radio station URLs to the database and it also generates various [Playlists](../usage.md/#playlists).
 
 ## Features
 

--- a/docs/player-support/squeezelite.md
+++ b/docs/player-support/squeezelite.md
@@ -9,7 +9,7 @@ Squeezelite clients are available for, and can run on, almost any hardware from 
 ## Features
 
 - Squeezelite client devices are automatically detected by Music Assistant
-- Individual player [DSP settings](index.md/#dsp-settings) will be used for [group](../faq/groups.md) playback
+- Individual player [DSP settings](../settings/individual-player.md/#dsp-settings) will be used for [group](../faq/groups.md) playback
 - Squeezelite client device buttons support
   - Any physical control buttons on the device should be supported as long as [flow mode](../faq/tech-info.md/#track-queueing) is not enabled
 

--- a/docs/settings/individual-player.md
+++ b/docs/settings/individual-player.md
@@ -66,7 +66,7 @@ There are a number of configurable options for controlling the volume of announc
 
 Each player has a number of options available to control the behaviour of the power, volume and mute controls in the MA UI. By default, if a device supports these controls then that native behaviour will be used or if the control is not supported then it will be disabled in the UI (the setting will indicate NONE). It is also possible to manually disable the controls by changing the setting to NONE.
 
-It is possible to map other HA entities to the MA player controls. in order for this to be an option the HA entities need to be first exposed to MA via the settings in the [HA Plugin](../ha-plugin.md/#configuring-the-home-assistant-plugin).
+It is possible to map other HA entities to the MA player controls. in order for this to be an option the HA entities need to be first exposed to MA via the settings in the [HA Plugin](../ha-plugin.md).
 
 **Power** If a player does not support power but it is desired that the player has an on and off state then a FAKE option is available which will simulate the on/off functionality. 
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -40,7 +40,7 @@ This view will change depending on screen width. With wider displays you will be
 
 The [Audio Pipeline](audiopipeline.md) selectable label is described above in the [Player Bar](#player-bar) section.
 
-You can also access the [Now Playing view directly via URL](faq/how-to.md/#access-the-now-playing-view-directly-via-url)
+You can also access the [Now Playing view directly via URL](faq/how-to.md/#now-playing-view)
 
 When the favourite icon is solid then selecting that will bring up two options - `Remove from Favorites` and `Add to Playlist`. It is possible that if the favorite status is changed from a different view after playback has commenced then the favourite status may not indicate correctly until playback of the track is restarted.
 ***************************************************************

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,7 +11,7 @@ nav:
       - Core Settings: settings/core.md
       - Player Provider Settings: settings/player-provider.md
       - Individual Player Settings: settings/individual-player.md
-      - Music Provider Settings: music-providers/#settings
+      - Music Provider Settings: music-providers/index.md
   - Home Assistant Integration:
       - integration/index.md
       - Installation: integration/installation.md


### PR DESCRIPTION
This PR contains 3 kind of related changes:

- Fix invalid internal relative links that led to 404 pages
- Fix links to invalid anchors
- Mkdocs nav config: link directly to Music Providers page instead of subsection

See below for the detailed explanations about these.

---

## Links to invalid _pages_

The following links led to unexisting pages, making readers end on a **404 page**:

- In `faq/groups.md` : link to `../integration/announcements/#group-behaviour`
- In `music-providers/builtin.md` : link to `../usage/#playlists`

They were both caused by a simple missing `.md` in the page filename.

## Links to invalid _anchors_

The following links led to invalid anchors, making readers end up on an existing page but no directly to the expected content:

- In `music-providers/apple-music.md` : link to `#known-issues--notes`
    - Just a typo in the anchor (double dash instead of single)
- In `ui.md` : link to `faq/how-to.md/#access-the-now-playing-view-directly-via-url`
    - While having such an explicit anchor would indeed be nice, the section is actually nested : How-to → "Access the MA Views directly via URL" → "Now Playing View". In the context of this PR, I limited myself to fixing the deadlink by using the existing minimally-descriptive `#now-playing-view` anchor. If having a more precise anchor in the link address was desired, I guess it could be achieved either by [using the `attr_list` extension and specifying the anchors directly](https://github.com/mkdocs/mkdocs/discussions/3754), or by finding some way to tell mkdocs to build anchors based on sections nesting (I'm not aware of such an existing thing)
- In `settings/individual-player.md` : link to `../ha-plugin.md/#configuring-the-home-assistant-plugin`
    - I fixed this by just removing the anchor and linking directly to the HA plugin doc page, but I'm not sure it was the _best_ way; I was unable to find something more precise that would be meaningful in the context of the link though. You might want to double check this.
- In `faq/troubleshooting.md` : link to `../player-support/index.md#player-controls`
    - → Linked to the `Player Controls` section in the "Server Install & configure" → "Individual Player Settings" page instead
- In `audiopipeline.md` : link to `player-support/index.md/#dsp-settings`
    - → Linked to the `DSP Settings` section in the "Server Install & configure" → "Individual Player Settings" page instead
- In `player-support/squeezelite.md` : link to `index.md/#dsp-settings`
    - → Linked to the `DSP Settings` section in the "Server Install & configure" → "Individual Player Settings" page instead

---

## On finding the issues & build warning

FYI, while my first 404-related PR (#374) was due to hitting the deadlink myself when bootstrapping Music Assistant, all of these were found by building the doc locally and getting the following being printed to stdout by `mkdocs serve`:

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/horgix/projects/oss-contribs/music-assistant.io/site
WARNING -  A reference to 'music-providers/#settings' is included in the 'nav' configuration, which is not found in the documentation files.
INFO    -  Doc file 'faq/groups.md' contains an unrecognized relative link '../integration/announcements/#group-behaviour', it was left as is. Did you mean '../integration/announcements.md#group-behaviour'?
INFO    -  Doc file 'music-providers/builtin.md' contains an unrecognized relative link '../usage/#playlists', it was left as is. Did you mean '../usage.md#playlists'?
INFO    -  Doc file 'audiopipeline.md' contains a link 'player-support/index.md/#dsp-settings', but the doc 'player-support/index.md' does not contain an anchor '#dsp-settings'.
INFO    -  Doc file 'ui.md' contains a link 'faq/how-to.md/#access-the-now-playing-view-directly-via-url', but the doc 'faq/how-to.md' does not contain an anchor '#access-the-now-playing-view-directly-via-url'.
INFO    -  Doc file 'faq/troubleshooting.md' contains a link '../player-support/index.md#player-controls', but the doc 'player-support/index.md' does not contain an anchor '#player-controls'.
INFO    -  Doc file 'music-providers/apple-music.md' contains a link '#known-issues--notes', but there is no such anchor on this page.
INFO    -  Doc file 'player-support/squeezelite.md' contains a link 'index.md/#dsp-settings', but the doc 'player-support/index.md' does not contain an anchor '#dsp-settings'.
INFO    -  Doc file 'settings/individual-player.md' contains a link '../ha-plugin.md/#configuring-the-home-assistant-plugin', but the doc 'ha-plugin.md' does not contain an anchor
           '#configuring-the-home-assistant-plugin'.
INFO    -  Documentation built in 2.92 seconds
```

And this is wad leads me to the last change in this PR, related to the only `WARNING` of that log:

```
WARNING -  A reference to 'music-providers/#settings' is included in the 'nav' configuration, which is not found in the documentation files.
```

It turns out that, while the `nav` config with:

```yaml
nav:
    - [...]
    - Server Install & Configure:
        - [...]
        - Music Provider Settings: music-providers/#settings
```

... actually creates a valid link when rendered, mkdocs detects it as being an non-existing page when checking the config.

**I took the liberty of just linking directly to the `Music Providers` page to avoid the warning, considering that the `Settings` section is the first one anyway, but I can revert that if preferred.**

---

## Validating changes

I rendered the doc locally to confirm everything was working as expected, and `mkdocs build -s` now doesn't output any of the warning mentioned above anymore :slightly_smiling_face: 

---

_Closing unrelated note: I only found out after my couple first PRs that there was a beta.music-assistant.io repository; should I send my PRs in the beta repository instead? (I believe I saw that you backported them over to it, thanks!)_
