### PR TITLE
docs(yandex): Media Types, My Wave / Wave Modes / My Presets, Device Flow auth

### DIFF
--- a/src/content/docs/music-providers/yandex-music.md
+++ b/src/content/docs/music-providers/yandex-music.md
@@ -24,12 +24,12 @@ This source is built on top of the [yandex-music-api](https://github.com/Marshal
 |           |                     |
 |:-----------------------|:---------------------:|
 | Self-Hosted Local Media | No |
-| Media Types Supported | Artists, Albums, Tracks, Playlists |
+| Media Types Supported | Artists, Albums, Tracks, Playlists, Podcasts, Audiobooks |
 | [Recommendations](/ui/#view---discover) Supported | Yes |
 | Lyrics Supported | Yes |
 | [Radio Mode](/ui/#track-menu) | Yes |
 | Maximum Stream Quality | Lossless FLAC (with Plus subscription) |
-| Login Method | Token |
+| Login Method | Device Flow / QR Code / Token |
 
 ### Other
 
@@ -39,27 +39,50 @@ This source is built on top of the [yandex-music-api](https://github.com/Marshal
 - Browse is available to explore the Yandex Music catalogue
 - Lyrics are displayed when available (synced line-by-line when provided by the service, otherwise plain text)
 - Personalized recommendations (My Wave, Made for You, Chart, New Releases and more) appear in the Recommendations section on the Home screen
-- Similar tracks are available from the track context menu (used by Radio Mode)
+- **My Wave** personalised radio with Yandex's long-lived rotor session (signals like/dislike, skips and full plays back to the recommendation algorithm)
+- **Wave Modes** — 11 one-click presets for My Wave (Discover / Favorites / Popular, Calm / Active / Fun / Sad, Russian / Non-Russian / Without Words)
+- **My Presets** — save your own named combinations of diversity, mood and language, re-launch them from Browse without fiddling with settings
+- Similar tracks are available from the track context menu (used by Radio Mode); when a wave track plays, Radio Mode continues the same Yandex-curated session instead of branching into an unrelated similar-tracks stream
+- **Podcasts** are synced from your Yandex library, browsable with episodes, and stream natively
+- **Audiobooks** are synced, browsable with chapters, and stream natively. Playback position round-trips between Music Assistant and Yandex's own apps, so resume points stay in sync
 - Multiple Yandex Music accounts can be added simultaneously
 
 ## Configuration
 
-Configuration requires obtaining an OAuth token from Yandex Music.
+The source supports three authentication methods. Device Flow is the recommended path — it's non-interactive, works on headless setups, and produces refreshable credentials.
 
-### Obtaining the Token
+### Option 1: Device Flow (recommended)
+
+1. In Music Assistant, add the Yandex Music source and click **Login with device code**
+2. A short verification URL and user code appear — open the URL on any device (phone, another computer) and enter the code
+3. Approve the request in your Yandex account
+4. Music Assistant receives the tokens automatically and finishes setup. Session tokens auto-refresh — no periodic re-login required.
+
+### Option 2: QR Code
+
+1. In Music Assistant, add the Yandex Music source and click **Login with QR code**
+2. Scan the QR with the Yandex app on your phone (signed into the account you want)
+3. Approve in the app — Music Assistant picks up the credentials
+
+### Option 3: Manual OAuth Token (advanced)
+
+For headless setups where neither device flow nor QR works:
 
 1. Open your browser and navigate to [Yandex OAuth](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d)
 2. Log in with your Yandex account if prompted
 3. After authorization, you will be redirected to a URL containing `access_token=YOUR_TOKEN`
 4. Copy the token value (the part after `access_token=` and before `&`)
-5. Paste this token into the Music Assistant Yandex Music source configuration
+5. Paste this token into the Music Assistant Yandex Music source configuration (under advanced settings)
 
 ### Settings
 
 - **Audio quality**: Select preferred audio quality. Options: `Efficient (AAC ~64 kbps)`, `Balanced (AAC ~192 kbps)` (default), `High (MP3 320 kbps)`, `Lossless (FLAC)` (requires Yandex Music Plus subscription)
+- **Remember session**: keeps the refresh token so tokens renew automatically (on by default for Device Flow / QR)
+- **My Wave custom presets**: advanced-settings builder for saving named wave combinations (name + up to three dropdowns). Saved entries surface under **Radio → My Presets** in Browse
 
 ## Known Issues / Notes
 
-- The token may expire and need to be refreshed periodically
+- Manually-obtained OAuth tokens expire and need to be refreshed periodically; Device Flow / QR setups auto-refresh
 - Lossless FLAC quality requires an active Yandex Music Plus subscription; without it the source falls back to the highest available quality
 - Lossless FLAC streams are fetched in 4 MB windows to work around Yandex CDN per-connection limits, ensuring uninterrupted playback for tracks of any length
+- Tracks played through Music Assistant currently **do not** appear in the Yandex Listening History feed — that feed is only written from an active Ynison WebSocket session. If you need Yandex-side history, play through the native Yandex app (or the companion [Yandex Music Connect (Ynison)](https://music-assistant.io/plugins/yandex-ynison/) plugin)


### PR DESCRIPTION
## Summary

Updates the Yandex Music source documentation to reflect features shipped in the provider after [#498](https://github.com/music-assistant/music-assistant.io/pull/498) — specifically ma-provider-yandex-music versions v3.0 through v3.4.0 (landing in core via [music-assistant/server#3606](https://github.com/music-assistant/server/pull/3606)).

## Changes

### Features table

| Feature | Before | After |
|---|---|---|
| Media Types Supported | Artists, Albums, Tracks, Playlists | **+ Podcasts, Audiobooks** |
| Login Method | Token | **Device Flow / QR Code / Token** |

### Other section — added

- **My Wave** personalised radio with long-lived rotor session (rotor signals like/dislike, skips and full plays back to the recommendation algorithm)
- **Wave Modes** — 11 one-click presets (Discover / Favorites / Popular · Calm / Active / Fun / Sad · Russian / Non-Russian / Without Words)
- **My Presets** — user-saved named combinations of diversity, mood and language, launchable from Browse
- Radio Mode from a wave track continues the *same* Yandex-curated session instead of branching into an unrelated similar-tracks stream
- Podcasts are synced, browsable with episodes, and stream natively
- Audiobooks are synced, browsable with chapters, stream natively, and resume points round-trip between Music Assistant and Yandex's own apps

### Configuration section — rewritten

Three authentication methods now, each as its own subsection. Device Flow is presented first as the recommended path (non-interactive, refreshable). QR second. Manual OAuth token stays as advanced/fallback.

### Settings — expanded

- Added **Remember session** toggle
- Added **My Wave custom presets** builder (the advanced-settings UI that backs the My Presets browse folder)

### Known Issues / Notes — added

- Clarified that Yandex Listening History is written only from an Ynison WebSocket session — tracks played through MA's Yandex Music source do *not* appear in Yandex's own history feed unless the companion [Yandex Music Connect (Ynison)](https://music-assistant.io/plugins/yandex-ynison/) plugin is also installed. This came up repeatedly during v3.4 rollout.
- Split the "token expires and needs refresh" note: only applies to manual OAuth tokens; Device Flow / QR setups auto-refresh.

## Related

- **In-tree sync PR (the feature work this doc describes):** [music-assistant/server#3606](https://github.com/music-assistant/server/pull/3606)
- Provider implementation: [trudenboy/ma-provider-yandex-music](https://github.com/trudenboy/ma-provider-yandex-music) (v3.4.0)
- Previous docs update this builds on: [#498](https://github.com/music-assistant/music-assistant.io/pull/498)
