### PR TITLE
Document AirPlay PTP container requirements

### DIFF
--- a/src/content/docs/faq/troubleshooting.md
+++ b/src/content/docs/faq/troubleshooting.md
@@ -15,6 +15,8 @@ For clarity, running installation options other than HAOS or simple docker and/o
 
 There are settings available in MA SETTINGS>> SYSTEM>> STREAMS and then select the "Show advanced settings" toggle, that might help you if you have non-standard setups. If you are running MA in your own docker container then make sure you have the correct PUBLISHED IP ADDRESS and BIND TO IP/INTERFACE set. Ensure containers are in HOST networking mode and note the extra privileges in the [example docker command](/installation/#docker-image).
 
+If native AirPlay 2 groups play but drift out of sync in a Docker installation, check the [AirPlay 2 multi-room synchronization requirements](/installation/#airplay-2-multi-room-synchronization). Playback falls back to less precise timing when Music Assistant cannot bind the required PTP ports.
+
 Most players are discovered using mDNS (broadcast) so if your players do not get discovered it means that your network is blocking that traffic (e.g. IGMP or multicast snooping or filtering). You will have to check your settings (e.g. WiFi setup) if multicast is being blocked. Business solutions tend to block multicast traffic as much as possible as it hurts performance when there are many clients. In a home setup is it mandatory to have because all home gear relies on multicast. Users of Ubiquiti devices must ensure the setting `Multicast to Unicast` is turned OFF.
 
 Make sure the HA internal url is set correctly. HA SETTINGS>> SYSTEM>> NETWORK>> Home Assistant URL>> Local network (set to automatic or use your internal HA IP). If it is automatic you can try changing it to http://your.internal.ip:8123/
@@ -138,4 +140,3 @@ If the above is not the issue then start MA in safe mode:
 - With Docker run the container with the environmental variable MASS_SAFE_MODE set to a boolean true value, e.g. "1" or "true"
 
 If MA now starts, you can start any of the providers by clicking "reload" in the settings (click the 3 dots). If one particular provider causes MA to crash then open an issue with the details.
-

--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -93,6 +93,21 @@ If you do not use any local/networked players and only stream to software player
 
 Be aware of the trade-off: on a bridge network, player discovery and any players that need direct network access (AirPlay, Chromecast, DLNA, Sonos, and similar) will not work, and this configuration is not supported by the MA team.
 
+### AirPlay 2 multi-room synchronization
+
+Native AirPlay 2 groups use Precision Time Protocol (PTP) for accurate synchronization. Music Assistant must be able to bind UDP ports `319` and `320` in its network namespace.
+
+The official Music Assistant container image runs as root, so no extra permissions are required. If you run a custom container as a non-root user, grant it the `NET_BIND_SERVICE` capability:
+
+```
+    cap_add:
+      - NET_BIND_SERVICE
+```
+
+For `docker run`, use `--cap-add NET_BIND_SERVICE`. The ports must also be free in the container's network namespace. With `network_mode: host`, this means they must be free on the host; with macvlan, they only need to be free in the Music Assistant container. Do not add Docker `ports` mappings for UDP `319` or `320`: publishing them does not grant bind permission or resolve a conflict, and they are not incoming Music Assistant service ports.
+
+If either port cannot be bound, AirPlay playback continues using less precise Network Time Protocol (NTP) timing, but native AirPlay 2 groups may drift out of sync. Check the server logs, container capability, and port usage if this happens.
+
 The MA team will support docker installs that are installed per the above instructions. For clarity, to receive support from the MA team:
 
 - The docker install must be a simple standalone container (e.g. not using kubernetes)

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -36,12 +36,12 @@ AirPlay 1 (RAOP) specific advanced settings are:
 
 AirPlay 2 specific advanced settings are:
 
-- <b>Expected milliseconds to establish streaming session with the AirPlay device.</b> The number of milliseconds of data to buffer in the cliap2 binary. Try increasing the value if playback is unreliable (out of sync or not working). <b>NOTE:</b> This adds to the latency experienced for the commencement of playback.
+- <b>Expected milliseconds to establish streaming session with the AirPlay device.</b> The number of milliseconds of data to buffer while establishing an AirPlay 2 stream. Try increasing the value if playback is unreliable (out of sync or not working). <b>NOTE:</b> This adds to the latency experienced for the commencement of playback.
 
 ## Known Issues / Notes
 
 - Music Assistant implements <a href="https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol" target="_blank" rel="noopener noreferrer">RAOP</a> and <a href="https://en.wikipedia.org/wiki/AirPlay" target="_blank" rel="noopener noreferrer">AirPlay2</a>. Most devices will default to RAOP because AirPlay 2 devices should be backwards compatible by default. If a device has a bad implementation of AirPlay 1 and/or only supports AirPlay 2 without RAOP then select AirPlay2 as the protocol version.
-- Shairport and AirPlay 2 are currently incompatible due to lack of NTP timing support for AirPlay 2 in Shairport and lack of PTP timing support for AirPlay 2 in Music Assistant.
+- Native AirPlay 2 multi-room synchronization uses PTP timing. Custom non-root Docker deployments must meet the [AirPlay 2 container requirements](/installation/#airplay-2-multi-room-synchronization). If PTP is unavailable, playback falls back to NTP timing and groups may drift out of sync.
 - Playback to Macbooks is not possible due to removal of RAOP support
 - Apple TVs will be discovered but require pairing. In the player settings there is a pair button which will display a code on the screen of the Apple TV
 - Samsung seems to have implemented AirPlay 1 in a way that isn't fully backwards compatible. Everything seems to work, changing volume, song info is shown, and you can control the Samsung device as expected, however there is no sound. Users of similar applications such as Roon and anything based on slimproto have the same problem
@@ -52,4 +52,4 @@ AirPlay 2 specific advanced settings are:
 - Apple Homekit has been reported to interfere with playback. If problems are enountered then remove the devices from Apple Homekit or try changing the setting in the preferences section of Homekit (iOS) for `AirPlay (Speaker & TV)`.
   - In this section specifically check if the `Only people in this home` is not selected. When this option is selected, MusicAssistant cannot play audio on the HomePod (without setting the proper password in the advanced settings of the provider). Select the option `Everyone on the same network` instead.
 - If the AirPlay device incorrectly responds to change volume commands or randomly changes volume, try changing the `Volume Control` option in the `Player controls` section and set it to `None`
-- AirPlay 2 implementation is new and has not yet been extensively tested. It is known that Password-based pairing and PTP timing is not yet supported. There may be additional issues that are not yet known. The AirPlay 2 protocol takes longer to establish initial connection than AirPlay 1 (RAOP) due to more RTSP exchanges. This adds to the delay experienced for commencement of playback.
+- AirPlay 2 implementation is new and has not yet been extensively tested. Password-based pairing is not yet supported, and there may be additional issues that are not yet known. The AirPlay 2 protocol takes longer to establish initial connection than AirPlay 1 (RAOP) due to more RTSP exchanges. This adds to the delay experienced for commencement of playback.


### PR DESCRIPTION
## Summary

- document the PTP port and permission requirements for AirPlay 2 synchronization in Docker
- clarify host/macvlan behavior, NTP fallback, and why the PTP ports should not be published
- update AirPlay and troubleshooting guidance to link to the deployment requirements

## Validation

- `pnpm build`

Related to music-assistant/server#4881.