### PR TITLE
Add Balance and Gain filter descriptions to DSP overview

### DIFF
--- a/src/content/docs/dsp/index.md
+++ b/src/content/docs/dsp/index.md
@@ -27,6 +27,14 @@ Using the icons at the top of the view, the filters can be reordered, disabled/e
 
 The following filters can be added to the DSP path. The simpler filters are explained below, while the more advanced filters are described on their own dedicated pages.
 
+### Balance
+
+Shifts the stereo image left or right, from −100 (full left) through 0 (centred) to +100 (full right). Rather than the near side being boosted, the opposite side is quietened so the audio never becomes louder than the source and cannot distort. The value is the percentage by which the opposite channel is reduced: at +20 the left channel is played at 80% level, and at +100 the left channel is fully muted. Because the amount is expressed as a percentage of level rather than in decibels, it is best suited to balancing by ear; for a specific decibel trim, it should be noted that roughly every 20 points corresponds to about −2 dB on the opposite channel.
+
+### Gain
+
+Raises or lowers the overall volume by a fixed amount, from −60 dB to +60 dB (0 dB leaves the volume unchanged). It is useful for levelling a player against others, or for reclaiming headroom before other processing is applied.
+
 ### Parametric Equalizer
 
 Allows precise adjustment of specific frequency ranges and is the most powerful of the available filters. It is described in detail on the [Parametric Equalizer](/dsp/parametriceq/) page.


### PR DESCRIPTION
Adds the Balance and Gain filter descriptions on the DSP Overview page. The filters are listed alphabetically in the Available Filters section.

