### PR TITLE
Plex: document extended recommendations setting

### DIFF
--- a/src/content/docs/music-providers/plex.md
+++ b/src/content/docs/music-providers/plex.md
@@ -39,6 +39,10 @@ Music Assistant has support for using Plex (MusicLibrary). Contributed by <a hre
 - Select the library and type (Music, Audiobook, or Podcast) that you would like to use; options will be auto-selected based on your existing configuration, but you can change as needed.
 - Save the settings
 
+### Advanced Settings
+
+- <b>Extended recommendations.</b> Widens the set of hubs shown on the [Discover](/ui/#view---discover) view to include <b>Mixes For You</b> (the personalised mixes Plex builds from your listening history), recent library playlists and <b>On This Day</b> releases, matching the hubs Plex's own clients show. This is on by default; disable it for the narrower hub set. Changes take effect on the next recommendations refresh
+
 ## Plex Configuration
 
 - If you want to allow Music Assistant to connect to Plex without authentication, go to your Plex configuration, Settings / Network. In the field labeled `List of IP addresses and networks that are allowed without auth` enter the IP address of the computer running Music Assistant, and `Save Changes`

--- a/src/content/docs/music-providers/plex.md
+++ b/src/content/docs/music-providers/plex.md
@@ -41,7 +41,7 @@ Music Assistant has support for using Plex (MusicLibrary). Contributed by <a hre
 
 ### Advanced Settings
 
-- <b>Extended recommendations.</b> Widens the set of hubs shown on the [Discover](/ui/#view---discover) view to include <b>Mixes For You</b> (the personalised mixes Plex builds from your listening history), recent library playlists and <b>On This Day</b> releases, matching the hubs Plex's own clients show. This is on by default; disable it for the narrower hub set. Changes take effect on the next recommendations refresh
+- <b>Extended recommendations.</b> Enabled by default. Adds extra rows on the [Discover](/ui/#view---discover) view to include <b>Mixes For You</b> (the personalised mixes Plex builds from the listening history), recent library playlists and <b>On This Day</b> releases, matching the rows Plex's own clients show. Changes take effect on the next recommendations refresh
 
 ## Plex Configuration
 


### PR DESCRIPTION
Documents the `Extended recommendations` setting added in music-assistant/server#3736, as requested by @OzGav in https://github.com/music-assistant/server/pull/3736#issuecomment-5017918650.

Enabled by default; widens the Plex recommendation hubs shown on the Discover view to include Mixes For You, recent library playlists and On This Day releases.