### PR TITLE
Apple Music: document similar tracks/artists and library edit limitations

### DIFF
--- a/src/content/docs/music-providers/apple-music.md
+++ b/src/content/docs/music-providers/apple-music.md
@@ -28,6 +28,8 @@ Music Assistant has support for <a href="https://music.apple.com/" target="_blan
 - Searching the Apple Music catalogue
 - Browsing playlists organised in folders
 - Artist radio stations available via Browse and the [Discover view](/ui/#view---discover); live broadcast stations are not supported
+- Similar tracks are supported, shown in the track detail view and available for Radio Mode
+- Similar artists are supported and shown in the artist detail view
 
 
 ## Configuration


### PR DESCRIPTION
Updates the Apple Music provider documentation:

- Similar tracks are supported (shown in track detail view, available for Radio Mode)
- Similar artists are supported (shown in artist detail view)
- Removing items from the library is not supported by the Apple Music API
- Removing tracks from playlists is not supported by the Apple Music API