### PR TITLE
Document sidebar shortcuts in UI settings

### DIFF
--- a/src/content/docs/settings/user-interface.md
+++ b/src/content/docs/settings/user-interface.md
@@ -15,16 +15,6 @@ Customise the user interface from this page
 - <b>Force mobile layout.</b> The mobile layout has the menu at the bottom and has icons for HOME, and SEARCH and the remainder of the items are accessed via a single library icon
 - <b>Mobile sidebar side.</b> Which side the navigation menu opens from. Default is left
 
-## Sidebar Shortcuts
-
-Use shortcuts to pin frequently used library items to the sidebar for quick access.
-
-- Pin an item from its context menu (`...` or right-click) by selecting **Add to shortcuts**.
-- Remove it from the same menu with **Remove from shortcuts**.
-- Shortcuts are stored per user account.
-- If a pinned item is updated (for example renamed), the shortcut is updated automatically.
-- If a pinned item is deleted, it is removed from shortcuts automatically.
- 
 ## Web Player
 
 - <b>Enable built-in (Sendspin) Web Player.</b> Allows playback to THIS DEVICE

--- a/src/content/docs/settings/user-interface.md
+++ b/src/content/docs/settings/user-interface.md
@@ -14,6 +14,16 @@ Customise the user interface from this page
 - <b>Enable browser media controls</b> Allow control of playback using the browser's built in media controls (e.g. keyboard media keys)
 - <b>Force mobile layout.</b> The mobile layout has the menu at the bottom and has icons for HOME, and SEARCH and the remainder of the items are accessed via a single library icon
 - <b>Mobile sidebar side.</b> Which side the navigation menu opens from. Default is left
+
+## Sidebar Shortcuts
+
+Use shortcuts to pin frequently used library items to the sidebar for quick access.
+
+- Pin an item from its context menu (`...` or right-click) by selecting **Add to shortcuts**.
+- Remove it from the same menu with **Remove from shortcuts**.
+- Shortcuts are stored per user account.
+- If a pinned item is updated (for example renamed), the shortcut is updated automatically.
+- If a pinned item is deleted, it is removed from shortcuts automatically.
  
 ## Web Player
 

--- a/src/content/docs/ui.md
+++ b/src/content/docs/ui.md
@@ -11,6 +11,16 @@ description: A Walkthrough of the Music Assistant User Interface
 
 This menu's appearance can be configured in Settings / User Interface. On a desktop, it can be placed vertically on the left (as shown) or horizontally at the bottom (by selecting "Force mobile layout"). In the mobile layout, Menu, Discover, Search, and Players will be seen. The enabled menu items (Views) are displayed in the order they were selected in the User Interface settings. Any of the views can be hidden. If the Settings view is hidden from the menu it can be accessed by navigating to `YOUR_MA_IP_ADDRESS:8095/#/settings`
 
+### Sidebar Shortcuts
+
+Use shortcuts to pin frequently used library items to the main menu for quick access.
+
+- Add a shortcut from an item's context menu (⋮ menu, right click, or long press) by selecting **Add to shortcuts**.
+- Remove it from the same menu with **Remove from shortcuts**.
+- Shortcuts are stored per user account.
+- If a pinned item is updated (for example renamed), the shortcut is updated automatically.
+- If a pinned item is deleted, it is removed from shortcuts automatically.
+
 ***************************************************************
 
 ## Global Search


### PR DESCRIPTION
## Summary
Add a Sidebar Shortcuts section to the User Interface docs.

## What changed
- Added a new **### Sidebar Shortcuts** subsection under the **Main Menu** section in `ui.md`.
- Documented how to add/remove shortcuts from the context menu.
- Clarified that the context menu can be opened via the ⋮ menu, right-click, or long press.
- Added behavior notes for per-user storage and automatic update/removal behavior.