### PR TITLE
CI: enable strict mode for mkdocs build to avoid deadlinks

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -27,4 +27,4 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs gh-deploy --force --strict


### PR DESCRIPTION
In order to actively prevent _internal_ deadlinks from being created when moving pages around and renaming sections, resulting in PRs like #376 to fix them, `mkdocs` can be told to run in _"strict" mode_, meaning it will actually fail (non-0 return code) when encountering a warning of any kind.

This PR enables this on the CI, allowing to detect through its failure if an
invalid internal link somewhat makes its way to the doc.

I can also enable it (only?) on PRs in order to prevent it before an invalid
link is pushed to `main` if you're OK with it!
