### PR TITLE
Update AirPlay provider documentation

### DIFF
--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -11,7 +11,7 @@ Music Assistant supports devices that receive [AirPlay 1 (RAOP)](https://en.wiki
 - AirPlay devices are detected automatically.
 - Music Assistant automatically uses AirPlay 2 when a device supports it and RAOP for legacy receivers.
 - Timestamped playback keeps AirPlay 1 and AirPlay 2 players synchronized in multi-room groups.
-- The `cliairplay` transport always uses lossless ALAC internally. Playback defaults to 44.1 kHz/16-bit; native AirPlay 2 devices can optionally use 24-bit audio at 44.1 or 48 kHz.
+- The provider's internal `cliairplay` transport always uses lossless ALAC. Playback defaults to 44.1 kHz/16-bit; native AirPlay 2 devices can optionally use 24-bit audio at 44.1 or 48 kHz.
 - The player settings support [stereo pairs](/faq/how-to/#create-a-stereo-pair).
 
 ## Protocol selection
@@ -47,7 +47,7 @@ If Music Assistant cannot bind these ports, playback continues using NTP timing,
 
 ## Troubleshooting and known issues
 
-- Samsung devices are marked as having broken AirPlay support. Playback can fail or remain silent with both RAOP and AirPlay 2, and there is currently no workaround.
+- Samsung devices have known broken AirPlay implementations. Playback can fail or remain silent with both RAOP and AirPlay 2, and there is currently no workaround.
 - If an eligible AirPlay 2 receiver has dropouts, remains silent, or fails to play, try **Force RAOP protocol**.
 - If RAOP playback is silent, verify **Enable encryption** and **Device password** against the receiver's requirements.
 - If 24-bit playback is silent, disable **Enable hi-res (24-bit) playback**.

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -11,7 +11,7 @@ Music Assistant supports devices that receive [AirPlay 1 (RAOP)](https://en.wiki
 - AirPlay devices are detected automatically.
 - Music Assistant automatically uses AirPlay 2 when a device supports it and RAOP for legacy receivers.
 - Timestamped playback keeps AirPlay 1 and AirPlay 2 players synchronized in multi-room groups.
-- The provider's internal `cliairplay` transport always uses lossless ALAC. Playback defaults to 44.1 kHz/16-bit; native AirPlay 2 devices can optionally use 24-bit audio at 44.1 or 48 kHz.
+- Audio is streamed losslessly as ALAC. Playback defaults to 44.1 kHz/16-bit; supported AirPlay 2 devices can opt into 24-bit playback at 44.1 or 48 kHz.
 - The player settings support [stereo pairs](/faq/how-to/#create-a-stereo-pair).
 
 ## Protocol selection
@@ -37,13 +37,13 @@ Settings are shown only when they apply to the selected device and protocol.
 - **Ignore volume reports sent by the device itself.** Ignores unreliable device volume feedback that can otherwise cause unexpected volume changes.
 - **Enable encryption.** Controls encrypted communication when RAOP applies. Some third-party receivers require a particular setting for playback to work.
 - **Device password.** Supplies the playback password required by some RAOP receivers. This is separate from pairing credentials.
-- **Enable hi-res (24-bit) playback.** Opts a native AirPlay 2 device into 24-bit audio at 44.1 or 48 kHz. Leave it disabled unless the device supports 24-bit rendering; some receivers accept the stream but play silence.
+- **Enable hi-res (24-bit) playback.** Enables 24-bit audio at 44.1 or 48 kHz for supported AirPlay 2 devices. Leave it disabled unless the device supports 24-bit rendering; some receivers accept the stream but play silence.
 
-## Native AirPlay 2 group synchronization
+## AirPlay 2 group synchronization
 
-Native AirPlay 2 group synchronization uses PTP timing and requires permission to bind UDP ports `319` and `320`. Custom containers that run Music Assistant as a non-root user need the `NET_BIND_SERVICE` capability. This is a local bind-permission requirement; the ports do not need to be published.
+AirPlay 2 devices that use PTP timing require Music Assistant to bind UDP ports `319` and `320` for synchronized group playback. Custom containers that run Music Assistant as a non-root user need the `NET_BIND_SERVICE` capability. This is a local bind-permission requirement; the ports do not need to be published.
 
-If Music Assistant cannot bind these ports, playback continues using NTP timing, but native AirPlay 2 groups may drift out of sync.
+If Music Assistant cannot bind these ports, playback continues using NTP timing, but these groups may drift out of sync.
 
 ## Troubleshooting and known issues
 

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -16,7 +16,7 @@ Music Assistant supports devices that receive [AirPlay 1 (RAOP)](https://en.wiki
 
 ## Protocol selection
 
-AirPlay 1 is also known as RAOP. Protocol selection is automatic and there is no protocol dropdown: AirPlay 2-capable devices use AirPlay 2, while legacy receivers use RAOP.
+AirPlay 1 is also known as RAOP. Music Assistant automatically uses AirPlay 2 for capable devices and RAOP for legacy receivers.
 
 Eligible AirPlay 2-capable non-Apple receivers that also support RAOP expose the advanced **Force RAOP protocol** setting. This is an escape hatch for devices whose AirPlay 2 implementation causes dropouts, silence, or failed playback. Leave it disabled unless the receiver works better with RAOP.
 
@@ -35,7 +35,7 @@ Settings are shown only when they apply to the selected device and protocol.
 - **Audio synchronization delay correction.** Adjusts this player from `-500 ms` to `+500 ms` relative to the other players in a synchronized group. Negative values make it play earlier and positive values make it play later. For example, use `-100 ms` when downstream processing by a TV or AV receiver makes this player lag by about 100 ms.
 - **Output Channel Mode.** Plays both channels or only the left or right channel, for example when creating a stereo pair from two players.
 - **Ignore volume reports sent by the device itself.** Ignores unreliable device volume feedback that can otherwise cause unexpected volume changes.
-- **Enable encryption.** Controls encrypted communication when RAOP applies. Some third-party receivers require a particular setting for playback to work.
+- **Enable encryption.** Controls encrypted communication when RAOP applies. If RAOP playback fails, try toggling this setting.
 - **Device password.** Supplies the playback password required by some RAOP receivers. This is separate from pairing credentials.
 - **Enable hi-res (24-bit) playback.** Enables 24-bit audio at 44.1 or 48 kHz for supported AirPlay 2 devices. Leave it disabled unless the device supports 24-bit rendering; some receivers accept the stream but play silence.
 
@@ -47,9 +47,7 @@ If Music Assistant cannot bind these ports, playback continues using NTP timing,
 
 ## Troubleshooting and known issues
 
-- Samsung devices have known broken AirPlay implementations. Playback can fail or remain silent with both RAOP and AirPlay 2, and there is currently no workaround.
 - If an eligible AirPlay 2 receiver has dropouts, remains silent, or fails to play, try **Force RAOP protocol**.
-- If RAOP playback is silent, verify **Enable encryption** and **Device password** against the receiver's requirements.
+- If RAOP playback fails, try toggling **Enable encryption** and verify **Device password** against the receiver's requirements.
 - If 24-bit playback is silent, disable **Enable hi-res (24-bit) playback**.
 - If volume changes unexpectedly, enable **Ignore volume reports sent by the device itself**. If volume control remains unreliable, set **Volume Control** to **None** in the **Player controls** settings.
-- If a powered-on receiver repeatedly becomes unavailable, increase its availability timeout. Some receivers send keep-alive messages so infrequently that a timeout of up to one hour may be needed.

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -18,7 +18,7 @@ Music Assistant supports devices that receive [AirPlay 1 (RAOP)](https://en.wiki
 
 AirPlay 1 is also known as RAOP. Music Assistant automatically uses AirPlay 2 for capable devices and RAOP for legacy receivers.
 
-Eligible AirPlay 2-capable non-Apple receivers that also support RAOP expose the advanced **Force RAOP protocol** setting. This is an escape hatch for devices whose AirPlay 2 implementation causes dropouts, silence, or failed playback. Leave it disabled unless the receiver works better with RAOP.
+Some AirPlay 2-capable non-Apple receivers that also support RAOP expose the advanced **Force RAOP protocol** setting. This is an escape hatch for devices whose AirPlay 2 implementation causes dropouts, silence, or failed playback. Leave it disabled unless the receiver works better with RAOP.
 
 ## Pairing and passwords
 
@@ -26,7 +26,7 @@ Devices that advertise authentication requirements, including many Apple TVs and
 
 A pairing password is not the same as the RAOP-only **Device password** setting. Pairing establishes trusted access to a device; **Device password** supplies a password required by some receivers when connecting or playing over RAOP.
 
-Home app access restrictions are supported through the same pairing flow. If speaker and TV access is limited to people in the home, pair the device in Music Assistant. If that restriction is not required, you can instead change the Home access setting to allow devices on the same network.
+Apple Home app access restrictions are supported through the same pairing flow. If speaker and TV access is limited to people in the home, pair the device in Music Assistant. If that restriction is not required, you can instead change the Home access setting to allow devices on the same network.
 
 ## Player settings
 
@@ -47,7 +47,7 @@ If Music Assistant cannot bind these ports, playback continues using NTP timing,
 
 ## Troubleshooting and known issues
 
-- If an eligible AirPlay 2 receiver has dropouts, remains silent, or fails to play, try **Force RAOP protocol**.
+- If an AirPlay 2 receiver that also supports RAOP has dropouts, remains silent, or fails to play, try **Force RAOP protocol**.
 - If RAOP playback fails, try toggling **Enable encryption** and verify **Device password** against the receiver's requirements.
 - If 24-bit playback is silent, disable **Enable hi-res (24-bit) playback**.
 - If volume changes unexpectedly, enable **Ignore volume reports sent by the device itself**. If volume control remains unreliable, set **Volume Control** to **None** in the **Player controls** settings.

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -2,54 +2,54 @@
 title: "AirPlay"
 ---
 
-# AirPlay <img src="/assets/icons/airplay-logo.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
+# AirPlay <img src="/assets/icons/airplay-logo.png" alt="AirPlay logo" style="width: 70px; float: right;" loading="lazy" />
 
-Music Assistant has support for AirPlay based devices which support <a href="https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol" target="_blank" rel="noopener noreferrer">RAOP</a> and <a href="https://en.wikipedia.org/wiki/AirPlay" target="_blank" rel="noopener noreferrer">AirPlay2</a>. This includes Apple devices such as the Homepod but also a very wide range of 3rd party devices such as receivers and smart speakers. Due to the fact that AirPlay uses lossless, timestamped streaming it is a very interesting protocol for lossless multi room playback.
+Music Assistant supports devices that receive [AirPlay 1 (RAOP)](https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol) or [AirPlay 2](https://en.wikipedia.org/wiki/AirPlay). This includes Apple devices such as HomePod, Apple TV, and Macs, as well as many third-party receivers and smart speakers.
 
 ## Features
 
-- AirPlay devices are auto detected in Music Assistant, plug and play
-- AirPlay devices will play in sync, even when there is a combination of AirPlay 1 (RAOP) and AirPlay 2 devices in the sync group
-- Audio quality is lossless 44.1 kHz/16bits PCM and optionally compressed as (lossless) ALAC
-- The player settings allow configuration of [stereo pairs](/faq/how-to/#create-a-stereo-pair) of speakers
+- AirPlay devices are detected automatically.
+- Music Assistant automatically uses AirPlay 2 when a device supports it and RAOP for legacy receivers.
+- Timestamped playback keeps AirPlay 1 and AirPlay 2 players synchronized in multi-room groups.
+- The `cliairplay` transport always uses lossless ALAC internally. Playback defaults to 44.1 kHz/16-bit; native AirPlay 2 devices can optionally use 24-bit audio at 44.1 or 48 kHz.
+- The player settings support [stereo pairs](/faq/how-to/#create-a-stereo-pair).
 
-## Protocol Settings
+## Protocol selection
 
-Support exists for devices which require pairing with a PIN before they can be used (e.g. Apple TV's). Select the `START AIRPLAY PAIRING` button to register the PIN and when successful, click the `SAVE` button to save the authorisation key.
+AirPlay 1 is also known as RAOP. Protocol selection is automatic and there is no protocol dropdown: AirPlay 2-capable devices use AirPlay 2, while legacy receivers use RAOP.
 
-Music Assistant has support for both versions of the AirPlay protocol. AirPlay 1 is also known as RAOP. Under normal circumstances, the AirPlay protocol version to use for streaming can be left as `Automatically select [default]`. The default for most devices is AirPlay 1 (RAOP). Devices which are known to have issues with AirPlay 1 (RAOP) and known to work with AirPlay 2 will automatically use AirPlay 2 for streaming.
+Eligible AirPlay 2-capable non-Apple receivers that also support RAOP expose the advanced **Force RAOP protocol** setting. This is an escape hatch for devices whose AirPlay 2 implementation causes dropouts, silence, or failed playback. Leave it disabled unless the receiver works better with RAOP.
 
-### Advanced Protocol Settings
+## Pairing and passwords
 
-Advanced Protocol Settings applicable to both versions of the AirPlay protocol are:
+Some devices, including Apple TV and macOS AirPlay receivers, require pairing before playback. Start pairing from the player's settings and follow the prompts. Depending on the device, Music Assistant asks for either the PIN displayed by the device or its pairing password, then stores the resulting credentials.
 
-- <b>Audio synchronization delay correction.</b> If audio played by this player is synchronized with other players and is found to be slightly out of sync, a fixed delay of up to ±500 ms can be adjusted using this setting.
-- <b>Output Channel Mode.</b> You can configure this player to play only the left or right channel, for example to create a stereo pair with 2 players.
+A pairing password is not the same as the RAOP-only **Device password** setting. Pairing establishes trusted access to a device; **Device password** supplies a password required by some receivers when connecting or playing over RAOP.
 
+Home app access restrictions are supported through the same pairing flow. If speaker and TV access is limited to people in the home, pair the device in Music Assistant. If that restriction is not required, you can instead change the Home access setting to allow devices on the same network.
 
-AirPlay 1 (RAOP) specific advanced settings are:
+## Player settings
 
-- <b>Enable encryption.</b> Enable encrypted communication if required by the player. AirPlay 1 only.
-- <b>Enable compression.</b> Enable to save some bandwidth by sending the audio as (lossless) ALAC
-- <b>Device password.</b> If the device requires a password to play then it is added here
-- <b>Milliseconds of data to buffer.</b> Try increasing this value if playback is unreliable. This adds to the latency experienced for the commencement of playback.
+Settings are shown only when they apply to the selected device and protocol.
 
-AirPlay 2 specific advanced settings are:
+- **Audio synchronization delay correction.** Adjusts this player from `-500 ms` to `+500 ms` relative to the other players in a synchronized group. Negative values make it play earlier and positive values make it play later. For example, use `-100 ms` when downstream processing by a TV or AV receiver makes this player lag by about 100 ms.
+- **Output Channel Mode.** Plays both channels or only the left or right channel, for example when creating a stereo pair from two players.
+- **Ignore volume reports sent by the device itself.** Ignores unreliable device volume feedback that can otherwise cause unexpected volume changes.
+- **Enable encryption.** Controls encrypted communication when RAOP applies. Some third-party receivers require a particular setting for playback to work.
+- **Device password.** Supplies the playback password required by some RAOP receivers. This is separate from pairing credentials.
+- **Enable hi-res (24-bit) playback.** Opts a native AirPlay 2 device into 24-bit audio at 44.1 or 48 kHz. Leave it disabled unless the device supports 24-bit rendering; some receivers accept the stream but play silence.
 
-- <b>Expected milliseconds to establish streaming session with the AirPlay device.</b> The number of milliseconds of data to buffer in the cliap2 binary. Try increasing the value if playback is unreliable (out of sync or not working). <b>NOTE:</b> This adds to the latency experienced for the commencement of playback.
+## Native AirPlay 2 group synchronization
 
-## Known Issues / Notes
+Native AirPlay 2 group synchronization uses PTP timing and requires permission to bind UDP ports `319` and `320`. Custom containers that run Music Assistant as a non-root user need the `NET_BIND_SERVICE` capability. This is a local bind-permission requirement; the ports do not need to be published.
 
-- Music Assistant implements <a href="https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol" target="_blank" rel="noopener noreferrer">RAOP</a> and <a href="https://en.wikipedia.org/wiki/AirPlay" target="_blank" rel="noopener noreferrer">AirPlay2</a>. Most devices will default to RAOP because AirPlay 2 devices should be backwards compatible by default. If a device has a bad implementation of AirPlay 1 and/or only supports AirPlay 2 without RAOP then select AirPlay2 as the protocol version.
-- Shairport and AirPlay 2 are currently incompatible due to lack of NTP timing support for AirPlay 2 in Shairport and lack of PTP timing support for AirPlay 2 in Music Assistant.
-- Playback to Macbooks is not possible due to removal of RAOP support
-- Apple TVs will be discovered but require pairing. In the player settings there is a pair button which will display a code on the screen of the Apple TV
-- Samsung seems to have implemented AirPlay 1 in a way that isn't fully backwards compatible. Everything seems to work, changing volume, song info is shown, and you can control the Samsung device as expected, however there is no sound. Users of similar applications such as Roon and anything based on slimproto have the same problem
-- Some devices (such as Kodi or some 3rd party AirPlay receivers) require encryption. You can enable encryption in the advanced player settings if there is no sound
-- Also try compression on and off in the advanced player settings if there is no sound
-- A device password can be set for those devices which require it in the advanced settings
-- If you find your player is going unavailable when still powered on then it may not be sending its keep alive message. A timeout can be configured for each player. Some users have reported they have needed to set it as long as one hour
-- Apple Homekit has been reported to interfere with playback. If problems are enountered then remove the devices from Apple Homekit or try changing the setting in the preferences section of Homekit (iOS) for `AirPlay (Speaker & TV)`.
-  - In this section specifically check if the `Only people in this home` is not selected. When this option is selected, MusicAssistant cannot play audio on the HomePod (without setting the proper password in the advanced settings of the provider). Select the option `Everyone on the same network` instead.
-- If the AirPlay device incorrectly responds to change volume commands or randomly changes volume, try changing the `Volume Control` option in the `Player controls` section and set it to `None`
-- AirPlay 2 implementation is new and has not yet been extensively tested. It is known that Password-based pairing and PTP timing is not yet supported. There may be additional issues that are not yet known. The AirPlay 2 protocol takes longer to establish initial connection than AirPlay 1 (RAOP) due to more RTSP exchanges. This adds to the delay experienced for commencement of playback.
+If Music Assistant cannot bind these ports, playback continues using NTP timing, but native AirPlay 2 groups may drift out of sync.
+
+## Troubleshooting and known issues
+
+- Samsung devices are marked as having broken AirPlay support. Playback can fail or remain silent with both RAOP and AirPlay 2, and there is currently no workaround.
+- If an eligible AirPlay 2 receiver has dropouts, remains silent, or fails to play, try **Force RAOP protocol**.
+- If RAOP playback is silent, verify **Enable encryption** and **Device password** against the receiver's requirements.
+- If 24-bit playback is silent, disable **Enable hi-res (24-bit) playback**.
+- If volume changes unexpectedly, enable **Ignore volume reports sent by the device itself**. If volume control remains unreliable, set **Volume Control** to **None** in the **Player controls** settings.
+- If a powered-on receiver repeatedly becomes unavailable, increase its availability timeout. Some receivers send keep-alive messages so infrequently that a timeout of up to one hour may be needed.

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -22,7 +22,7 @@ Eligible AirPlay 2-capable non-Apple receivers that also support RAOP expose the
 
 ## Pairing and passwords
 
-Some devices, including Apple TV and macOS AirPlay receivers, require pairing before playback. Start pairing from the player's settings and follow the prompts. Depending on the device, Music Assistant asks for either the PIN displayed by the device or its pairing password, then stores the resulting credentials.
+Devices that advertise authentication requirements, including many Apple TVs and macOS AirPlay receivers, must be paired before playback. Start pairing from the player's settings and follow the prompts. Depending on the device, Music Assistant asks for either the PIN displayed by the device or its pairing password, then stores the resulting credentials.
 
 A pairing password is not the same as the RAOP-only **Device password** setting. Pairing establishes trusted access to a device; **Device password** supplies a password required by some receivers when connecting or playing over RAOP.
 


### PR DESCRIPTION
## Summary

- rewrite only `src/content/docs/player-support/airplay.md` to match the current AirPlay provider on `music-assistant/server` `dev`
- document automatic AirPlay 2/RAOP selection, pairing flows, current player settings, and lossless ALAC/hi-res behavior
- document AirPlay 2 PTP permissions and NTP fallback alongside current troubleshooting guidance

## Validation

- `pnpm build`

Related to music-assistant/server#4881.