### PR TITLE
Plex Connect: added additional information

### DIFF
--- a/src/content/docs/plugins/plex-connect.md
+++ b/src/content/docs/plugins/plex-connect.md
@@ -18,6 +18,8 @@ Music Assistant has the ability to expose MA players to Plex clients like Plexam
 - Queue management: add tracks, reorder, clear queue
 - Access to Plex features: Sonic Adventures, Radio, DJs, Mixes
 - Playback state, current track, progress, and queue are synchronized in real-time
+- Volume control works on groups and sync groups, adjusting the members together while keeping their balance
+- If a player already has a queue when the plugin starts, that queue is sent to Plex so you can see and control it straight away
 - Playback activity is reported to the Plex server
 - Listening history and scrobbles are visible in Plex dashboard
 - Supports Plex features like "Continue Listening"
@@ -26,7 +28,19 @@ Music Assistant has the ability to expose MA players to Plex clients like Plexam
 
 To make each player appear as a Plex Connect target in Plex clients, the Plex Connect plugin needs to be added individually for each player. The plugin is added by navigating to the MA Settings then selecting Plugins and then clicking on ADD A PLUGIN.
 
+### Configuration Options
+
+- **Plex Music Provider**: the Plex music source this instance connects to (required).
+- **Music Assistant Player**: the MA player to expose as a Plex remote client.
+- **Player Name in Plex**: the name shown for this player in Plex apps. Leave empty to use the player's name.
+- **Device Class**: how the player shows up in Plex apps. Choose from Speaker, Phone, Tablet, Set-Top Box, TV, PC or Cloud.
+- **Network Port** (advanced): the TCP port this player is reachable on. Leave it empty to have Music Assistant pick a free port and remember it, so the instance keeps the same port after a restart.
+
 ## Known Issues / Notes
 
 - To use Plex Connect, all devices must be connected to the same network
 - Timeline reporting to the Plex server is done on a per-player basis
+- A queue loaded from Plex is capped at 100 tracks to keep loading and syncing responsive
+- Each plugin instance keeps the same network port across restarts. If you run several instances, give each one a different port, or leave the port empty and let Music Assistant pick and remember a free one for each
+- Plex does not offer a public protocol for controlling Plex players, so this plugin builds on the reverse-engineering work done by others. A Plex update could stop it from working overnight, and there is no guarantee it can be fixed
+- Playback is driven by Music Assistant, not by Plex, so features are mirrored by MA and are not exactly the same as playing on a real Plex client. The sweet fades and the shuffling, for example, are handled on the MA side


### PR DESCRIPTION
In line with the new refactor, here are a couple of additional information for people that run this plugin. I have also seen people complaining about some features being slightly different than with native Plex clients: the doc now clarifies this specific aspect.