### PR TITLE
Redesign DSP documentation with a dedicated Digital Signal Processing section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -165,12 +165,19 @@ export default defineConfig({
 						{ label: 'Audio Pipeline', slug: 'audiopipeline' },
 						{ label: 'Groups', slug: 'faq/groups' },
 						{ label: 'Genres', slug: 'genres' },
-						{ label: 'DSP Parametric EQ', slug: 'dsp/parametriceq' },
-						{ label: 'DSP Tone Controls', slug: 'dsp/tonecontrols' },
 						{ label: 'How Do I...', slug: 'faq/how-to' },
 						{ label: 'I Want To Stream To', slug: 'faq/stream-to' },
 						{ label: 'Technical Info', slug: 'faq/tech-info' },
 						{ label: 'Troubleshooting', slug: 'faq/troubleshooting' },
+					],
+				},
+				{
+					label: 'Digital Signal Processing',
+					collapsed: true,
+					items: [
+						{ label: 'Overview', slug: 'dsp' },
+						{ label: 'Parametric Equalizer', slug: 'dsp/parametriceq' },
+						{ label: 'Tone Controls', slug: 'dsp/tonecontrols' },
 					],
 				},
 				{

--- a/src/content/docs/audiopipeline.md
+++ b/src/content/docs/audiopipeline.md
@@ -33,7 +33,7 @@ The maximum sample rate that can be expected can be found in the [Player Provide
 ## Digital Signal Processing
 <img src="/assets/screenshots/audiopipeline-dsp.png" alt="image" style="width: 500px;"  loading="lazy" />
 
-In this example [DSP](/settings/individual-player/#dsp-settings) has been enabled. High level information about the DSP filters which have been applied are shown. A tooltip is available to explain why the DSP is not supported if that is the case (See the example below in [Groups](#groups)).
+In this example [DSP](/dsp/) has been enabled. High level information about the DSP filters which have been applied are shown. A tooltip is available to explain why the DSP is not supported if that is the case (See the example below in [Groups](#groups)).
 
 Also of note in this example is the icon shown in the input section where the codec icon is normally. This icon will be displayed when MA cannot determine the codec and can occur with container formats such as <a href="https://www.wavpack.com/" target="_blank" rel="noopener noreferrer">WavPack</a>, <a href="https://cloudinary.com/guides/video-formats/what-is-the-m4a-format-understanding-the-difference-between-m4a-mp3-and-wav" target="_blank" rel="noopener noreferrer">M4A</a> or <a href="https://en.wikipedia.org/wiki/Direct_Stream_Digital" target="_blank" rel="noopener noreferrer">DSD64</a>.
 

--- a/src/content/docs/dsp/index.md
+++ b/src/content/docs/dsp/index.md
@@ -1,0 +1,44 @@
+---
+title: Digital Signal Processing
+description: Overview of the Digital Signal Processing (DSP) capabilities of Music Assistant and the filters that are available
+---
+
+# Digital Signal Processing
+
+All players have the option to apply <a href="https://en.wikipedia.org/wiki/Digital_signal_processing" target="_blank" rel="noopener noreferrer">Digital Signal Processing</a> (DSP) filters to the audio stream. DSP allows the audio to be shaped and refined with a variety of filters. It can be used to tailor the sound to a room's acoustics, compensate for speaker characteristics, and fine-tune the frequency balance to personal taste.
+
+The DSP option is found in the [Music Assistant settings for each player](/settings/individual-player/#dsp-settings) which means that each player has its own independently configurable DSP settings.
+
+When playing in a group, individual player DSP settings will only be used for Universal groups and when playing via AirPlay, Squeezelite or Sendspin. Groups using all other protocols will have DSP disabled.
+
+## The DSP Path
+
+The DSP path consists of an INPUT pre-amplifier for initial gain control, followed by optional audio filters that can be added between input and output (multiple times if desired). The path ends with an OUTPUT stage that provides both gain control and a limiter (enabled by default) to prevent signal clipping.
+
+The DSP settings can be enabled and disabled via a toggle which allows easy <a href="https://www.youtube.com/watch?v=KefGjPYyIO4" target="_blank" rel="noopener noreferrer">A-B testing</a>
+
+The line on the left of the DSP settings represents the audio path, in sequential order, from the audio file (top) to the player (bottom). A dot on the line represents a component that changes the signal. The lack of a dot indicates that the particular component has been disabled.
+
+Using the icons at the top of the view, the filters can be reordered, disabled/enabled or deleted.
+
+![DSP image](/assets/screenshots/dsp.jpg)
+
+## Available Filters
+
+The following filters can be added to the DSP path. The simpler filters are explained below, while the more advanced filters are described on their own dedicated pages.
+
+### Balance
+
+Shifts the stereo image left or right, from −100 (full left) through 0 (centred) to +100 (full right). Rather than the near side being boosted, the opposite side is quietened so the audio never becomes louder than the source and cannot distort. The value is the percentage by which the opposite channel is reduced: at +20 the left channel is played at 80% level, and at +100 the left channel is fully muted. Because the amount is expressed as a percentage of level rather than in decibels, it is best suited to balancing by ear; for a specific decibel trim, it should be noted that roughly every 20 points corresponds to about −2 dB on the opposite channel.
+
+### Gain
+
+Raises or lowers the overall volume by a fixed amount, from −60 dB to +60 dB (0 dB leaves the volume unchanged). It is useful for levelling a player against others, or for reclaiming headroom before other processing is applied.
+
+### Parametric Equalizer
+
+Allows precise adjustment of specific frequency ranges and is the most powerful of the available filters. It is described in detail on the [Parametric Equalizer](/dsp/parametriceq/) page.
+
+### Tone Controls
+
+Provide simple bass, mid and treble adjustments of the audio signal. They are described in detail on the [Tone Controls](/dsp/tonecontrols/) page.

--- a/src/content/docs/dsp/index.md
+++ b/src/content/docs/dsp/index.md
@@ -27,14 +27,6 @@ Using the icons at the top of the view, the filters can be reordered, disabled/e
 
 The following filters can be added to the DSP path. The simpler filters are explained below, while the more advanced filters are described on their own dedicated pages.
 
-### Balance
-
-Shifts the stereo image left or right, from −100 (full left) through 0 (centred) to +100 (full right). Rather than the near side being boosted, the opposite side is quietened so the audio never becomes louder than the source and cannot distort. The value is the percentage by which the opposite channel is reduced: at +20 the left channel is played at 80% level, and at +100 the left channel is fully muted. Because the amount is expressed as a percentage of level rather than in decibels, it is best suited to balancing by ear; for a specific decibel trim, it should be noted that roughly every 20 points corresponds to about −2 dB on the opposite channel.
-
-### Gain
-
-Raises or lowers the overall volume by a fixed amount, from −60 dB to +60 dB (0 dB leaves the volume unchanged). It is useful for levelling a player against others, or for reclaiming headroom before other processing is applied.
-
 ### Parametric Equalizer
 
 Allows precise adjustment of specific frequency ranges and is the most powerful of the available filters. It is described in detail on the [Parametric Equalizer](/dsp/parametriceq/) page.

--- a/src/content/docs/faq/stream-to.md
+++ b/src/content/docs/faq/stream-to.md
@@ -118,7 +118,7 @@ We don’t believe most people can hear the difference in sample rates above CD 
 
 Note that many Sonos devices can be synced with AirPlay devices which is another plus for AirPlay.
 
-Lastly, if grouping of players is planned and use of the DSP settings is desired then review which protocols support DSP in this circumstance in the [DSP Settings description](/settings/individual-player/#dsp-settings)
+Lastly, if grouping of players is planned and use of the DSP settings is desired then review which protocols support DSP in this circumstance in the [Digital Signal Processing overview](/dsp/)
 
 The following table is a non-exhaustive list of possible solutions:
 

--- a/src/content/docs/player-support/squeezelite.md
+++ b/src/content/docs/player-support/squeezelite.md
@@ -13,7 +13,7 @@ Squeezelite clients are available for hardware from desktop OS to <a href="https
 ## Features
 
 - Squeezelite client devices are automatically detected by Music Assistant
-- Individual player [DSP settings](/settings/individual-player/#dsp-settings) will be used for [group](/faq/groups/) playback
+- Individual player [DSP settings](/dsp/) will be used for [group](/faq/groups/) playback
 - Squeezelite client device buttons support
   - Any physical control buttons on the device should be supported as long as [flow mode](/faq/tech-info/#track-queueing) is not enabled
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -57,28 +57,9 @@ It is possible to map other HA entities to the MA player controls. in order for 
 
 ## DSP Settings
 
-All providers have the option to apply <a href="https://en.wikipedia.org/wiki/Digital_signal_processing" target="_blank" rel="noopener noreferrer">Digital Signal Processing</a> (DSP) filters to the audio stream. DSP lets you shape and refine the audio with a variety of filters. Use it to tailor the sound to a room's acoustics, compensate for speaker characteristics, and fine-tune the frequency balance to personal taste.
+All providers have the option to apply <a href="https://en.wikipedia.org/wiki/Digital_signal_processing" target="_blank" rel="noopener noreferrer">Digital Signal Processing</a> (DSP) filters to the audio stream. This section is where the DSP is configured for each player, which means that each player has its own independently configurable DSP settings.
 
-The DSP option is found in the MA settings for each player which means that each player has its own independently configurable DSP settings.
-
-When playing in a group, individual player DSP settings will only be used for Universal groups and when playing via AirPlay, Squeezelite or Sendspin. Groups using all other protocols will have DSP disabled.
-
-The DSP path consists of an INPUT pre-amplifier for initial gain control, followed by optional audio filters that can be added between input and output (multiple times if desired). The following filters are available:
-
-- [Parametric Equalizer](/dsp/parametriceq/)
-- [Tone Controls](/dsp/tonecontrols/)
-
-The path ends with an OUTPUT stage that provides both gain control and a limiter (enabled by default) to prevent signal clipping.
-
-The DSP settings can be enabled and disabled via a toggle which allows easy <a href="https://www.youtube.com/watch?v=KefGjPYyIO4" target="_blank" rel="noopener noreferrer">A-B testing</a>
-
-The line on the left of the DSP settings represents the audio path, in sequential order, from the audio file (top) to the player (bottom).
-
-A dot on the line represents a component that changes the signal. The lack of a dot indicates that the particular component has been disabled.
-
-Using the icons at the top of the view, the additional filters can be reordered, disabled/enabled or deleted.
-
-![DSP image](/assets/screenshots/dsp.jpg)
+Full details of the DSP capabilities and the filters that are available can be found in the [Digital Signal Processing](/dsp/) section of the documentation.
 
 ## Player Options
 


### PR DESCRIPTION
- Add a new Digital Signal Processing sidebar section immediately below Usage, containing an Overview page plus the existing Parametric Equalizer and Tone Controls pages
- Create the DSP Overview page describing the DSP path and listing the available filters, with links to the dedicated pages for the advanced filters
- Move the DSP path details from Individual Player Settings to the Overview page and condense that section to a pointer
- Update cross-links in Audio Pipeline, Stream To, and Squeezelite pages to point at the new Overview page

Note: the Balance and Gain filter descriptions (from #783) are not included here because those filters are only available in the beta version — they will be added in a follow-up change against the beta branch.