### PR TITLE
Fix 'Naba Casa' > 'Nabu Casa' typo

### DIFF
--- a/src/content/docs/settings/remote-access.md
+++ b/src/content/docs/settings/remote-access.md
@@ -12,7 +12,7 @@ Remote Access allows you to securely connect to your Music Assistant server from
 - For those with a Nabu Casa subscription, ensure the option `WebRTC Connections` (in the Home Assistant Cloud settings) is ON
 
 > [!NOTE]
-> A Nabu Casa subscription is not required for this functionality unless running in a complex network environment. For example, double NAT or mobile carriers or corporate networks blocking standard <a href="https://medium.com/@jamesbordane57/what-is-a-stun-server-df3563dbf14a" target="_blank" rel="noopener noreferrer">STUN servers</a>. This is where TURN servers (which Naba Casa provides) are useful as they basically relay the traffic.
+> A Nabu Casa subscription is not required for this functionality unless running in a complex network environment. For example, double NAT or mobile carriers or corporate networks blocking standard <a href="https://medium.com/@jamesbordane57/what-is-a-stun-server-df3563dbf14a" target="_blank" rel="noopener noreferrer">STUN servers</a>. This is where TURN servers (which Nabu Casa provides) are useful as they basically relay the traffic.
 
 Setup is automatic and further instructions are shown in the MA UI
 


### PR DESCRIPTION
Fix 'Naba Casa' > 'Nabu Casa' typo in Remote Access doc.