### PR TITLE
Update Power option description in individual-player.md

### DIFF
--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -45,7 +45,7 @@ Each player has a number of options available to control the behaviour of the po
 
 It is possible to map other HA entities to the MA player controls. in order for this to be an option the HA entities need to be first exposed to MA via the settings in the [HA Plugin](/ha-plugin/).
 
-**Power** If a player does not support power but it is desired that the player has an on and off state then a FAKE option is available which will simulate the on/off functionality.
+**Power** If a player does not support power but it is desired that the player has an on and off state then a FAKE option is available which will simulate the on/off functionality. Power controls assume the underlying device is in a standby mode and not physically powered off.
 
 **Volume** This allows the volume control to be defined or disabled.
 


### PR DESCRIPTION
Clarified the description of the Power option to indicate that it assumes the device is in standby mode.