### PR TITLE
Document one-click LastFM auth

### DIFF
--- a/src/content/docs/plugins/lastfm_scrobble.md
+++ b/src/content/docs/plugins/lastfm_scrobble.md
@@ -14,12 +14,22 @@ Music Assistant has the ability to <a href="https://www.collinsdictionary.com/di
 
 ## Configuration
 
-- First obtain the API credentials. For LastFM follow the first two steps from <a href="https://www.last.fm/api/authentication" target="_blank" rel="noopener noreferrer">here</a>
-- Enter your credentials and click `Authorize with LastFM`, this will open a new tab with LastFM where permission must be given by clicking "Yes, allow access"
+For LastFM, Music Assistant includes the required API credentials. You do not need to create a LastFM API application.
+
+- Leave the Provider set to `Last.FM`
+- Click `Authorize with lastfm`, this will open a new tab with LastFM where permission must be given by clicking "Yes, allow access"
 - The UI will indicate a successful login. Ensure to click SAVE to complete the configuration
+
+> [!NOTE]
+> The LastFM authorization callback uses the Music Assistant Base URL from Settings > System > Webserver. If authorization does not return to Music Assistant, set the Base URL to the same URL that you use to open Music Assistant in your browser.
+
+For LibreFM, or to use your own LastFM API application, open the advanced settings and enter the API Key and Shared secret before authorizing. LibreFM always requires custom API credentials.
 
 ### Settings
 
+- <b>Provider.</b> Select `Last.FM` for LastFM scrobbling or `LibreFM` for LibreFM scrobbling
+- <b>API Key.</b> Advanced setting to override the built-in LastFM API key. Required for LibreFM
+- <b>Shared secret.</b> Advanced setting to override the built-in LastFM shared secret. Required for LibreFM
 - <b>Suffix version to track names.</b> This adds the version, as stored in the Music Assistant database, to the end of the track name when it is sent to Last.fm. This may be useful if Musicbrainz IDs are not available to disambiguate same named tracks from an artist
 - <b>Scrobble for users.</b> This allows selection of which logged-in user will be scrobbled by this plugin. Multiple instances of this plugin can be added
 - <b>Scrobble for players.</b> This allows selection of which players will register scrobbles


### PR DESCRIPTION
## Motivation

music-assistant/server#3739 added built-in LastFM API credentials and one-click authorization for the LastFM Scrobbler provider. The beta docs still told users to create their own LastFM API application before authorizing.

## Summary

- Update the LastFM Scrobbler configuration docs to describe the new default one-click LastFM authorization flow.
- Add a note about the Music Assistant Base URL being used for the LastFM authorization callback.
- Clarify that API Key and Shared secret are now advanced settings for LastFM overrides, and remain required for LibreFM.

## Testing

- [x] Ran `npm run build`
- [x] Ran `git diff --check`

## Related

- music-assistant/server#3739
