### PR TITLE
Update Deezer documentation for GraphQL provider rewrite

### DIFF
--- a/src/content/docs/music-providers/deezer.md
+++ b/src/content/docs/music-providers/deezer.md
@@ -61,5 +61,3 @@ Authentication with Deezer happens through an ARL cookie token. Unfortunately, D
 - Have a Hifi/Premium/Family account
 - Are on the latest Music Assistant version
 - Try different browsers
-
-Big thanks to <a href="https://github.com/music-assistant/deezer-python-gql" target="_blank" rel="noopener noreferrer">deezer-python-gql</a>, the typed async GraphQL client that powers this provider.

--- a/src/content/docs/music-providers/deezer.md
+++ b/src/content/docs/music-providers/deezer.md
@@ -4,13 +4,12 @@ title: "Deezer"
 
 # Deezer <img src="/assets/icons/deezer-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-Music Assistant has support for <a href="https://www.deezer.com/" target="_blank" rel="noopener noreferrer">Deezer</a>. Contributed and maintained by <a href="https://github.com/arctixdev" target="_blank" rel="noopener noreferrer">arctixdev</a> and <a href="https://github.com/micha91" target="_blank" rel="noopener noreferrer">micha91</a> 
+Music Assistant has support for <a href="https://www.deezer.com/" target="_blank" rel="noopener noreferrer">Deezer</a>. Contributed and maintained by <a href="https://github.com/arctixdev" target="_blank" rel="noopener noreferrer">arctixdev</a>, <a href="https://github.com/micha91" target="_blank" rel="noopener noreferrer">micha91</a> and <a href="https://github.com/jdaberkow" target="_blank" rel="noopener noreferrer">jdaberkow</a>
 
 > [!TIP]
 > **Note**
 >
 > - Because of Deezer's TOS only HiFi/Premium/Family accounts are supported
-> - It is normal that syncing all the items from Deezer takes some time
 
 ## Features
 
@@ -18,39 +17,42 @@ Music Assistant has support for <a href="https://www.deezer.com/" target="_blank
 |:-----------------------|:---------------------:|
 | Subscription FREE | No |
 | Self-Hosted Local Media  | No |
-| Media Types Supported | Artists, Albums, Tracks, Playlists |
-| [Recommendations](/ui/#view---discover) Supported | No |
-| Lyrics Supported | No |
+| Media Types Supported | Artists, Albums, Tracks, Playlists, Podcasts, Audiobooks, Radio |
+| [Recommendations](/ui/#view---discover) Supported | Yes |
+| Lyrics Supported | Yes |
 | [Radio Mode](/ui/#track-menu) | Yes |
 | Artist Top Tracks Support                       |            Yes                     |
-| Similar Artists Support                         |            No                      |
+| Similar Artists Support                         |            Yes                     |
 | Similar Tracks Support                          |            Yes                     | 
 | Maximum Stream Quality | Lossless FLAC (44.1 kHz / 16 bit) |
-| Login Method | OAuth + Cookie |
+| Login Method | Cookie (ARL) |
 
 ### Other
 
 - Searching the Deezer catalogue
 - Items in your Deezer Favourites will be imported into the MA Library and automatically marked as a "Favorite" in MA
 - If you add an item from Deezer to the MA library then nothing will happen in Deezer unless you also mark it as a favourite (at which time the item will be added to the Deezer favourites)
-- Artist, Album, Track and Playlist metadata is fully supported
+- Artist, Album, Track, Playlist, Podcast and Audiobook metadata is fully supported
 - Playlist creation is possible as well as adding and removing tracks from existing playlists
+- Synchronized (LRC) and plain text lyrics
+- Podcast and audiobook progress (bookmark/resume) is synced both ways
+- Personal (user-uploaded) songs are available via the "My Uploads" playlist
+- Recommendations: Made For You, Explore (charts, new releases, editorial playlists), Recently Played, Music Together and dynamic Flow/mood/genre mixes
+- Pasting or searching a Deezer share URL (`deezer.com/{type}/{id}`) resolves the item directly
+- Podcasts, radio and audiobooks depend on availability in your country (audiobooks are currently limited to Germany, the Netherlands and Austria)
 - Logging of played tracks in Deezer
 
 ## Configuration
 
-Authentication with Deezer happens through an Access and ARL Token. Unfortunately, Deezer does not officially support third party logins, so you will need to obtain your own ARL Token. Instructions were written for Chrome:
+Authentication with Deezer happens through an ARL cookie token. Unfortunately, Deezer does not officially support third party logins, so you will need to obtain your own ARL Token. Instructions were written for Chrome:
 
-1. in the MA SETTINGS select MUSIC SOURCES, then ADD A MUSIC SOURCE and then DEEZER.
-2. Launch the authentication process by pressing the `Authenticate` button
-3. Login to Deezer on the popup window
-4. After logging in the MA settings page will have the ACCESS TOKEN automatically populated but the ARL TOKEN now needs to be manually obtained
-5. Navigate in another browser tab to <a href="https://deezer.com/" target="_blank" rel="noopener noreferrer">https://deezer.com/</a>
-6. Right click on the browser window and select INSPECT. A new window will open
-7. Click the 'Application' tab. You might need to expand your window or click the `>>` button
-8. Under Storage > Cookies, click "https://www.deezer.com" and find the entry labelled "arl"
+1. In the MA SETTINGS select MUSIC SOURCES, then ADD A MUSIC SOURCE and then DEEZER.
+2. Navigate in another browser tab to <a href="https://deezer.com/" target="_blank" rel="noopener noreferrer">https://deezer.com/</a> and log in.
+3. Right click on the browser window and select INSPECT. A new window will open
+4. Click the 'Application' tab. You might need to expand your window or click the `>>` button
+5. Under Storage > Cookies, click "https://www.deezer.com" and find the entry labelled "arl"
   [![Preview image](/assets/screenshots/deezer-arl.png)](/assets/screenshots/deezer-arl.png)
-9. Copy the cookie value and use this in Music Assistant as the 'ARL TOKEN'
+6. Copy the cookie value and paste it into Music Assistant as the 'ARL TOKEN'
 
 **If this does not work ensure that you:**
 
@@ -60,8 +62,4 @@ Authentication with Deezer happens through an Access and ARL Token. Unfortunatel
 - Are on the latest Music Assistant version
 - Try different browsers
 
-## Not yet supported
-- Podcasts
-- Fully featured recommendation/flow
-
-Big thanks to <a href="https://GitHub.com/browniebroke/deezer-python" target="_blank" rel="noopener noreferrer">Deezer-python</a> made by <a href="https://github.com/browniebloke" target="_blank" rel="noopener noreferrer">browniebroke</a>. Without it, this would have taken a lot longer to make.
+Big thanks to <a href="https://github.com/music-assistant/deezer-python-gql" target="_blank" rel="noopener noreferrer">deezer-python-gql</a>, the typed async GraphQL client that powers this provider.


### PR DESCRIPTION
Updates the Deezer provider page to reflect the rewrite in music-assistant/server#3900, which moves the provider onto the typed async GraphQL client [`deezer-python-gql`](https://github.com/music-assistant/deezer-python-gql).

Depends on music-assistant/server#3900


## :warning:  Important note: I'm probably not able to update the big "overview" image, which is slightly outdated now as well.