### PR TITLE
Restructure Spotify and YouTube Music setup for new users (tier 4)

### DIFF
--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -41,11 +41,23 @@ Music Assistant has full support for Spotify media listing and playback.
 - Multiple Spotify accounts can be added. All playlists from all accounts will be shown. If a playlist is selected for playback the source Spotify account will be used
 
 ## Configuration
-- The Spotify source can only be configured from a device which is on the same subnet as the MA server (and not via a VPN)
-- Configuration is done with an OAuth callback. Clicking on the AUTHENTICATE WITH SPOTIFY button will open a new tab where permission can be given for MA to access the logged in account
-- Once the intial authentication is done a new option will appear towards the bottom of the view titled `Developer Token`. It is advantageous to add a personal Client ID as this will speed up access to the Spotify API and should eliminate rate limiting. How to obtain a Client ID is explained <a href="https://developer.spotify.com/documentation/web-api/concepts/apps" target="_blank" rel="noopener noreferrer">here</a>. When entering the information in the various fields the only mandatory item is the REDIRECT URL which must be set to `https://music-assistant.io/callback`. Using a personal Client ID is optional but rate limiting and streaming errors may be seen in the log if it is not supplied
-- If a personal Client ID is added then click on the large button AUTHENTICATE DEVELOPER SESSION
-- Finally the SAVE button must be pressed on the Spotify settings page. If the device being used kills the MA frontend before this is done then the source setup will fail (Use a different, typically non-mobile, device if this happens)
+
+### Basic setup
+
+1. Add the Spotify source via `SETTINGS >> MUSIC SOURCES >> ADD A MUSIC SOURCE`.
+2. Click the `AUTHENTICATE WITH SPOTIFY` button. A new tab opens on Spotify's own website where you give Music Assistant permission to access your account, so make sure your browser allows pop-ups. Use a device that is on the same home network as your MA server and is not connected to a VPN (see [Networking Basics](/faq/networking/)); if the button appears to do nothing, this is the most likely cause.
+3. Click `SAVE` on the Spotify settings page. The setup will fail if you skip this step. If your device closes the MA page before you can click `SAVE` (this can happen on mobile devices), retry from a laptop or PC.
+
+Spotify will now work, but consider the optional step below.
+
+### Optional: add a personal Client ID (recommended)
+
+Spotify limits how quickly third party apps can make requests on its shared access. Adding your own free Client ID gives Music Assistant a dedicated allowance, which speeds up access and should eliminate rate limiting. Without it, you may see rate limiting and streaming errors in the log.
+
+1. Complete the basic setup above, then reopen the Spotify settings. A new option titled `Developer Token` appears towards the bottom of the view.
+2. Create an app on Spotify's <a href="https://developer.spotify.com/documentation/web-api/concepts/apps" target="_blank" rel="noopener noreferrer">developer dashboard</a>. When filling in the app details, the only field that matters is the `Redirect URL`: set it exactly to `https://music-assistant.io/callback`.
+3. Enter the Client ID from your new app in the `Developer Token` section, then click the large `AUTHENTICATE DEVELOPER SESSION` button.
+4. Click `SAVE` again.
 
 ### Settings
 
