### PR TITLE
Make permissive Docker settings opt-in in install docs

### DIFF
--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -26,15 +26,14 @@ A HAOS installation is fully supported by the MA team regardless of whether it r
 An alternative way to run the Music Assistant server is by running the docker image:
 
 ```
-docker run -v <dir>:/data --network host --cap-add=DAC_READ_SEARCH --cap-add=SYS_ADMIN --security-opt apparmor:unconfined ghcr.io/music-assistant/server
+docker run -v <dir>:/data --network host ghcr.io/music-assistant/server
 ```
 
-You must run the docker container with **host network mode**. The data volume is `/data` - replace `<dir>` with a writable directory to ensure the data volume persists between updates. If you want access to your local music files from within MA, make sure to also mount that local directory, e.g. /media.
+You must run the docker container with **host network mode** (see the note on networking below). The data volume is `/data` - replace `<dir>` with a writable directory to ensure the data volume persists between updates. If you want access to your local music files from within MA, make sure to also mount that local directory, e.g. `/media` (mount it read-only where possible).
 
-Note that accessing remote (SMB) shares is done from within MA by using the SMB File provider.
-The additional privileges are only required if you want to use a remote (Samba/NFS) share within Music Assistant.
+The recommended setup keeps the container as restricted as possible. The extra privileges (`SYS_ADMIN`, `DAC_READ_SEARCH` and `apparmor:unconfined`) shown further down are **only** needed if you want MA to mount a remote (Samba/NFS) share itself from inside the container. For most users, mounting music on the host and bind-mounting it into the container is the more secure choice.
 
-**Docker compose:**
+**Docker compose (recommended):**
 
 ```
 services:
@@ -42,16 +41,12 @@ services:
     image: ghcr.io/music-assistant/server:latest # <<< Desired release version here (or use beta to get the latest beta version)
     container_name: music-assistant-server
     restart: unless-stopped
-    # Network mode must be set to host for MA to work correctly
+    # Network mode must be set to host for MA to discover and stream to players (see networking note below)
     network_mode: host
     volumes:
       - ${USERDIR:-$HOME}/docker/music-assistant-server/data:/data/
-    # privileged caps (and security-opt) needed to mount smb folders within the container
-    cap_add:
-      - SYS_ADMIN
-      - DAC_READ_SEARCH
-    security_opt:
-      - apparmor:unconfined
+      # Optional: expose local music to MA by bind-mounting it read-only
+      - /path/to/your/music:/media:ro
     environment:
       # Provide logging level as environment variable.
       # default=info, possible=(critical, error, warning, info, debug)
@@ -60,6 +55,43 @@ services:
 ```
 
 The desired release version can be found on <a href="https://github.com/music-assistant/server/pkgs/container/server" target="_blank" rel="noopener noreferrer">the container image releases page</a>
+
+### Advanced: mounting SMB/network shares inside the container
+
+Music Assistant can mount a remote (Samba/NFS) share itself using the SMB File provider. Doing this **from inside the container** requires the container to be granted broad privileges: the `SYS_ADMIN` and `DAC_READ_SEARCH` capabilities and `apparmor:unconfined`. These significantly reduce container isolation and make a container escape more damaging if MA or one of its dependencies is ever compromised, so only add them if you actually need in-container mounting.
+
+The more secure alternative is to **mount the share on the host** (e.g. via `/etc/fstab` or your NAS tooling) and bind-mount that path into the container read-only, exactly like a local music folder:
+
+```
+    volumes:
+      - /mnt/nas/music:/media:ro
+```
+
+If you do need MA to mount the share itself, add the privileges to the recommended compose file above:
+
+```
+    # WARNING: only needed to mount SMB/NFS shares from inside the container.
+    # These reduce container isolation - prefer host-mounting the share instead.
+    cap_add:
+      - SYS_ADMIN
+      - DAC_READ_SEARCH
+    security_opt:
+      - apparmor:unconfined
+```
+
+### A note on host networking
+
+`network_mode: host` gives the container direct (layer 2) access to your network. Music Assistant relies on this for local player discovery (mDNS/uPnP) and for streaming to and interacting with networked audio devices (AirPlay, Chromecast, DLNA, Sonos), which open random TCP/UDP ports. This is why host networking (or macvlan) is a supported requirement - see the support notes below.
+
+If you do not use any local/networked players and only stream to software players, you can instead run the container on a normal bridge network with explicit port mappings, for example the web UI on `8095` and the stream server on `8097`:
+
+```
+    ports:
+      - "8095:8095"
+      - "8097:8097"
+```
+
+Be aware of the trade-off: on a bridge network, player discovery and any players that need direct network access (AirPlay, Chromecast, DLNA, Sonos, and similar) will not work, and this configuration is not supported by the MA team.
 
 The MA team will support docker installs that are installed per the above instructions. For clarity, to receive support from the MA team:
 
@@ -105,7 +137,7 @@ If you run into any issues when using a docker install vs the recommended/standa
 - MA is designed to work on a Raspberry Pi (4+) which is also running Home Assistant. For this reason it does not make large demands on resources. Additionally, there are limits on the free API calls used for artwork and other metadata. The result of this is that initial syncs of large libraries can take a long time. Subsequent syncs should be noticeably faster
 - If a song is [linked across multiple providers](/ui/#provider-details) (e.g. Spotify and a FLAC file on disk), the file/stream with the highest quality is always preferred when starting a stream. Highest quality is based on sample rate, bit depth and codec and local is always preferred over cloud if the quality is equal.
 
-- Music Assistant uses a custom stream port (TCP 8097 by default) to stream audio to players. Players must be able to reach the Home Assistant instance and this port. If you're running one of the recommended HAOS installation methods, this is all handled for you, otherwise you will have to make sure you're running MA in a container with HOST network mode and with the privileges shown in the example docker compose above. Note: If the default port 8097 is occupied, the next port will be tried, and so on
+- Music Assistant uses a custom stream port (TCP 8097 by default) to stream audio to players. Players must be able to reach the Home Assistant instance and this port. If you're running one of the recommended HAOS installation methods, this is all handled for you, otherwise you will have to make sure you're running MA in a container with HOST network mode (see the networking note in the Docker section above). Note: If the default port 8097 is occupied, the next port will be tried, and so on
 - Any restriction of the available ports (e.g. trying to run MA through a firewall) is not supported as protocols such as AirPlay open random TCP and/or UDP ports
 - Attempting to create or manipulate a playlist or queue with more than a thousand items can cause unresponsivness or high resource usage depending on the resources of the host
 


### PR DESCRIPTION
The standalone Docker install instructions recommended a compose file that granted `SYS_ADMIN` + `DAC_READ_SEARCH` capabilities and `apparmor:unconfined` by default. These are broad privileges that reduce container isolation and are only needed when MA mounts SMB/NFS shares from inside the container. This makes the default setup more permissive than most users need.

This reframes those settings as opt-in, with clear explanations of when they're required and the more secure alternative.

## Changes

- Default `docker run` and compose examples no longer include `SYS_ADMIN`, `DAC_READ_SEARCH` or `apparmor:unconfined`.
- Default compose now shows an optional read-only bind-mount for local music.
- New "Advanced: mounting SMB/network shares inside the container" section explaining that the extra privileges are only needed for in-container mounting, with a warning, and documenting host-mount + read-only bind-mount as the safer alternative.
- New networking note explaining what `network_mode: host` is needed for (player discovery / networked audio) and the bridge-network + port-mapping alternative, including the feature trade-off.

This is a documentation/design fix; there is no code-level change to reproduce or unit-test.

Security assessment finding: 6.3 Insecure Design