### PR TITLE
ariacast_receiver: update documentation

### DIFF
--- a/src/content/docs/plugins/ariacast-receiver.md
+++ b/src/content/docs/plugins/ariacast-receiver.md
@@ -15,7 +15,7 @@ The **AriaCast Receiver** plugin allows for streaming of high-quality audio wire
 1. Add the **AriaCast Receiver** plugin in the Music Assistant settings.
 2. Configure the playback settings:
    - **Connected Player**: Select a specific player or set to "Auto" to use the currently active player.
-   - **Allow manual player switching**: If enabled, allows the stream to be moved to a different player within Music Assistant
+   - **AriaCast Device Name**: The name shown to AriaCast senders when they discover this receiver on the network. Defaults to "Music Assistant" if left empty.
 
 ## Usage
 1. Install the [AriaCast Android app](https://github.com/AriaCast/AriaCast-app/releases/latest).
@@ -26,7 +26,8 @@ The **AriaCast Receiver** plugin allows for streaming of high-quality audio wire
 
 ## Troubleshooting
 
-- **Server Not Found**: Ensure the Android device and MA server are on the same network. The plugin uses a helper binary that listens for discovery broadcasts
+- **Server Not Found**: Ensure the Android device and MA server are on the same network, and that UDP port `12888` isn't blocked by a firewall.
 - **No Audio Playback**: If the app shows as connected but no audio is playing, try disconnecting and reconnecting from the Android app to reset the stream.
-- **Binary Issues**: If the plugin fails to start, check the Music Assistant logs for errors related to the AriaCast binary execution.
+- **Only One Sender at a Time**: The receiver accepts a single AriaCast sender at once. A second device attempting to connect while one is already streaming will be rejected until the first one disconnects.
+- **Startup Issues**: If the plugin fails to start (for example because port `12889` is already in use), check the Music Assistant logs for details.
 


### PR DESCRIPTION
Update documentation for https://github.com/music-assistant/server/pull/4922 and some general parts (e.g. no binary used anymore).