@@ -54,8 +66,8 @@ Refer to the [Library Import Control](/music-providers/#library-import-control) 
 ## Known Issues / Notes
 
 - Due to restrictions with Spotify's API, only Spotify Premium accounts are supported (including Duo and Family). Free accounts will not work
-- Upon first saving of the source a check is done for Audiobook support within the account. If the check is successful then additional Audiobook related options will be seen when revisiting the source's settings
-- After adding the developer token there is then two sessions created to a single spotify source and MA routes the requests appropriately. For example, playlists are requested via the MA global token (which is rate limited but allows playlist retrieval) while other items are retrieved via the dev token. Search is done using the dev token by default as otherwise it is very slow. Playing and browsing playlists is routed through the global token to the originating source (useful when multiple Spotify accounts are added)
+- When you first save the source, MA checks whether the account supports audiobooks. If it does, additional audiobook related options appear when you revisit the source's settings
+- After you add the developer token, MA maintains two sessions to a single Spotify source and routes requests appropriately. For example, MA requests playlists via its global token (which is rate limited but allows playlist retrieval) while it retrieves other items via the dev token. Search uses the dev token by default as it is otherwise very slow. Playing and browsing playlists is routed through the global token to the originating source (useful when multiple Spotify accounts are added)
 - The Spotify API does not support the provision of recommendations
 - The Spotify API does not return genre information
-- Spotify has curtailed the usability of Client IDs for recently created accounts. If 403 errors are seen in the log then remove the Client ID
+- Spotify has curtailed the usability of Client IDs for recently created accounts. If you see 403 errors in the log, remove the Client ID

--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -7,7 +7,7 @@ title: "Spotify"
 Music Assistant has full support for Spotify media listing and playback.
 
 > [!WARNING]
-> Spotify is preventing accounts from approximately 2023 from working. Some even older accounts are affected. If the provider does not work and `key error` messages are seen in the log then the account is affected
+> Spotify has blocked accounts created around 2024 and later from working with third party apps like Music Assistant, and some older accounts are also affected. If the provider does not work and you see `Key Error` messages in the log, your account is affected. There is currently no remedy; consider using [another streaming source that we support](/music-providers/) instead
 
 > [!NOTE]
 > A Spotify Premium account is required for this music source. Free accounts will not work.
@@ -65,6 +65,7 @@ Refer to the [Library Import Control](/music-providers/#library-import-control) 
 
 ## Known Issues / Notes
 
+- Spotify has blocked accounts created around 2024 and later, and some older accounts are also affected. If you see `Key Error` messages in the log, your account is affected. There is currently no remedy; consider changing to [another streaming source that we support](/music-providers/)
 - Due to restrictions with Spotify's API, only Spotify Premium accounts are supported (including Duo and Family). Free accounts will not work
 - When you first save the source, MA checks whether the account supports audiobooks. If it does, additional audiobook related options appear when you revisit the source's settings
 - After you add the developer token, MA maintains two sessions to a single Spotify source and routes requests appropriately. For example, MA requests playlists via its global token (which is rate limited but allows playlist retrieval) while it retrieves other items via the dev token. Search uses the dev token by default as it is otherwise very slow. Playing and browsing playlists is routed through the global token to the originating source (useful when multiple Spotify accounts are added)

--- a/src/content/docs/music-providers/youtube-music.md
+++ b/src/content/docs/music-providers/youtube-music.md
@@ -36,7 +36,7 @@ Music Assistant has support for Youtube Music. Contributed and maintained by <a 
 
 ## Configuration
 
-As of Nov 2024, Google has removed OAuth authentication from YT Music. This means this (somewhat cumbersome) method of cookie authentication is the **only** way to get YT Music working. Setup has three parts: install the PO Token add-on, obtain your login cookie, then configure the source.
+As of Nov 2024, Google has removed OAuth authentication from YT Music. This means this (somewhat cumbersome) method of cookie authentication is the **only** way to get YT Music working. Setup has three parts: install the PO Token app, obtain your login cookie, then configure the source.
 
 > [!NOTE]
 > Cookies expire after some time. If YT Music stops working and you see `401: Unauthorized` or `Unable to fetch PO Token for web_music client` in the MA log, run the cookie steps again
@@ -44,13 +44,13 @@ As of Nov 2024, Google has removed OAuth authentication from YT Music. This mean
 > [!NOTE]
 > If you use a Family Account, setting up a dedicated account for MA will help maximise cookie life
 
-### Step 1: Install the PO Token add-on
+### Step 1: Install the PO Token app
 
-Google requires a 'Proof of Origin' (PO) token before it allows streaming; without one, Music Assistant cannot play your music. This add-on generates the token for you automatically. Install it before adding the YT Music source:
+Google requires a 'Proof of Origin' (PO) token before it allows streaming; without one, Music Assistant cannot play your music. This app generates the token for you automatically. Install it before adding the YT Music source:
 
-1. In Home Assistant, go to `Settings > Add-ons > Add-on Store`.
+1. In Home Assistant, go to `Settings >> Apps >> Install app`.
 2. Scroll down to the 'Music Assistant' section.
-3. Install the add-on called 'YT Music PO Token Generator' and make sure it is started.
+3. Install the app called 'YT Music PO Token Generator' and make sure it is started.
 
 > [!NOTE]
 > If you host Music Assistant yourself, download the Docker file for the PO Token server <a href="https://github.com/Brainicism/bgutil-ytdlp-pot-provider" target="_blank" rel="noopener noreferrer">here</a>. You must run the version currently supported by MA, which is 1.2.1. Install and run the correct version, then add its URL when configuring the YT Music source in Step 3.

--- a/src/content/docs/music-providers/youtube-music.md
+++ b/src/content/docs/music-providers/youtube-music.md
@@ -36,7 +36,7 @@ Music Assistant has support for Youtube Music. Contributed and maintained by <a 
 
 ## Configuration
 
-As of Nov 2024, Google has removed OAuth authentication from YT Music. This means this (somewhat cumbersome) method of cookie authentication is the **only** way to get YT Music working. Setup has three parts: install the PO Token app, obtain your login cookie, then configure the source.
+Cookie authentication is the **only** way to get YT Music working; Google does not support any other login method for third party apps. The process is somewhat cumbersome, but you only need to repeat it when the cookie expires. Setup has three parts: install the PO Token app, obtain your login cookie, then configure the source.
 
 > [!NOTE]
 > Cookies expire after some time. If YT Music stops working and you see `401: Unauthorized` or `Unable to fetch PO Token for web_music client` in the MA log, run the cookie steps again

--- a/src/content/docs/music-providers/youtube-music.md
+++ b/src/content/docs/music-providers/youtube-music.md
@@ -36,56 +36,60 @@ Music Assistant has support for Youtube Music. Contributed and maintained by <a 
 
 ## Configuration
 
-As of Nov 2024, Google has removed OAuth authentication from YT Music. This means using this (somewhat cumbersome) method of cookie authentication is the **only** way to get YT Music working.
+As of Nov 2024, Google has removed OAuth authentication from YT Music. This means this (somewhat cumbersome) method of cookie authentication is the **only** way to get YT Music working. Setup has three parts: install the PO Token add-on, obtain your login cookie, then configure the source.
 
 > [!NOTE]
-> Cookies will expire after some time. This means that you will have to run this process again if YT Music stops working and you see `401: Unauthorized` or `Unable to fetch PO Token for web_music client` in the MA log. Maximise the cookie life by using this <a href="https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies" target="_blank" rel="noopener noreferrer">method to obtain the cookie</a>
+> Cookies expire after some time. If YT Music stops working and you see `401: Unauthorized` or `Unable to fetch PO Token for web_music client` in the MA log, run the cookie steps again
 
 > [!NOTE]
-> If a Family Account is in use then setting up a dedicated account for MA will assist in maximising cookie life
-    
-### Obtaining the Cookies
-YouTube rotates account cookies frequently on open YouTube browser tabs as a security measure. To export cookies that will remain working, you will need to export cookies in such a way that they are never rotated. One way to do this is through a private browsing/incognito window.
+> If you use a Family Account, setting up a dedicated account for MA will help maximise cookie life
 
-- Open <a href="http://music.youtube.com/" target="_blank">YT Music</a> in your browser in an incognito window.
-- Open the developer tools via View -> Developer -> Developer Tools. Note that this might be named differently based on your browser. It should open a window similar to this:
+### Step 1: Install the PO Token add-on
+
+Google requires a 'Proof of Origin' (PO) token before it allows streaming; without one, Music Assistant cannot play your music. This add-on generates the token for you automatically. Install it before adding the YT Music source:
+
+1. In Home Assistant, go to `Settings > Add-ons > Add-on Store`.
+2. Scroll down to the 'Music Assistant' section.
+3. Install the add-on called 'YT Music PO Token Generator' and make sure it is started.
+
+> [!NOTE]
+> If you host Music Assistant yourself, download the Docker file for the PO Token server <a href="https://github.com/Brainicism/bgutil-ytdlp-pot-provider" target="_blank" rel="noopener noreferrer">here</a>. You must run the version currently supported by MA, which is 1.2.1. Install and run the correct version, then add its URL when configuring the YT Music source in Step 3.
+
+### Step 2: Obtain your login cookie
+
+YouTube rotates account cookies frequently on open YouTube browser tabs as a security measure. To export a cookie that keeps working, export it in a way that never rotates it. One way to do this is through a private browsing/incognito window:
+
+1. Open <a href="http://music.youtube.com/" target="_blank">YT Music</a> in your browser in an incognito window and log in to your account.
+2. Open the developer tools via View -> Developer -> Developer Tools. Note that this might be named differently based on your browser. It should open a window similar to this:
 [![Dev tools](/assets/screenshots/ytmusic-developer-tools.png)](/assets/screenshots/ytmusic-developer-tools.png)
-
-- Navigate to the 'Network' tab
-- In the filter bar, type "/browse". Reload the page if no results are shown.
-- Now navigate to a page in YT Music that requires authentication, for example, on of your library playlists
-- A request will show-up in the table:
+3. Navigate to the 'Network' tab.
+4. In the filter bar, type "/browse". Reload the page if no results are shown.
+5. Now navigate to a page in YT Music that requires authentication, for example, one of your library playlists.
+6. A request will show up in the table:
 
 [![Auth request](/assets/screenshots/ytmusic-auth-request.png)](/assets/screenshots/ytmusic-auth-request.png)
 
-- Click the request and make sure you are on the 'Headers' tab
-- Find the section called 'Request Headers'
-- Find the item named 'Cookie' and copy the **value**. It is **VERY** important that you copy the exact value. Double check that you do not include any additional spaces or characters at the start/end of the value
+7. Click the request and make sure you are on the 'Headers' tab.
+8. Find the section called 'Request Headers'.
+9. Find the item named 'Cookie' and copy the **value**. It is **VERY** important that you copy the exact value. Double check that you do not include any additional spaces or characters at the start/end of the value.
 [![Cookie value](/assets/screenshots/ytmusic-cookie-value.png)](/assets/screenshots/ytmusic-cookie-value.png)
 
-### Installing the PO Token addon
-As of March 2025, Google has implemented a new security mechanism called 'PO Tokens' (Proof of Origin). Music Assistant will not be able to resolve stream urls for your music without a valid PO Token. Luckily, we can automatically generate this for you, but you will need to install an add-on (also available as a docker image) for this.
-
-- Within Home Assistant, go to Settings > Add-ons > Add-on Store
-- Scroll down to the 'Music Assistant' section.
-- A new add-on called 'YT Music PO Token Generator' is available.
-- Install this add-on and make sure it is started before adding the YT Music source within Music Assistant
-
 > [!NOTE]
-> If you are hosting Music Assistant yourself, you can download the Docker file for the PO Token server <a href="https://github.com/Brainicism/bgutil-ytdlp-pot-provider" target="_blank" rel="noopener noreferrer">here</a> but you must run the version currently supported by MA which is 1.2.1. Install the correct version and run it, then return to Music Assistant and add the URL to the PO token server when configuring the YT Music source.
+> Advanced: if your cookie still expires quickly, the yt-dlp project documents an <a href="https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies" target="_blank" rel="noopener noreferrer">alternative export method</a> aimed at maximising cookie life
 
-### Configuring the source 
-- Navigate to 'Settings'
-- Under Music Sources, click 'Add a new source', select 'Youtube Music' and fill out the fields in the Generic Settings section as follows:
+### Step 3: Configure the source
+
+1. In Music Assistant, go to `SETTINGS >> MUSIC SOURCES >> ADD A MUSIC SOURCE` and select 'Youtube Music'.
+2. Fill out the fields in the Generic Settings section as follows:
     - <b>Username.</b> Use your gmail address or use a brand account (see [brand account](#using-brand-accounts))
-    - <b>Login Cookie.</b> Paste the value obtained above
-    - <b>PO Token Server URL.</b> Leave this setting as the default if running the PO server as an App on the same host as the MA App. If running the PO token server separately then adjust the IP address and port accordingly
-- Click 'Save'
+    - <b>Login Cookie.</b> Paste the value you copied in Step 2
+    - <b>PO Token Server URL.</b> Leave this setting as the default if you run the PO server as an App on the same host as the MA App. If you run the PO token server separately, adjust the IP address and port accordingly
+3. Click 'Save'.
 
 > [!CAUTION]
-> **Error on Saving**
+> **Error on saving?**
 >
-> If `__Secure-3PAPISID` is seen after saving this means the cookie is not from an authenticated request. Navigate to some more pages inside YT Music that require authentication (e.g. your library). To confirm the right cookie has been obtained paste it into a text editor and search for "__Secure-3PAPISID". If difficulties are encountered obtaining a cookie with this value, try a different browser.
+> If the error mentions `__Secure-3PAPISID`, your cookie did not come from a logged-in (authenticated) request. Go back to the incognito window, open a few more pages that require your account (for example your library), and copy the cookie again. You can check a cookie before saving it: paste it into a text editor and search for `__Secure-3PAPISID`; the right cookie contains this value. If you cannot obtain a cookie containing this value, try a different browser.
 
 ### Settings
 
@@ -94,7 +98,7 @@ Refer to the [Library Import Control](/music-providers/#library-import-control) 
 ## Using brand accounts
 A brand account is a sub-account that lives under your main Google account. You need to find your brand account id if you want to login using your brand account.
 
-- Go to <a href="https://myaccount.google.com/" target="_blank>https://myaccount.google.com/</a>
+- Go to <a href="https://myaccount.google.com/" target="_blank" rel="noopener noreferrer">https://myaccount.google.com/</a>
 - From the top right menu, select your brand account
 - Look at the URL and copy the 21-digit number
 - Use this number in the 'Username' field when setting up the source


### PR DESCRIPTION
Fourth PR from the docs approachability review, covering the two highest-traffic music source pages. Both pages are also converted to the agreed style (second person active voice, no em dashes) while I was in them.

## Spotify

The configuration section opened with "same subnet as the MA server" and packed the optional Client ID, API, rate-limiting and redirect-URL detail into one dense unnumbered bullet.

- Split into **Basic setup** (three numbered steps ending at SAVE, with the mobile-kills-the-page failure case kept) and an **Optional: add a personal Client ID (recommended)** subsection.
- The optional section now explains in plain terms why you would bother (your own free request allowance instead of Spotify's shared one) before giving four numbered steps.
- "Same subnet" is now "same home network" with a Networking Basics link, and the failure symptom is described (the authenticate button appears to do nothing).
- Light voice pass on Known Issues (e.g. "If you see 403 errors in the log, remove the Client ID").

## YouTube Music

The page offered two conflicting cookie methods (its own screenshot walkthrough and a link to the expert-oriented yt-dlp wiki) and led the PO Token section with the history of Google's security mechanism rather than the required action. The sections were also in the wrong order relative to how you must do them.

- Configuration reordered into three explicit steps: **Step 1 install the PO Token add-on** (action first, one line of why), **Step 2 obtain your login cookie**, **Step 3 configure the source**.
- The on-page walkthrough is now the single canonical cookie method; the yt-dlp link is demoted to an advanced note for cookies that expire quickly.
- The `__Secure-3PAPISID` caution is reframed symptom-first ("Error on saving?") with concrete recovery steps, and now states plainly that the *right* cookie contains this value.
- Walkthrough steps numbered, "log in to your account" added to the incognito step, typo fixes ("on of"), and a malformed anchor in the brand-account section repaired.

## Please double-check

- The add-source path is written as `SETTINGS >> MUSIC SOURCES >> ADD A MUSIC SOURCE`, taken from the music sources index page. Given the recent provider/plugin path renames, please confirm this matches the current UI.
- My reading of the `__Secure-3PAPISID` caution: the original text said the error appears "if `__Secure-3PAPISID` is seen after saving" but also said to confirm a good cookie by searching for that same string, which contradicts itself. I've written it as: the error names that cookie key when it is missing from your pasted value, and a correct cookie contains it. If the mechanics are different, that caution needs correcting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbELYAWFLnuJnv7VQ8NxC8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbELYAWFLnuJnv7VQ8NxC8)_