### PR TITLE
docs(plugins): add FastMCP Server plugin page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -263,6 +263,7 @@ export default defineConfig({
 					items: [
 						{ label: 'AirPlay Receiver', slug: 'plugins/airplay-receiver' },
 						{ label: 'Ariacast Receiver', slug: 'plugins/ariacast-receiver' },
+						{ label: 'FastMCP Server', slug: 'plugins/fastmcp-server' },
 						{ label: 'Home Assistant', slug: 'ha-plugin' },
 						{ label: 'Hue Entertainment', slug: 'plugins/hue-entertainment' },
 						{ label: 'LastFM Scrobbler', slug: 'plugins/lastfm_scrobble' },

--- a/public/assets/icons/fastmcp-server-icon.svg
+++ b/public/assets/icons/fastmcp-server-icon.svg
@@ -1,0 +1,12 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_19_13)">
+<path d="M18 84.8528L85.8822 16.9706C95.2548 7.59798 110.451 7.59798 119.823 16.9706V16.9706C129.196 26.3431 129.196 41.5391 119.823 50.9117L68.5581 102.177" stroke="black" stroke-width="12" stroke-linecap="round"/>
+<path d="M69.2652 101.47L119.823 50.9117C129.196 41.5391 144.392 41.5391 153.765 50.9117L154.118 51.2652C163.491 60.6378 163.491 75.8338 154.118 85.2063L92.7248 146.6C89.6006 149.724 89.6006 154.789 92.7248 157.913L105.331 170.52" stroke="black" stroke-width="12" stroke-linecap="round"/>
+<path d="M102.853 33.9411L52.6482 84.1457C43.2756 93.5183 43.2756 108.714 52.6482 118.087V118.087C62.0208 127.459 77.2167 127.459 86.5893 118.087L136.794 67.8822" stroke="black" stroke-width="12" stroke-linecap="round"/>
+</g>
+<defs>
+<clipPath id="clip0_19_13">
+<rect width="180" height="180" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/content/docs/plugins/fastmcp-server.md
+++ b/src/content/docs/plugins/fastmcp-server.md
@@ -1,0 +1,56 @@
+---
+title: FastMCP Server Plugin
+description: Features and Notes for the FastMCP Server Plugin
+---
+
+# FastMCP Server <img src="/assets/icons/fastmcp-server-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
+
+Music Assistant has the ability to expose its library, queue, playback and player controls as a <a href="https://modelcontextprotocol.io/" target="_blank" rel="noopener noreferrer">Model Context Protocol (MCP)</a> server, so AI assistants like Claude, ChatGPT, Cursor and Codex can search your library, control playback and manage queues on your behalf using natural language.
+
+> [!NOTE]
+> This plugin is still in an early stage of development. Bugs may occur.
+
+## Features
+
+- Any MCP-aware AI client can connect to your Music Assistant library through a single URL
+- One-click Connect Wizard with ready-to-paste configuration for Claude Desktop, Claude Code, Cursor, Windsurf, VSCode, ChatGPT Connectors, Codex CLI, Gemini CLI, Cline and Zed
+- Each connected client gets its own access token, revocable individually under Profile → Long-lived access tokens
+- Nineteen fine-grained permission toggles let you decide what each connected AI client may do — browse the library, control playback, manage queues, edit playlists, remove favourites, and choose which URI-addressable resources the client can see
+- Optional confirmation prompt before destructive actions like clearing a queue or removing a track from the library
+- Reuses the Music Assistant webserver — no extra port to open, works behind reverse proxies and Home Assistant ingress out of the box
+- Permission changes take effect immediately without restarting Music Assistant
+
+## Configuration
+
+The plugin is single-instance. Add it to Music Assistant by navigating to the MA Settings then selecting Plugins and then clicking on ADD A PLUGIN.
+
+### Connecting an AI client
+
+Once the plugin has been added, the Connect Wizard becomes available from the plugin's configuration panel. To connect a new client:
+
+1. Open the plugin settings and click **Open Connect Wizard**.
+2. Pick your AI client from the list.
+3. The wizard mints a long-lived token, names it after the client (for example `MCP — Claude Desktop`), and shows a ready-to-paste configuration snippet.
+4. Paste the snippet into your client's MCP configuration, or — for Cursor — click the **Add to Cursor** deep-link.
+
+Regenerating the snippet for a client revokes the previous token for that same client, so stale credentials are never left behind.
+
+### Settings
+
+- <b>Require authentication.</b> Reject MCP clients that do not present a valid Music Assistant token. Strongly recommended to leave enabled.
+- <b>Confirm destructive operations.</b> Ask the client to confirm before clearing a queue, removing a library item or deleting a playlist. Falls through to the matching permission toggle on clients that do not yet support confirmation prompts.
+- <b>Permissions.</b> Nineteen toggles in total — sixteen action toggles split across Query Permissions, Control Permissions, Edit Permissions and Delete Permissions, plus three MCP Resources toggles that control which library, player/queue and prompt resources are advertised to clients. The defaults enable read-only access only; every action that mutates state is off by default.
+
+In the ADVANCED section:
+
+- <b>Mount path.</b> The URL path the MCP server is mounted under on the Music Assistant webserver. Default `/mcp/v1`. Change only if it conflicts with another route.
+- <b>Enforce token audience (RFC 8707).</b> Rejects tokens that are not bound to this MCP server's URL. Leave off until Music Assistant issues audience-bound tokens by default.
+- <b>Additional allowed Origins (CSV).</b> Comma-separated list of additional Origin headers to accept, on top of the Music Assistant hosts that are auto-detected.
+- <b>Connect Wizard external URL (fallback).</b> Explicit base URL the Connect Wizard should use in the generated snippets. Only needed when the wizard cannot detect the public URL from the active client's request headers.
+
+## Known Issues / Notes
+
+- The plugin is experimental and the Model Context Protocol itself is still evolving, so behaviour may change between Music Assistant releases.
+- AI clients vary in how strictly they implement MCP. Clients that do not support confirmation prompts will instead be gated entirely by the relevant permission toggle.
+- All write permissions are disabled by default. Enable only the actions you want each connected AI client to be able to perform.
+- Tokens minted by the Connect Wizard are long-lived. Revoke any client you no longer trust from Profile → Long-lived access tokens.


### PR DESCRIPTION
Adds documentation for the FastMCP Server plugin
([trudenboy/ma-provider-mcp](https://github.com/trudenboy/ma-provider-mcp)),
which exposes Music Assistant over the
[Model Context Protocol](https://modelcontextprotocol.io/) so AI
clients (Claude Desktop / Claude Code / Cursor / Windsurf / VSCode /
ChatGPT Connectors / Codex CLI / Gemini CLI / Cline / Zed) can browse
the library, manage queues and drive playback through a single URL.

The page follows the established plugin layout (Features /
Configuration / Known Issues) and mirrors the structure of
`plex-connect.md`. It adds:

- `src/content/docs/plugins/fastmcp-server.md`
- `public/assets/icons/fastmcp-server-icon.svg`
- one sidebar entry in `astro.config.mjs` (alphabetical, between Ariacast Receiver and Home Assistant)

The corresponding upstream provider PR is
[music-assistant/server#3858](https://github.com/music-assistant/server/pull/3858).