### PR TITLE
Edit docs (android) from sideload apk to public test on google play

### DIFF
--- a/src/content/docs/mobile/index.mdx
+++ b/src/content/docs/mobile/index.mdx
@@ -45,4 +45,4 @@ If the media player widget is not seen then a different, supported browser will 
 	}
 `}</style>
 
-The official mobile apps are still in BETA. Android users wishing to try it out can [sideload the APK](https://github.com/music-assistant/mobile-app/releases). iOS users can get the app from [Testflight](https://testflight.apple.com/join/4byCu2Nk). More information is available in the [Mobile App Repository](https://github.com/music-assistant/mobile-app).
+The official mobile apps are still in BETA. Android users wishing to try it out can [sign up as a tester on Google Play](https://play.google.com/apps/testing/io.music_assistant.client). iOS users can get the app from [Testflight](https://testflight.apple.com/join/4byCu2Nk). More information is available in the [Mobile App Repository](https://github.com/music-assistant/mobile-app).


### PR DESCRIPTION
MA mobile app is now available to test on Android without sideloading an APK. Users can sign up via Google Play link now. Updated doc to reflect this change.