### PR TITLE
Update Apple Music docs to reflect recently merged features

### DIFF
--- a/src/content/docs/music-providers/apple-music.md
+++ b/src/content/docs/music-providers/apple-music.md
@@ -16,16 +16,18 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 |:-----------------------|:---------------------:|
 | Subscription FREE | No |
 | Self-Hosted Local Media   | No |
-| Media Types Supported | Artists, Albums, Tracks, Playlists |
-| [Recommendations](/ui/#view-home) Supported | No |
+| Media Types Supported | Artists, Albums, Tracks, Playlists, Artist Radio Stations |
+| [Recommendations](/ui/#view-home) Supported | Yes |
 | Lyrics Supported | No |
 | [Radio Mode](/ui/#track-menu) | Yes |
 | Maximum Stream Quality | [Lossy AAC (256kbps)](#known-issues--notes) |
-| Login Method | Cookie |
+| Login Method | OAuth or Cookie |
 
 ### Other
 
 - Searching the Apple Music catalogue
+- Browsing playlists organised in folders
+- Artist radio stations available via Browse and the Music Assistant [Home view](/ui/#view-home); live broadcast stations are not supported
 
 
 ## Configuration
@@ -71,6 +73,4 @@ The token needs to be retrieved through your browser. Instructions were written 
 - Due to Apple's proprietary encryption (FairPlay), Lossless and Dolby Atmos versions of songs are not supported
 - Due to limitations in the API, favouriting an item will only sync back to Apple Music for albums, playlists and tracks
 - Due to lack of an offical API, it can take up to 5 seconds to transition between tracks
-
-## Not yet supported
-- Library interaction, such as adding and removing items to your Apple Music library from within Music Assistant
+- Only user-created playlists can be edited; shared and curated playlists are read-only

--- a/src/content/docs/music-providers/apple-music.md
+++ b/src/content/docs/music-providers/apple-music.md
@@ -16,7 +16,7 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 |:-----------------------|:---------------------:|
 | Subscription FREE | No |
 | Self-Hosted Local Media   | No |
-| Media Types Supported | Artists, Albums, Tracks, Playlists, Artist Radio Stations |
+| Media Types Supported | Artists, Albums, Tracks, Playlists, Radio |
 | [Recommendations](/ui/#view-home) Supported | Yes |
 | Lyrics Supported | No |
 | [Radio Mode](/ui/#track-menu) | Yes |
@@ -27,7 +27,7 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 
 - Searching the Apple Music catalogue
 - Browsing playlists organised in folders
-- Artist radio stations available via Browse and the Music Assistant [Home view](/ui/#view-home); live broadcast stations are not supported
+- Artist radio stations available via Browse and the [Discover view](/ui/#view-home); live broadcast stations are not supported
 
 
 ## Configuration


### PR DESCRIPTION
Updates the Apple Music documentation to reflect features merged into `dev` in recent months.

**Changes:**
- Media Types: added Artist Radio Stations
- Recommendations Supported: No → Yes
- Login Method: Cookie → OAuth or Cookie
- Other features: added playlist folder browsing and artist radio stations (Browse + Home view)
- Known Issues: added note that only user-created playlists are editable
- Removed outdated "Not yet supported" section (library editing is now supported)

**Relevant merged PRs:**
- [#3008](https://github.com/music-assistant/server/pull/3008) — Playlist browsing with folders
- [#3095](https://github.com/music-assistant/server/pull/3095) — Fix syncing shared playlists
- [#3433](https://github.com/music-assistant/server/pull/3433) — Radio station support
- [#3622](https://github.com/music-assistant/server/pull/3622) — Station recommendations on Discover page

cc @MarvinSchenkel — as Apple Music maintainer, please verify the changes are accurate before merging.