### PR TITLE
Provide info on how to establish a Sendspin connection to MA

### DIFF
--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -25,7 +25,9 @@ Because Sendspin is **license-free and open source**, anyone can build apps, dev
 
 The Sendspin provider is **built-in and always enabled**. There are no configuration options required to get started.
 
-Individual Sendspin players will appear automatically when clients connect
+Individual Sendspin players will appear automatically when clients connect.
+
+External Sendspin clients can connect using the `/sendspin` WebSocket endpoint on port `8927`, so a full connection URL will look like `ws://100.64.2.30:8927/sendspin` (replacing 100.64.2.30 with the IP address of Music Assistant).
 
 ## Settings
 

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -27,7 +27,7 @@ The Sendspin provider is **built-in and always enabled**. There are no configura
 
 Individual Sendspin players will appear automatically when clients connect.
 
-External Sendspin clients can connect using the `/sendspin` WebSocket endpoint on port `8927`, so a full connection URL will look like `ws://100.64.2.30:8927/sendspin` (replacing 100.64.2.30 with the IP address of Music Assistant).
+External Sendspin clients can connect using the `/sendspin` WebSocket endpoint on port `8927`. A full connection URL will look like `ws://100.64.2.30:8927/sendspin` (replacing 100.64.2.30 with the IP address of Music Assistant).
 
 ## Settings
 


### PR DESCRIPTION
### Motivation

I was trying to build my own Sendspin client using Rust, and was hitting my head against the wall because the `/sendspin` WS endpoint on port 8095 immediately closed my connections.

I finally realised that the Sendspin server actually listens on port **8927, so I wanted to update the documentation to let people know exactly what Sendspin URL they need to give to a third-party/external Sendspin server.

### This PR

I added the following paragraph to the Sendspin-audio Provider page, in the _Configuration_ section:

> External Sendspin clients can connect using the `/sendspin` WebSocket endpoint on port `8927`, so a full connection URL will look like `ws://100.64.2.30:8927/sendspin` (replacing 100.64.2.30 with the IP address of Music Assistant).

### Notes

Let me know if you want any changes to the phrasing (or, if you want to close this PR and add the info yourself to another section, I will not take offense!)

I have not tested this locally, since it is (hopefully) a text-only change :)