### PR TITLE
Fix Language setting description regressed by the menu update

### DIFF
--- a/src/content/docs/settings/user-interface.md
+++ b/src/content/docs/settings/user-interface.md
@@ -9,7 +9,7 @@ Customise the user interface from this page. Preferences are stored per user and
 ## Preferences
 
 - <b>Theme.</b> Allow selection of a light or dark theme. Options are `Auto (follow system configuration) [default]`, `Light`, and `Dark`
-- <b>Language.</b> Allow selection of a light or dark theme. Options are `Auto (follow system configuration) [default]`, or a wide variety of languages. Translations are [contributed by the community](/help/lokalise/). Note that the AUTO setting takes the language from the Browser's settings
+- <b>Language.</b> Allow selection of the language used by the user interface. Options are `Auto (follow system configuration) [default]`, or a wide variety of languages. Translations are [contributed by the community](/help/lokalise/). Note that the AUTO setting takes the language from the Browser's settings
 - <b>Customise Menu.</b> This button enables the edit mode for the menu
 
 ## Display


### PR DESCRIPTION
The beta menu-editing update reintroduced the copy-paste error previously fixed on main: the Language bullet on the User Interface settings page described the Theme setting ("Allow selection of a light or dark theme"). Restored the language description; the rest of the beta update (Customise Menu, waveform progress bar) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbELYAWFLnuJnv7VQ8NxC8

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbELYAWFLnuJnv7VQ8NxC8)_