### PR TITLE
Update Apple Music docs to reflect recently merged features

### DIFF
--- a/src/content/docs/music-providers/apple-music.md
+++ b/src/content/docs/music-providers/apple-music.md
@@ -17,7 +17,7 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 | Subscription FREE | No |
 | Self-Hosted Local Media   | No |
 | Media Types Supported | Artists, Albums, Tracks, Playlists, Radio |
-| [Recommendations](/ui/#view---discover) Supported | Yes |
+| [Recommendations](/ui/#view-home) Supported | Yes |
 | Lyrics Supported | No |
 | [Radio Mode](/ui/#track-menu) | Yes |
 | Maximum Stream Quality | [Lossy AAC (256kbps)](#known-issues--notes) |
@@ -27,7 +27,7 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 
 - Searching the Apple Music catalogue
 - Browsing playlists organised in folders
-- Artist radio stations available via Browse and the [Discover view](/ui/#view---discover); live broadcast stations are not supported
+- Artist radio stations available via Browse and the [Recommendations](/ui/#view-home) section; live broadcast stations are not supported
 
 
 ## Configuration


### PR DESCRIPTION
Updates the Apple Music documentation to reflect features merged into `dev` (not yet in stable).

**Changes:**
- Media Types Supported: added `Radio`
- Recommendations Supported: `No` → `Yes`
- Login Method: `Cookie` → `OAuth or Cookie`
- Added: browsing playlists organised in folders
- Added: artist radio stations available via Browse and the Recommendations section; live broadcast stations are not supported
- Removed: "Not yet supported" section (library editing is now supported)
- Added: note that only user-created playlists are editable

**Related server PRs (all targeting `dev`):**
- music-assistant/server#3008
- music-assistant/server#3095
- music-assistant/server#3433
- music-assistant/server#3622

cc @MarvinSchenkel for review
