### PR TITLE
local_audio_source: initial documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -252,6 +252,7 @@ export default defineConfig({
 						{ label: 'HEOS', slug: 'player-support/heos' },
 						{ label: 'Home Assistant', slug: 'player-support/ha' },
 						{ label: 'Local Audio Out', slug: 'player-support/local-audio' },
+						{ label: 'Local Audio Source', slug: 'player-support/local-audio-source' },
 						{ label: 'MSX Bridge', slug: 'player-support/msx-bridge' },
             			{ label: 'Music Player Daemon (MPD)', slug: 'player-support/mpd' },
 						{ label: 'MusicCast', slug: 'player-support/musiccast' },

--- a/public/assets/icons/local-audio-source.svg
+++ b/public/assets/icons/local-audio-source.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Svg Vector Icons : http://www.onlinewebfonts.com/icon -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 256 256" enable-background="new 0 0 256 256" xml:space="preserve">
+<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>
+<g><g><g><path fill="#000000" d="M120.5,15.6l-5.6,5.6v7.5v7.5H128h13.1v-7.5v-7.5l-5.6-5.6c-4.9-4.9-5.8-5.6-7.5-5.6C126.4,10,125.4,10.7,120.5,15.6z"/><path fill="#000000" d="M114.9,49.3v4.4H128h13.1v-4.4V45H128h-13.1V49.3z"/><path fill="#000000" d="M114.9,79.9v17.5h-11.7H91.3L90,98.8l-1.4,1.4l0.2,39.4l0.2,39.5l1.5,4.4c3.7,10.7,11.7,19.8,21.4,24l3.1,1.4v17.2v17.3l1.4,1.3c1.3,1.4,1.4,1.4,11.7,1.4c10.3,0,10.4,0,11.7-1.4l1.4-1.3v-17.3v-17.2l3.1-1.4c9.6-4.3,17.8-13.4,21.4-24l1.5-4.4l0.2-39.5l0.2-39.4l-1.4-1.4l-1.4-1.4h-11.8h-11.7V79.9V62.4H128h-13.1V79.9z M148.5,116.3l1.4,1.3v14.8v14.8l-1.4,1.3c-0.8,0.9-2,1.4-3,1.4s-2.2-0.5-3-1.4c-1.4-1.3-1.4-1.3-1.4-13.1v-11.7h-7.4c-7.2,0-7.5-0.1-8.7-1.4c-0.9-0.8-1.4-2-1.4-3c0-1,0.5-2.2,1.4-3c1.3-1.4,1.4-1.4,11.7-1.4C147.1,114.9,147.2,114.9,148.5,116.3z"/></g></g></g>
+</svg>

--- a/src/content/docs/player-support/local-audio-source.md
+++ b/src/content/docs/player-support/local-audio-source.md
@@ -1,0 +1,48 @@
+---
+title: Local Audio Source Plugin
+description: Capture live audio from a line-in, USB or Bluetooth input on the server and play it on any Music Assistant player
+---
+
+# Local Audio Source <img src="/assets/icons/local-audio-source.svg" alt="Preview image" style="width: 70px; float: right;" loading="lazy" />
+
+Local Audio Source captures live audio from a device connected to the machine running the Music Assistant server — a Bluetooth receiver, a line-in jack, a USB sound card — and turns it into a source you can play on any Music Assistant player.
+
+:::note
+This provider is in an early (alpha) stage of development.
+:::
+
+## Features
+
+- Captures from any audio input on the host: line-in, USB audio interfaces, Bluetooth receivers, or (optionally) monitor sources
+- Add multiple instances to capture from several sources at once, each shown as its own source
+- Pick a bundled icon (Bluetooth, Line-in/Cable, Turntable/Vinyl, Stereo, Chromecast) or a custom thumbnail image URL
+- Optional auto-start on signal: watches the input's level and automatically starts/stops playback on a chosen player, for sources that are always connected rather than selected on demand
+- The auto-start target player can be a fixed player or "Auto", which prefers whichever player is currently playing and otherwise picks the first available one
+
+## Use cases
+
+- **Bluetooth receiver.** Pair a Bluetooth audio receiver to the server and let guests quick-connect their phone to play music through the whole house
+- **Announcement/paging microphone.** Plug in a USB microphone for announcements or a simple intercom
+- **Turntable.** Connect a phono preamp's line-out and stream vinyl playback to any player
+
+## Docker installs
+
+The container needs access to the host's sound system. Add the following to the `music-assistant-server` service in your compose file:
+
+```yaml
+volumes:
+  - /run/user/1000/pulse:/run/pulse:ro # adjust the uid to your user session
+environment:
+  - PULSE_SERVER=unix:/run/pulse/native
+group_add:
+  - "audio"
+```
+
+## Settings
+
+For information about the settings seen in the MA UI refer to the [Player Provider Settings](/settings/player-provider) page. Specific settings available for this provider are:
+
+- **Include monitor sources**. Off by default. When enabled, the Audio Input Device list also shows monitor sources, which are special inputs that capture whatever is currently playing on one of the host's audio outputs
+- **Audio Input Device**. The capture source this instance uses, picked from the capture sources detected on the host
+- **Thumbnail**. A bundled icon, or a custom image URL
+- **Auto-start on signal**. Off by default. When enabled, also set an **Auto-start target player** and, optionally, a **Signal threshold (dBFS)** — the volume level above which the input counts as active audio. The default (-50.0) suits most hardware; raise it if quiet background noise causes false starts, lower it if quiet material fails to trigger playback. Playback starts after a fraction of a second of continuous signal and stops about 5 seconds after the input goes silent.


### PR DESCRIPTION
Adds the initial documentation for the Local Audio Source provider plugin, see https://github.com/music-assistant/server/pull/5079