### PR TITLE
Add explicit content filter documentation to smart playlists

### DIFF
--- a/src/content/docs/plugins/smart_playlist.md
+++ b/src/content/docs/plugins/smart_playlist.md
@@ -70,7 +70,7 @@ Explicit content filter options:
 - **Explicit only**: include only tracks marked as explicit content
 - **Not allowed**: exclude all tracks marked as explicit content
 
-Note: Explicit content filtering depends on your music provider supplying explicit markers in their metadata. Not all music providers include this information, and availability varies by provider and region. If your provider does not supply explicit markers, this filter will have no effect.
+**Note:** Explicit content filtering depends on your music provider supplying explicit markers in their metadata. Not all music providers include this information, and availability varies by provider and region. If your provider does not supply explicit markers, this filter will have no effect.
 
 In **From my library** mode you can choose whether tracks must match **all** rules or **any** rule.
 

--- a/src/content/docs/plugins/smart_playlist.md
+++ b/src/content/docs/plugins/smart_playlist.md
@@ -46,6 +46,7 @@ Smart playlists use include/exclude style rules:
 - **Artist**: is / is not (library mode, one or more artists)
 - **Album**: is / is not (library mode, one or more albums)
 - **Album type**: is / is not (filter by album type: album, single, EP, compilation, etc.)
+- **Explicit**: filter tracks by explicit content marker (three options: allowed, explicit only, not allowed)
 - **Favorite**: yes (library mode)
 - **Year**: between from/to (you can also use only `from` or only `to`).
 
@@ -63,6 +64,14 @@ Album type examples:
 
 Available album types: **Album**, **Single**, **EP**, **Compilation**, **Live**, **Soundtrack**, **Audiobook**, **Podcast**, **Unknown album type** (albums without a specific type classification or where the music provider does not provide type information).
 
+Explicit content filter options:
+
+- **Allowed**: include both explicit and non-explicit tracks (no filtering)
+- **Explicit only**: include only tracks marked as explicit content
+- **Not allowed**: exclude all tracks marked as explicit content
+
+Note: Explicit markers depend on your music provider's metadata and may not be available for all tracks.
+
 In **From my library** mode you can choose whether tracks must match **all** rules or **any** rule.
 
 In **Discover mode**, filters are applied to the provider result after similar content is fetched.
@@ -70,6 +79,15 @@ In **Discover mode**, filters are applied to the provider result after similar c
 ![Rule examples in From my library mode](/assets/screenshots/smart_playlist/rules_example.png)
 
 ## Discover mode
+
+:::note[Best Effort Service]
+Discover mode relies on external music provider APIs for content recommendations. Results depend on:
+- Provider availability and API limits
+- Seed track/artist/album recognition by the provider
+- Provider-specific recommendation algorithms
+
+Quality and availability of results may vary between providers and over time.
+:::
 
 When using **Discover mode**:
 

--- a/src/content/docs/plugins/smart_playlist.md
+++ b/src/content/docs/plugins/smart_playlist.md
@@ -46,7 +46,7 @@ Smart playlists use include/exclude style rules:
 - **Artist**: is / is not (library mode, one or more artists)
 - **Album**: is / is not (library mode, one or more albums)
 - **Album type**: is / is not (filter by album type: album, single, EP, compilation, etc.)
-- **Explicit**: filter tracks by explicit content marker (three options: allowed, explicit only, not allowed)
+- **Explicit**: filter tracks by explicit content marker (three options: allowed, explicit only, not allowed; provider-dependent)
 - **Favorite**: yes (library mode)
 - **Year**: between from/to (you can also use only `from` or only `to`).
 
@@ -70,7 +70,7 @@ Explicit content filter options:
 - **Explicit only**: include only tracks marked as explicit content
 - **Not allowed**: exclude all tracks marked as explicit content
 
-Note: Explicit markers depend on your music provider's metadata and may not be available for all tracks.
+Note: Explicit content filtering depends on your music provider supplying explicit markers in their metadata. Not all music providers include this information, and availability varies by provider and region. If your provider does not supply explicit markers, this filter will have no effect.
 
 In **From my library** mode you can choose whether tracks must match **all** rules or **any** rule.
 

--- a/src/content/docs/plugins/smart_playlist.md
+++ b/src/content/docs/plugins/smart_playlist.md
@@ -80,6 +80,8 @@ In **Discover mode**, filters are applied to the provider result after similar c
 
 ## Discover mode
 
+Discover mode fetches similar content from your streaming providers based on seed items.
+
 :::note[Best Effort Service]
 Discover mode relies on external music provider APIs for content recommendations. Results depend on:
 - Provider availability and API limits


### PR DESCRIPTION
## Changes

Adds documentation for the new explicit content filter feature in smart playlists:

- **Explicit filter rule** with three options:
  - **Allowed**: include both explicit and non-explicit tracks (no filtering)
  - **Explicit only**: include only tracks marked as explicit content
  - **Not allowed**: exclude all tracks marked as explicit content

- **Best effort disclaimer** for Discover mode explaining dependency on external provider APIs

- **Note about metadata dependency** - explicit markers depend on music provider's metadata and may not be available for all tracks

## Related

- Frontend PR: music-assistant/frontend#1865 (merged)

## Testing

- [x] Documentation builds without errors
- [x] Consistent with existing documentation style (admonition blocks, inline notes)