### PR TITLE
Close out remaining review findings (tier 7)

### DIFF
--- a/src/content/docs/api.md
+++ b/src/content/docs/api.md
@@ -8,6 +8,11 @@ Music Assistant provides a powerful API to control your music library, manage pl
 
 The API documentation is automatically generated and available at http://YOUR_MA_SERVER_IP:8095/api-docs
 
+## Before you start
+
+- Every request needs an authentication token. Create a long lived access token in the MA UI via `SETTINGS >> PROFILE` and send it in the `Authorization: Bearer <token>` header (the examples below show a truncated token)
+- The `message_id` is any string of your choosing; it is echoed back in the response so you can match responses to requests
+- Each example below is shown in two forms: a `curl` command you can run from any terminal, and the equivalent Home Assistant <a href="https://www.home-assistant.io/integrations/rest_command/" target="_blank" rel="noopener noreferrer">rest_command</a> YAML for use in automations
 
 ## Examples
 

--- a/src/content/docs/audiopipeline.md
+++ b/src/content/docs/audiopipeline.md
@@ -5,6 +5,8 @@ description: A Description of the Audio Pipeline View
 
 # Audio Pipeline
 
+The Audio Pipeline view shows exactly what happens to your audio on its way from the source to your speakers, so you can confirm the quality is being preserved. It is a read-only view; there is nothing to configure here, and you can safely ignore it if you are not interested in the detail. Open it by selecting the quality label on the [Player Bar](/ui/#player-bar) or in the [Now Playing view](/ui/#now-playing-view).
+
 <video controls autoplay loop muted playsinline style="width: 100%; max-width: 800px;">
   <source src="/videos/audio-pipeline.mp4" type="video/mp4" />
 </video>
@@ -14,7 +16,7 @@ description: A Description of the Audio Pipeline View
 
 This view shows the complete path that the audio takes. A blue dot on the line on the left shows a processing point in the pipeline.
 
-The view is broken into two sections, Input and Output. The colored dot on the section title indicates the quality as the audio leaves the section. Orange indicates a lossy codec is in use. Green indicates a lossless codec is in use. Cyan indicates a lossless codec is in use and either the sample rate is above 48kHz or the bit depth is above 16 (also known as "Hi-Res").
+The view is broken into two sections, Input and Output. The colored dot on the section title indicates the quality as the audio leaves the section: orange (LQ, Low Quality) indicates a lossy codec below 256 kbps, light green (SQ, Standard Quality) a lossy codec at 256 kbps or higher, green (HQ, High Quality) a lossless codec, and cyan (HR, Hi-Res) a lossless codec where either the sample rate is above 48kHz or the bit depth is above 16.
 
 The Input section shows the origin of the stream and the codec, <a href="https://www.izotope.com/en/learn/digital-audio-basics-sample-rate-and-bit-depth.html" target="_blank" rel="noopener noreferrer">sample rate and bit depth</a>. All tracks are processed internally as raw <a href="https://diyodemag.com/education/what_is_pcm_pulse_code_modulation" target="_blank" rel="noopener noreferrer">PCM</a> by Music Assistant and are decoded to <a href="https://www.youtube.com/watch?v=4YRp-FIsNDA" target="_blank" rel="noopener noreferrer">32 bits floating point</a> in the sample rate of the source. Even more details about the original file are available by hovering over the ⓘ including the bitrate.
 

--- a/src/content/docs/metadata-providers/lastfm-recommendations.md
+++ b/src/content/docs/metadata-providers/lastfm-recommendations.md
@@ -53,11 +53,11 @@ Same as Global Charts, but using Last.fm's per-country chart. Top 15 in chart or
 
 ## Known Issues / Notes
 
-  - Personalized rows need listening history in Music Assistant: a fresh install with no plays will not produce them
+  - Personalized rows need listening history in Music Assistant, so a fresh install with no plays will not produce them
   - Genre rows require your Last.fm username. Without it, the Genre toggle does nothing
   - At least one streaming provider that exposes library/search (e.g. Spotify, Tidal, Apple Music) must be configured, otherwise there's nothing to resolve items against and rows will be empty
   - Obscure artists/tracks may not be found on your streaming providers and are silently dropped from the row. If a row looks short, this is usually why
-  - Clearing the cache and immediately rebuilding will usually produce very similar results: not because cached data is being served, but because Last.fm's own responses for "similar to X" are stable
+  - Clearing the cache and immediately rebuilding will usually produce very similar results - not because cached data is being served, but because Last.fm's own responses for "similar to X" are stable
 
 ### Choosing a refresh interval
 

--- a/src/content/docs/metadata-providers/lastfm-recommendations.md
+++ b/src/content/docs/metadata-providers/lastfm-recommendations.md
@@ -13,64 +13,62 @@ Music Assistant has the ability to generate recommendation rows based on data av
 ## Features
 
 The provider can create up to nine recommendation rows, grouped via four toggles which can be enabled independently (each row can still be shown or hidden via the Discover view edit mode):
- 
-- Personalized (2 rows) — Discover Similar Artists + Discover Similar Tracks, seeded from your top-played artists and tracks in Music Assistant
-- Global Charts (2 rows) — Global Top Artists + Global Top Tracks from Last.fm's worldwide charts
-- Genre (3 rows) — Top Artists / Albums / Tracks for your most-played Last.fm genres, cycling through your top three genres one per day (requires a Last.fm username)
-- Geographic (2 rows) — Top Artists + Top Tracks for a country you pick from the list
+
+- Personalized (2 rows): Discover Similar Artists + Discover Similar Tracks, seeded from your top-played artists and tracks in Music Assistant
+- Global Charts (2 rows): Global Top Artists + Global Top Tracks from Last.fm's worldwide charts
+- Genre (3 rows): Top Artists / Albums / Tracks for your most-played Last.fm genres, cycling through your top three genres one per day (requires a Last.fm username)
+- Geographic (2 rows): Top Artists + Top Tracks for a country you pick from the list
 
 The rows surface music you don't currently have and each item is resolved to a streaming provider you already have configured (e.g. Spotify) so it's playable with one click.
 
 This provider also has support for populating Similar Artists, Similar Tracks and Artist Top Tracks throughout the UI.
-                                                                                                                                   
-### How each row is built                                                                                                              
-                                                                                                                                   
-Each row holds up to 10 items. They are constructed as follows:                                                           
- 
-**Personalized (Similar Artists / Similar Tracks)**
-Similar Artists seeds from up to five artists, ranked by how often they appear across the 200 most recently played tracks. Similar Tracks seeds from up to ten of the most-played tracks. Last.fm is asked for similar items for each seed; the combined list is deduplicated and sorted by Last.fm's similarity match score, and the top-scoring items are resolved against available streaming providers. The row only depends upon the listening history so two refreshes with the same history produce the same row.
-  
-Takes the 5 most-played artists (or tracks) as seeds from the MA playlog, asks Last.fm for similar items for each seed, deduplicates the combined list, and sorts by Last.fm's own similarity match score. The top-scoring items are then resolved against the available streaming providers. The row is fully deterministic given the MA library state — two refreshes with the same play counts produce the same row. It only shifts when listening habits change or Last.fm updates its similarity data.                                                   
-
-**Global Charts (Top Artists / Top Tracks)**                                                                                           
-Takes Last.fm's worldwide chart in order, resolves the top 15, and shows the first 10 that match something on the available streaming providers. No randomisation — the order is exactly Last.fm's chart ranking. The row changes when Last.fm's chart changes.                         
-
-**Genre (Top Artists / Albums / Tracks)**                   
-Cycles through your top three Last.fm genres, a different one each day. For the day's genre it fetches Last.fm's top 60, drops any already in your library, then picks items via "top 3 + random 7": the first three are fixed to Last.fm's top three, the other seven are a random sample from the rest. The random portion rotates each time the update task runs while the top three stay put.
-
-**Geographic (Top Artists / Top Tracks)**
-Same as Global Charts, but using Last.fm's per-country chart. Top 15 in chart order, first 10 that resolve. No randomisation.
 
 ## Configuration
 
 MA ships with an API key inbuilt but if a personal API key is desired to be used the obtain one by following the first two steps from <a href="https://www.last.fm/api/authentication" target="_blank" rel="noopener noreferrer">here</a>. It can be entered in a field which is seen when the advanced toggle is on.
 
-- **Last.fm Username** (optional) — required only for the Genre rows
-- **Last.fm API Key** (optional, advanced) — override the built-in key with your own if you prefer
+- **Last.fm Username** (optional): required only for the Genre rows
+- **Last.fm API Key** (optional, advanced): override the built-in key with your own if you prefer
 - Enable the row categories as desired. See above for a description of the rows which will be made available for each selection
 
 ### Settings
 
 - <b>Refresh Recommendations.</b> This button (requires advanced settings to be selected) will clear the recommendation rows and cause an instant refresh
 
+### How each row is built
+
+Each row holds up to 10 items. They are constructed as follows:
+
+**Personalized (Similar Artists / Similar Tracks)**
+Similar Artists seeds from up to five artists, and Similar Tracks from up to twenty tracks, ranked by how often they appear across your recent listening. Last.fm is asked for similar items for each seed; the combined list is deduplicated and sorted by Last.fm's similarity match score, and the top-scoring items are resolved against available streaming providers. The row is fully deterministic given the listening history: two refreshes with the same play history produce the same row. It only shifts when listening habits change or Last.fm updates its similarity data.
+
+**Global Charts (Top Artists / Top Tracks)**
+Takes Last.fm's worldwide chart in order, resolves the top 15, and shows the first 10 that match something on the available streaming providers. No randomisation: the order is exactly Last.fm's chart ranking. The row changes when Last.fm's chart changes.
+
+**Genre (Top Artists / Albums / Tracks)**
+Cycles through your top three Last.fm genres, a different one each day. For the day's genre it fetches Last.fm's top 60, drops any already in your library, then picks items via "top 3 + random 7": the first three are fixed to Last.fm's top three, the other seven are a random sample from the rest. The random portion rotates each time the update task runs while the top three stay put.
+
+**Geographic (Top Artists / Top Tracks)**
+Same as Global Charts, but using Last.fm's per-country chart. Top 15 in chart order, first 10 that resolve. No randomisation.
+
 ## Known Issues / Notes
 
-  - Personalized rows need listening history in Music Assistant — a fresh install with no plays will not produce them
+  - Personalized rows need listening history in Music Assistant: a fresh install with no plays will not produce them
   - Genre rows require your Last.fm username. Without it, the Genre toggle does nothing
   - At least one streaming provider that exposes library/search (e.g. Spotify, Tidal, Apple Music) must be configured, otherwise there's nothing to resolve items against and rows will be empty
-  - Obscure artists/tracks may not be found on your streaming providers and are silently dropped from the row. If a row looks short, this is usually why                                                         
-  - Clearing the cache and immediately rebuilding will usually produce very similar results — not because cached data is being served, but because Last.fm's own responses for "similar to X" are stable
+  - Obscure artists/tracks may not be found on your streaming providers and are silently dropped from the row. If a row looks short, this is usually why
+  - Clearing the cache and immediately rebuilding will usually produce very similar results: not because cached data is being served, but because Last.fm's own responses for "similar to X" are stable
 
-### Choosing a refresh interval                                                                                                        
-                                                          
+### Choosing a refresh interval
+
 The default 6 hours is a reasonable middle ground. The right value depends on what you want:
 
-Short intervals (1–3 hours):                                                                                                       
-- Personalized rows respond to recent listening faster — tracks you played this morning can influence "Similar Artists" by the afternoon.                                                                                   
+Short intervals (1-3 hours):
+- Personalized rows respond to recent listening faster: tracks you played this morning can influence "Similar Artists" by the afternoon.
 - Global and Geographic rows reflect Last.fm's chart movements sooner.
 - Downside: rows shift while you're browsing. If a track caught your eye but you didn't play it, it may be gone next time. If you like to work through a row at your own pace, a short interval will not be ideal.
-                                                                                                                                   
-Long intervals (12–24 hours):
-- Rows stay stable long enough to actually listen to them all.                                                                    
-- Fewer API calls.                                             
+
+Long intervals (12-24 hours):
+- Rows stay stable long enough to actually listen to them all.
+- Fewer API calls.
 - Potential Downside: Personalized and Global rows may feel stale, especially if your listening has changed recently.

--- a/src/content/docs/metadata-providers/lastfm-recommendations.md
+++ b/src/content/docs/metadata-providers/lastfm-recommendations.md
@@ -64,7 +64,7 @@ Same as Global Charts, but using Last.fm's per-country chart. Top 15 in chart or
 The default 6 hours is a reasonable middle ground. The right value depends on what you want:
 
 Short intervals (1-3 hours):
-- Personalized rows respond to recent listening faster: tracks you played this morning can influence "Similar Artists" by the afternoon.
+- Personalized rows respond to recent listening faster - tracks you played this morning can influence "Similar Artists" by the afternoon.
 - Global and Geographic rows reflect Last.fm's chart movements sooner.
 - Downside: rows shift while you're browsing. If a track caught your eye but you didn't play it, it may be gone next time. If you like to work through a row at your own pace, a short interval will not be ideal.
 

--- a/src/content/docs/metadata.md
+++ b/src/content/docs/metadata.md
@@ -5,15 +5,17 @@ description: A Description of the Metadata sources available to Music Assistant
 
 # Metadata <img src="/assets/icons/metadata-general-icon.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-Music Assistant draws on two layers of metadata. **Source metadata** comes from wherever a track actually lives — embedded file tags, `.lrc` and [`.nfo` files](https://kodi.wiki/view/NFO_files), and music providers such as Plex, Jellyfin, Subsonic, Spotify or Tidal. **Online metadata providers** (Fanart.tv, The Audio DB, MusicBrainz, Cover Art Archive, iTunes Artwork, LRCLIB, Genius, Wikipedia) are dedicated third-party services queried only to fill in fields the source did not supply.
+Metadata is everything Music Assistant shows around your music: artwork, artist biographies, genres, lyrics and more. If you are here because artwork or artist info is missing, the short version is: your own tags and files always win, free online services fill in the gaps slowly in the background, and adding a MusicBrainz ID to a tag or `.nfo` file fixes most matching problems.
+
+Music Assistant draws on two layers of metadata. **Source metadata** comes from wherever a track actually lives: embedded file tags, `.lrc` and [`.nfo` files](https://kodi.wiki/view/NFO_files), and music providers such as Plex, Jellyfin, Subsonic, Spotify or Tidal. **Online metadata providers** are dedicated third-party services queried only to fill in fields the source did not supply; they are listed in the [provider summary](#provider-summary) below.
 
 Source metadata is always preferred; online metadata is complementary.
 
 This section describes which providers contribute which fields and when lookups occur.
 
-- [Media items](./media-items) — what is gathered for artists, albums, tracks, playlists, audiobooks and podcasts
-- [Artwork](./artwork) — sources and ordering for thumbnails, fanart, disc art and radio stream artwork
-- [Lyrics](./lyrics) — what lyrics are available
+- [Media items](./media-items): what is gathered for artists, albums, tracks, playlists, audiobooks and podcasts
+- [Artwork](./artwork): sources and ordering for thumbnails, fanart, disc art and radio stream artwork
+- [Lyrics](./lyrics): what lyrics are available
 
 For loudness measurement, see the [Loudness Analysis](../audio-analysis/loudness-analysis) provider page.
 
@@ -25,7 +27,7 @@ Library items are enriched on a **90-day refresh cycle**. Refreshes are triggere
 - **On-demand lookup**, scheduled in the background when an item is opened in the UI and its metadata is older than 90 days
 - **Manual refresh** via the "Update metadata" action, which bypasses the 90-day restriction and forces a fresh lookup immediately
 
-For each item, source metadata is collected first (sorted so local providers — file system, Plex, Jellyfin, Subsonic, etc. — outrank streaming providers), then the online metadata providers are queried when "Enable metadata retrieval from online metadata providers" is on (default).
+For each item, source metadata is collected first (sorted so local providers such as the file system, Plex, Jellyfin and Subsonic outrank streaming providers), then the online metadata providers are queried when "Enable metadata retrieval from online metadata providers" is on (default).
 
 The language used for descriptions and bios is set under [Settings → System Settings → Metadata](/settings/core/#metadata) → "Preferred language". English is always used as fallback.
 
@@ -33,11 +35,11 @@ The language used for descriptions and bios is set under [Settings → System Se
 
 For library items backed by a local music collection, the following are read automatically during the library scan:
 
-- **Embedded tags** in audio files — title, artists, album, genres, year, MusicBrainz IDs, ISRC, embedded cover art, embedded lyrics, ReplayGain values, etc. The `genre` tag is applied to the track only; album and artist genres are sourced separately (see below).
-- **`.lrc` sidecar files** with the same name as the audio file — used as synchronized lyrics. This is the format produced by tools such as LRCGET
-- **`artist.nfo`** in an artist folder ([Kodi NFO format](https://kodi.wiki/view/NFO_files)) — title, sort name, biography, genres, MusicBrainz artist ID
-- **`album.nfo`** in an album folder — title, sort name, review, year, genres, MusicBrainz release group / album / album-artist IDs
-- **Folder images** (`cover.jpg`, `folder.jpg`, `artist.jpg`, [etc.](/music-providers/filesystem/#known-issues--notes)) — used as thumbnails and other artwork for albums and artists
+- **Embedded tags** in audio files: title, artists, album, genres, year, MusicBrainz IDs, ISRC, embedded cover art, embedded lyrics, ReplayGain values, etc. The `genre` tag is applied to the track only; album and artist genres are sourced separately (see below).
+- **`.lrc` sidecar files** with the same name as the audio file, used as synchronized lyrics. This is the format produced by tools such as LRCGET
+- **`artist.nfo`** in an artist folder ([Kodi NFO format](https://kodi.wiki/view/NFO_files)): title, sort name, biography, genres, MusicBrainz artist ID
+- **`album.nfo`** in an album folder: title, sort name, review, year, genres, MusicBrainz release group / album / album-artist IDs
+- **Folder images** (`cover.jpg`, `folder.jpg`, `artist.jpg`, [etc.](/music-providers/filesystem/#known-issues--notes)): used as thumbnails and other artwork for albums and artists
 
 These are part of the source metadata layer and always take priority over online lookups. They are also the most reliable way to fix problems with online matching: adding a MusicBrainz ID to a tag or `.nfo` file immediately unlocks the rest of the online providers for that item.
 
@@ -45,7 +47,7 @@ These are part of the source metadata layer and always take priority over online
 
 The file `genre` tag is applied to the track, but not to the album or the artist. By default an album's genre comes from an `album.nfo`, a music provider that supplies one, or an online metadata provider; an artist's genre comes from an `artist.nfo`, a music provider, or an online metadata provider once a MusicBrainz Artist ID has been resolved.
 
-The local filesystem providers offer an opt-in `Propagate track genres to albums and artists` setting that fills the gap by deriving the album's and artist's genres from their tracks' `genre` tags. Propagation only fills genres that are still empty — it never overwrites a genre that came from an `NFO` file, a music provider, or an online metadata provider.
+The local filesystem providers offer an opt-in `Propagate track genres to albums and artists` setting that fills the gap by deriving the album's and artist's genres from their tracks' `genre` tags. Propagation only fills genres that are still empty; it never overwrites a genre that came from an `NFO` file, a music provider, or an online metadata provider.
 
 Apart from propagation, sources merge their genres into whatever is already there rather than replacing or being suppressed. An `artist.nfo` genre plus genres returned by The Audio DB will both end up on the artist. 
 
@@ -57,15 +59,15 @@ By design the music collection is treated as **read-only**:
 - Bios, descriptions, genres, artwork and lyrics are never written back to files
 - `.nfo` files are never created or modified
 
-When write access is available the exceptions to this are :
-- [Loudness Analysis](../audio-analysis/loudness-analysis) plugin's optional "Write REPLAYGAIN_TRACK_GAIN tags back to files" setting (default **off**). When enabled, a `REPLAYGAIN_TRACK_GAIN` tag is written into each track after its loudness is measured, so other apps on the network can use it for volume normalization
-- [AcoustID Lookup](../audio-analysis/acoustid) plugin's optional "Write AcoustID/MusicBrainz tags back to files" setting (default **off**). When enabled, the Acoustid Id, MusicBrainz Recording Id, ISRC, and (where resolvable) MusicBrainz Artist Id tags are written back into the source audio file once identification succeeds
+When write access is available the exceptions to this are:
+- The [Loudness Analysis](../audio-analysis/loudness-analysis) provider's optional "Write REPLAYGAIN_TRACK_GAIN tags back to files" setting (default **off**); see its page for details
+- The [AcoustID Lookup](../audio-analysis/acoustid) provider's optional "Write AcoustID/MusicBrainz tags back to files" setting (default **off**); see its page for details
 
 ## Provider summary
 
 | Provider | Used for | Requires |
 | --- | --- | --- |
-| **MusicBrainz** | Looking up MBIDs from artist / album / track names. Cannot be disabled — it is used for identification only and never replaces information that already exists. | — |
+| **MusicBrainz** | Looking up MBIDs from artist / album / track names. Cannot be disabled; it is used for identification only and never replaces information that already exists. | None |
 | **Fanart.tv** | High-quality artist and album imagery (thumb, logo, banner, fanart, CD art). | Artist or release-group MBID |
 | **The Audio DB** | Bios, descriptions, genres / style / mood, label, links, images. | Artist MBID for artist metadata; release-group / recording MBID preferred for albums and tracks (with artist + name fallback). |
 | **Cover Art Archive** | Album front covers from MusicBrainz's official archive. | Release-group MBID |

--- a/src/content/docs/metadata/lyrics.md
+++ b/src/content/docs/metadata/lyrics.md
@@ -4,6 +4,8 @@ title: Lyrics
 
 # Lyrics <img src="/assets/icons/metadata-lyrics-icon.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
+Music Assistant shows lyrics in the [Now Playing view](/ui/#now-playing-view) when they are available for the playing track; there is nothing to configure by default. This page explains where lyrics come from and how to fix wrong ones.
+
 Two kinds of lyrics are available:
 
 - **Synchronized lyrics** (`.lrc` format with timestamps)

--- a/src/content/docs/metadata/media-items.md
+++ b/src/content/docs/metadata/media-items.md
@@ -4,7 +4,7 @@ title: Media items
 
 # Media Item Metadata <img src="/assets/icons/metadata-mediaitem-icon.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-This page lists what metadata is gathered for each kind of media item — artists, albums, tracks, playlists, audiobooks and podcasts — and where each field comes from. As [elsewhere](/metadata/), source metadata always takes priority and the online providers only fill in the gaps.
+This page lists what metadata is gathered for each kind of media item (artists, albums, tracks, playlists, audiobooks and podcasts) and where each field comes from. As [elsewhere](/metadata/), source metadata always takes priority and the online providers only fill in the gaps.
 
 ## Artists
 
@@ -20,9 +20,7 @@ This page lists what metadata is gathered for each kind of media item — artist
 
 The MusicBrainz Artist ID is the key that unlocks all online artist enrichment. When no MBID can be determined for an artist (typically because none of the artist's tracks or albums matched), no online bio or imagery is fetched. Adding the MBID to file tags or to an `artist.nfo` is the most reliable fix.
 
-Note that the embedded `genre` tag in audio files is applied to the track only, not to the album or the artist. To get genres on an album or artist itself, either supply an `album.nfo` / `artist.nfo`, rely on an online metadata provider (which for artists requires an MBID), or enable `Propagate track genres to albums and artists` on the local filesystem provider, which derives them from the tracks' tags.
-
-Propagation only fills genres that are still empty and never overwrites a genre that came from another source. Apart from propagation, sources merge their genres into whatever is already there — an `artist.nfo` genre plus genres returned by The Audio DB will both end up on the artist.
+Note that the embedded `genre` tag in audio files is applied to the track only, not to the album or the artist. See [Album and artist genres](/metadata/#album-and-artist-genres) for how album and artist genres are derived, propagated and merged.
 
 ## Albums
 
@@ -56,8 +54,8 @@ Playlists don't have rich metadata of their own; instead Music Assistant derives
 
 ## Audiobooks
 
-Audiobook items collect publisher, authors, narrators, duration, description and chapter list — sourced from embedded tags or the audiobook provider (Audiobookshelf, Audible, etc.). Cover artwork follows the same precedence as albums.
+Audiobook items collect publisher, authors, narrators, duration, description and chapter list, sourced from embedded tags or the audiobook provider (Audiobookshelf, Audible, etc.). Cover artwork follows the same precedence as albums.
 
 ## Podcasts
 
-Podcast shows track publisher and total episode count from the podcast provider (Audiobookshelf, Podcast Index, RSS feed, etc.). Per-episode metadata — title, description, artwork — comes directly from the show's feed.
+Podcast shows track publisher and total episode count from the podcast provider (Audiobookshelf, Podcast Index, RSS feed, etc.). Per-episode metadata (title, description, artwork) comes directly from the show's feed.

--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -44,20 +44,29 @@ AirPlay 1 (RAOP) specific advanced settings are:
 
 AirPlay 2 specific advanced settings are:
 
-- <b>Expected milliseconds to establish streaming session with the AirPlay device.</b> The number of milliseconds of data to buffer in the cliap2 binary. Try increasing the value if playback is unreliable (out of sync or not working). <b>NOTE:</b> This adds to the latency experienced for the commencement of playback.
+- <b>Expected milliseconds to establish streaming session with the AirPlay device.</b> How much audio MA buffers while the connection to the player is established. Try increasing the value if playback is unreliable (out of sync or not working). <b>NOTE:</b> This adds to the latency experienced for the commencement of playback.
 
 ## Known Issues / Notes
+
+### If there is no sound
+
+Everything can appear to work (volume changes, song info shows, the device responds) and yet no sound comes out. Try these in order:
+
+- Enable encryption in the advanced player settings. Some devices (such as Kodi or some 3rd party AirPlay receivers) require it
+- Try compression on and off in the advanced player settings
+- HomePod owners: check Apple HomeKit. In the HomeKit (iOS) preferences for `AirPlay (Speaker & TV)`, make sure `Only people in this home` is NOT selected; when it is, Music Assistant cannot play audio on the HomePod (without setting the proper password in the advanced settings of the provider). Select the option `Everyone on the same network` instead. More generally, Apple HomeKit has been reported to interfere with playback; if problems are encountered, try removing the devices from HomeKit
+- If the device requires a password, set it in the advanced settings
+- Samsung devices seem to have implemented AirPlay 1 in a way that isn't fully backwards compatible and produce exactly this symptom. Users of similar applications such as Roon and anything based on slimproto have the same problem
+
+### Other playback problems
+
+- Apple TVs will be discovered but require pairing. In the player settings there is a pair button which will display a code on the screen of the Apple TV
+- If your player is going unavailable while still powered on then it may not be sending its keep alive message. A timeout can be configured for each player. Some users have reported they have needed to set it as long as one hour
+- If the AirPlay device incorrectly responds to change volume commands or randomly changes volume, try changing the `Volume Control` option in the `Player controls` section and set it to `None`
+
+### Technical notes
 
 - Music Assistant implements <a href="https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol" target="_blank" rel="noopener noreferrer">RAOP</a> and <a href="https://en.wikipedia.org/wiki/AirPlay" target="_blank" rel="noopener noreferrer">AirPlay2</a>. Most devices will default to RAOP because AirPlay 2 devices should be backwards compatible by default. If a device has a bad implementation of AirPlay 1 and/or only supports AirPlay 2 without RAOP then select AirPlay2 as the protocol version.
 - Shairport and AirPlay 2 are currently incompatible due to lack of NTP timing support for AirPlay 2 in Shairport and lack of PTP timing support for AirPlay 2 in Music Assistant.
 - Playback to Macbooks is not possible due to removal of RAOP support
-- Apple TVs will be discovered but require pairing. In the player settings there is a pair button which will display a code on the screen of the Apple TV
-- Samsung seems to have implemented AirPlay 1 in a way that isn't fully backwards compatible. Everything seems to work, changing volume, song info is shown, and you can control the Samsung device as expected, however there is no sound. Users of similar applications such as Roon and anything based on slimproto have the same problem
-- Some devices (such as Kodi or some 3rd party AirPlay receivers) require encryption. You can enable encryption in the advanced player settings if there is no sound
-- Also try compression on and off in the advanced player settings if there is no sound
-- A device password can be set for those devices which require it in the advanced settings
-- If you find your player is going unavailable when still powered on then it may not be sending its keep alive message. A timeout can be configured for each player. Some users have reported they have needed to set it as long as one hour
-- Apple Homekit has been reported to interfere with playback. If problems are enountered then remove the devices from Apple Homekit or try changing the setting in the preferences section of Homekit (iOS) for `AirPlay (Speaker & TV)`.
-  - In this section specifically check if the `Only people in this home` is not selected. When this option is selected, MusicAssistant cannot play audio on the HomePod (without setting the proper password in the advanced settings of the provider). Select the option `Everyone on the same network` instead.
-- If the AirPlay device incorrectly responds to change volume commands or randomly changes volume, try changing the `Volume Control` option in the `Player controls` section and set it to `None`
 - AirPlay 2 implementation is new and has not yet been extensively tested. It is known that Password-based pairing and PTP timing is not yet supported. There may be additional issues that are not yet known. The AirPlay 2 protocol takes longer to establish initial connection than AirPlay 1 (RAOP) due to more RTSP exchanges. This adds to the delay experienced for commencement of playback.

--- a/src/content/docs/player-support/sonos.md
+++ b/src/content/docs/player-support/sonos.md
@@ -14,7 +14,7 @@ Music Assistant has support for Sonos devices. There are two providers available
 
 ### AirPlay Functionality
 
-Many Sonos devices support the AirPlay 1 <a href="https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol" target="_blank" rel="noopener noreferrer">RAOP</a> protocol and this enables very useful functionality within Music Assistant.
+Many Sonos devices support the AirPlay 1 <a href="https://en.wikipedia.org/wiki/Remote_Audio_Output_Protocol" target="_blank" rel="noopener noreferrer">RAOP</a> protocol and this enables very useful functionality within Music Assistant. <a href="https://support.sonos.com/en-au/article/stream-airplay-audio-to-sonos" target="_blank" rel="noopener noreferrer">Sonos's AirPlay guide</a> lists which devices are AirPlay capable.
 
 If the Sonos device is grouped with an AirPlay device, or if the default [output protocol](/settings/individual-player/#output-protocols) is changed to `AirPlay`, then the AirPlay protocol will be used for playback. Other Sonos players can be synced with this player (even if they themselves do not have AirPlay, as the native Sonos protocol will be used for that connection). This means it is possible to play the same audio in perfect sync to a combination of AirPlay and Sonos speakers.
 
@@ -33,7 +33,7 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 In addition to the [Player Provider Settings](/settings/player-provider/) when setting up this provider the following settings are available:
 
-- <b>Manual IP addresses for discovery.</b> Not recommended for normal use. Refer to the description in the MA UI
+- <b>Manual IP addresses for discovery.</b> In normal circumstances Music Assistant will automatically discover all players on the network using multicast discovery (mDNS/UPnP, [explained here](/faq/networking/)). In the case of special network setups, or when issues are encountered with one or more players not being discovered, IP addresses can be manually added here. This setting is not recommended for normal use. Also, if players are not on the same subnet as the Music Assistant server, issues may be experienced with streaming; in that case ensure the players can reach the server on the network and double check the base URL configuration of the [Stream server in the settings](/settings/core/#streams)
 
 In addition to the [Individual Player Settings](/settings/individual-player/) the Sonos players have the following settings:
 
@@ -49,5 +49,4 @@ In addition to the [Individual Player Settings](/settings/individual-player/) th
 - Issues have been reported with playback not starting on the `Sonos Connect Amp` and `Play:1`. If this is encountered then set `Enable Queue Flow Mode` to ON in the [individual player settings](/settings/individual-player/)
 - S1 and S2 devices cannot be grouped together in the same Sync Group. S1 and S2 devices can be grouped via a Universal Group but will not play in sync
 - Using the Sonos HA Integration at the same time as the MA Sonos S1 player provider may cause problems. It is not possible to run the HA provider and Sonos S1 provider on the same host and additionally these speakers do not like too many requests from too many sources. It is therefore recommended to only use the MA Sonos S1 player provider
-- Syncing Sonos devices with AirPlay devices requires the enabling of an option on the Sonos player
 - Sonos firmware changes has resulted in crossfade not working when the output codec is lossless (i.e. FLAC or WAV). Users can either disable crossfade, switch to the MP3 codec or use AirPlay mode

--- a/src/content/docs/plugins/fastmcp-server.md
+++ b/src/content/docs/plugins/fastmcp-server.md
@@ -42,7 +42,7 @@ For multi-agent orchestrators the wizard emits the native form for each: an `ope
 
 - <b>Require authentication.</b> Reject MCP clients that do not present a valid Music Assistant token. Strongly recommended to leave enabled.
 - <b>Confirm destructive operations.</b> Ask the client to confirm before clearing a queue, removing a library item or deleting a playlist. Falls through to the matching permission toggle on clients that do not yet support confirmation prompts.
-- <b>Permissions.</b> Twenty-nine toggles in total — sixteen action toggles split across Query Permissions, Control Permissions, Edit Permissions and Delete Permissions; three MCP Resources toggles that control which library, player/queue and prompt resources are advertised to clients; five Debug toggles; and five Config toggles. The defaults enable read-only library and resource access only; every action that mutates state, and every Debug and Config capability, is off by default.
+- <b>Permissions.</b> The defaults enable read-only library and resource access only; every action that mutates state, and every Debug and Config capability, is off by default, so enable only what you need. There are twenty-nine toggles in total: sixteen action toggles split across Query Permissions, Control Permissions, Edit Permissions and Delete Permissions; three MCP Resources toggles that control which library, player/queue and prompt resources are advertised to clients; five Debug toggles; and five Config toggles.
 
 #### Optional capability namespaces (advanced)
 

--- a/src/content/docs/plugins/vban-receiver.md
+++ b/src/content/docs/plugins/vban-receiver.md
@@ -5,7 +5,7 @@ description: Features and Notes for the VBAN Receiver Plugin
 
 # VBAN Receiver <img src="/assets/icons/vban-icon.svg" alt="Preview image" style="width: 126px; float: right;"  loading="lazy" />
 
-The VBAN Receiver plugin gives Music Assistant a network-based auxiliary input: audio playing on another device can be sent into MA and treated as a standard streaming source. Typical use cases include transmitting system audio, audio from individual applications, or audio captured from soundcard inputs such as microphones or line-in devices on a remote machine. Contributed and maintained by <a href="https://github.com/sprocket-9" target="_blank" rel="noopener noreferrer">sprocket-9</a>
+The VBAN Receiver plugin gives Music Assistant a network-based auxiliary input - audio playing on another device can be sent into MA and treated as a standard streaming source. Typical use cases include transmitting system audio, audio from individual applications, or audio captured from soundcard inputs such as microphones or line-in devices on a remote machine. Contributed and maintained by <a href="https://github.com/sprocket-9" target="_blank" rel="noopener noreferrer">sprocket-9</a>
 
 VBAN itself is an audio-over-IP protocol from <a href="https://vb-audio.com/Voicemeeter/vban.htm" target="_blank" rel="noopener noreferrer">VB-Audio</a> that uses UDP to transmit high-quality, native PCM audio over a local network. See the [VBAN Senders section below](#vban-senders) for examples of compatible sender implementations.
 

--- a/src/content/docs/plugins/vban-receiver.md
+++ b/src/content/docs/plugins/vban-receiver.md
@@ -5,13 +5,15 @@ description: Features and Notes for the VBAN Receiver Plugin
 
 # VBAN Receiver <img src="/assets/icons/vban-icon.svg" alt="Preview image" style="width: 126px; float: right;"  loading="lazy" />
 
-Music Assistant has the ability to act as a VBAN protocol (PCM audio over UDP) receiver. Contributed and maintained by <a href="https://github.com/sprocket-9" target="_blank" rel="noopener noreferrer">sprocket-9</a>
+The VBAN Receiver plugin gives Music Assistant a network-based auxiliary input: audio playing on another device can be sent into MA and treated as a standard streaming source. Typical use cases include transmitting system audio, audio from individual applications, or audio captured from soundcard inputs such as microphones or line-in devices on a remote machine. Contributed and maintained by <a href="https://github.com/sprocket-9" target="_blank" rel="noopener noreferrer">sprocket-9</a>
 
-VBAN is commonly used to route audio between devices on a local network. In Music Assistant, the VBAN Receiver plugin functions as a network-based auxiliary input, allowing external audio sources to be ingested as a standard MA streaming source. Typical use cases include transmitting system audio, audio from individual applications, or audio captured from soundcard inputs such as microphones or line-in devices on a remote machine. See the [VBAN Senders section below](#vban-senders) for examples of compatible sender implementations.
+VBAN itself is an audio-over-IP protocol from <a href="https://vb-audio.com/Voicemeeter/vban.htm" target="_blank" rel="noopener noreferrer">VB-Audio</a> that uses UDP to transmit high-quality, native PCM audio over a local network. See the [VBAN Senders section below](#vban-senders) for examples of compatible sender implementations.
 
 ## Features
 
-VBAN is an audio-over-IP protocol from <a href="https://vb-audio.com/Voicemeeter/vban.htm" target="_blank" rel="noopener noreferrer">VB-Audio</a> that uses UDP to transmit high-quality, native PCM audio over a local network.
+- Ingest audio from any VBAN sender on the network as a standard MA streaming source
+- Play system audio, individual applications, microphones or line-in inputs from a remote machine to any MA player
+- Multiple instances can be added, one per incoming stream
 
 ## Configuration
 

--- a/src/content/docs/ui.md
+++ b/src/content/docs/ui.md
@@ -38,7 +38,7 @@ Selecting a specific category will then show a maximum of 50 items. Context sens
 
 When playing to a group, tapping near the volume control will open a dialog to control the individual players.
 
-The [Audio Pipeline](/audiopipeline/) selectable label shows, via a colored icon and two letters, the quality of the audio output (Low Quality, Standard Quality, High Quality and Hi-Res). An orange circle and LQ indicate a lossy codec below 256 kbps, a light-green dot with SQ (Standard Quality) indicates a lossy codec at 256 kbps or higher, a green circle and HQ indicates a lossless codec in use, and a cyan circle and HR indicates a lossless codec and [High Resolution sample rate or bit depth](/player-support/#audio-quality). For groups, where the quality varies between players, the highest quality available will be indicated.
+The [Audio Pipeline](/audiopipeline/) selectable label shows, via a colored icon and two letters, the sound quality of the audio output: LQ (Low Quality), SQ (Standard Quality), HQ (High Quality) or HR (Hi-Res). Select the label to see the full path the audio takes; what each quality level means is explained on the [Audio Pipeline](/audiopipeline/) page. For groups, where the quality varies between players, the highest quality available will be indicated.
 
 The overflow menu holds a number of useful options. Of note, for podcasts and audiobooks, there is a `Change playback speed` option which when selected will open a dialog with five preset speeds and a slider. The slider ranges from 0.5x to 2.0x and a preset is available for a boosted speed of 3.0x.
 


### PR DESCRIPTION
Seventh and final PR from the docs approachability review, closing out the findings that needed maintainer input or hadn't been picked up by earlier tiers.

## Sonos (using maintainer-supplied information)

- The **Manual IP addresses for discovery** setting is now documented in full, mirroring the UI text, instead of "Refer to the description in the MA UI".
- The dead-end "Syncing Sonos devices with AirPlay devices requires the enabling of an option on the Sonos player" bullet is **removed** as outdated; AirPlay-capable devices now simply appear as such.
- The AirPlay Functionality section links [Sonos's AirPlay guide](https://support.sonos.com/en-au/article/stream-airplay-audio-to-sonos) for which devices are AirPlay capable.

## AirPlay

- **Known Issues restructured symptom-first**: an "If there is no sound" checklist (encryption → compression → the HomeKit `Only people in this home` setting → device password → the Samsung case) followed by "Other playback problems", with the protocol/NTP/PTP/Shairport material under "Technical notes". No content removed, only regrouped, so a user hunting for "why is there no sound" no longer reads timing-protocol detail first.
- The AirPlay 2 buffer setting description no longer references the internal `cliap2` binary and now matches its own setting name.

## Orientation intros

- **audiopipeline.md** now opens by saying what the view is, that it is read-only and safe to ignore, and where to open it. The quality-dot paragraph now defines all four levels (LQ/SQ/HQ/HR), letting **ui.md**'s Player Bar walkthrough simply name the levels and defer the definitions here.
- **metadata/lyrics.md** opens with "lyrics just work by default; this page explains where they come from and how to fix wrong ones".

## api.md

- New **Before you start** section: where the bearer token comes from (`SETTINGS >> PROFILE`, long-lived access tokens), what `message_id` is, and that each example is a paired curl / Home Assistant `rest_command` form.

## Metadata pages

- **metadata.md** opens with the user outcome ("your own tags always win, online services fill gaps slowly, a MusicBrainz ID fixes most matching problems") and defers the eight-provider roll call to the summary table. Write-back bullets shortened to link the provider pages that own the detail.
- **media-items.md** genre paragraphs deduplicated to link the canonical [Album and artist genres](/metadata/#album-and-artist-genres) section (anchor verified in the built output).

## Smaller items

- **lastfm-recommendations.md**: the two near-duplicate "Personalized" paragraphs merged into one, with seed counts corrected against the server source (five artist seeds, twenty track seeds; the old text said ten). The "How each row is built" detail moved below Configuration. Trailing whitespace stripped.
- **vban-receiver.md**: intro leads with what the plugin does (a network auxiliary input) before the protocol definition, and Features now lists capabilities instead of defining VBAN.
- **fastmcp-server.md**: the Permissions bullet leads with the safe-defaults takeaway before the 29-toggle inventory.

Site builds cleanly; em dashes swept from all touched pages per the style rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbELYAWFLnuJnv7VQ8NxC8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbELYAWFLnuJnv7VQ8NxC8)_