### PR TITLE
Serve App Links / Universal Links association files

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "5J5R9QK64D.io.music-assistant.client",
+        "paths": ["/app/*"]
+      }
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,13 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "io.music_assistant.client",
+      "sha256_cert_fingerprints": [
+        "79:A9:D6:11:30:20:3E:3D:7A:D5:69:BF:F8:D6:43:4B:B0:35:10:C3:80:C5:9D:A8:FF:F4:9D:7F:C4:EF:88:01",
+        "B4:A2:9D:A8:82:7F:D5:A3:8F:DA:44:7B:07:CD:00:1C:AE:6B:BC:4D:36:10:A5:06:7E:F4:51:47:5D:A3:EB:27"
+      ]
+    }
+  }
+]

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/.well-known/apple-app-site-association
+  Content-Type: application/json


### PR DESCRIPTION
Deep links into the Music Assistant mobile app (`https://…/app/…`) only verify if the platform association files are served from the website. These are currently staged in the mobile-app repo but not hosted anywhere, so links open the browser instead of the app.

This adds both files under `public/.well-known/` so Astro serves them at the site root (`https://www.music-assistant.io/.well-known/…`).

## Changes
- Add `public/.well-known/assetlinks.json` — Android App Links verification
- Add `public/.well-known/apple-app-site-association` — iOS Universal Links verification

## Note for deploy
Both must be served as `application/json` over HTTPS with HTTP 200 and no redirect, on `www.` and the apex. The extensionless `apple-app-site-association` in particular may need a host/CDN Content-Type rule.