### PR TITLE
docs(audible): add Whispersync progress sync section

### DIFF
--- a/src/content/docs/music-providers/audible.md
+++ b/src/content/docs/music-providers/audible.md
@@ -25,11 +25,19 @@ Music Assistant has support for streaming from Audible. Contributed and maintain
 | Maximum Stream Quality | Lossy, AAC Variable Bitrate |
 | Login Method | OAuth |
 
+### Whispersync Progress Sync
+
+Music Assistant syncs your listening position with Audible's Whispersync service automatically. This means:
+
+- Resume anywhere: If you've been listening on your phone, Echo, or any other Audible device, MA will pick up from exactly where you left off when you press play.
+- Keep your phone in sync: When you stop or pause in MA, your position is reported back to Audible so you can continue on any other device.
+
+No configuration is needed — this works automatically once the Audible provider is set up.
+
 ### Other
 
 - The Audible library can be listed
 - Metadata for audiobooks will be populated
-- Playback can be resumed from the last position reported by Audible
 - Chapter navigation
 - Multiple Audible accounts can be added.
 
@@ -43,15 +51,6 @@ To set up the Audible provider, follow these steps:
 4. Click the "Verify Audible URL" button to check the URL and register the provider.
 
 Note: If you need to re-authenticate or change the marketplace, you will have to go through the authentication process again.
-
-## Whispersync Progress Sync
-
-Music Assistant syncs your listening position with Audible's Whispersync service automatically. This means:
-
-- Resume anywhere: If you've been listening on your phone, Echo, or any other Audible device, MA will pick up from exactly where you left off when you press play.
-- Keep your phone in sync: When you stop or pause in MA, your position is reported back to Audible so you can continue on any other device.
-
-No configuration is needed — this works automatically once the Audible provider is set up.
 
 ## Known Issues / Notes
 

--- a/src/content/docs/music-providers/audible.md
+++ b/src/content/docs/music-providers/audible.md
@@ -44,6 +44,15 @@ To set up the Audible provider, follow these steps:
 
 Note: If you need to re-authenticate or change the marketplace, you will have to go through the authentication process again.
 
+## Whispersync Progress Sync
+
+Music Assistant syncs your listening position with Audible's Whispersync service automatically. This means:
+
+- Resume anywhere: If you've been listening on your phone, Echo, or any other Audible device, MA will pick up from exactly where you left off when you press play.
+- Keep your phone in sync: When you stop or pause in MA, your position is reported back to Audible so you can continue on any other device.
+
+No configuration is needed — this works automatically once the Audible provider is set up.
+
 ## Known Issues / Notes
 
 - Last playback position is not currently reported back to Audible


### PR DESCRIPTION
Adds documentation for the Whispersync bidirectional progress sync feature introduced in music-assistant/server#3893.

## Changes
- Added "Whispersync Progress Sync" section to the Audible provider page explaining that MA automatically syncs listening position with Audible's Whispersync service
- Covers both directions: resuming in MA from an Audible device, and syncing back from MA to Audible
- Notes that no user configuration is required