### PR TITLE
Update Apple Music and TuneIn documentation

### DIFF
--- a/src/content/docs/music-providers/apple-music.md
+++ b/src/content/docs/music-providers/apple-music.md
@@ -17,7 +17,7 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 | Subscription FREE | No |
 | Self-Hosted Local Media   | No |
 | Media Types Supported | Artists, Albums, Tracks, Playlists, Radio |
-| [Recommendations](/ui/#view---discover) Supported | Yes |
+| [Recommendations](/ui/#view-home) Supported | Yes |
 | Lyrics Supported | No |
 | [Radio Mode](/ui/#track-menu) | Yes |
 | Maximum Stream Quality | [Lossy AAC (256kbps)](#known-issues--notes) |
@@ -27,7 +27,7 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 
 - Searching the Apple Music catalogue
 - Browsing playlists organised in folders
-- Artist radio stations available via Browse and the [Discover view](/ui/#view---discover); live broadcast stations are not supported
+- Artist radio stations available via Browse and the [Recommendations](/ui/#view-home) section; live broadcast stations are not supported
 
 
 ## Configuration


### PR DESCRIPTION
Updates Apple Music and TuneIn documentation to reflect recently added features:

**Apple Music:**
- Added Radio to supported media types
- Recommendations: Yes (artist radio stations via Browse and Recommendations section)
- Login method: OAuth or Cookie
- Added: browsing playlists in folders
- Removed "Not yet supported" section; added note about read-only shared playlists

**TuneIn:**
- Recommendations: Yes (trending stations shown on Home screen)
- Added: auto-imported presets info, Browse view by category