### PR TITLE
Document configurable Snapcast stream sample rate and bit depth

### DIFF
--- a/src/content/docs/player-support/snapcast.md
+++ b/src/content/docs/player-support/snapcast.md
@@ -1,11 +1,12 @@
 ---
-title: "Snapcast"
+title: Snapcast Player Provider
 description: Details for the Snapcast Player Provider
 ---
 
 # Snapcast <img src="/assets/icons/snapcast-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-Snapcast plays the same audio on several devices at once and keeps them in step, so music can follow you from room to room without any echo between them. Anything that can run the Snapcast client software becomes a speaker, which in practice means a Raspberry Pi, a spare computer, a phone or just a browser tab. This component is contributed and maintained by <a href="https://github.com/Santiagosotoc" target="_blank" rel="noopener noreferrer">SantiagoSotoC</a>.
+Music Assistant supports Snapcast, a powerful solution for synchronized multi-room audio streaming. Snapcast enables seamless playback across various devices, creating an immersive audio experience.
+Whether using Snapcast-compatible speakers or devices like the Raspberry Pi, synchronized audio playback can be enjoyed effortlessly. This component is contributed and maintained by <a href="https://github.com/Santiagosotoc" target="_blank" rel="noopener noreferrer">SantiagoSotoC</a>.
 
 MA includes a built-in Snapserver although an external server can also be used. The diagram below shows a possible combination of outputs. In the diagram a Raspberry Pi runs the server which communicates to MA and all of the clients. The server running Pi is also running Snapclient and is connected to a set of speakers. Then there is another Pi running Snapclient in another room, a phone running Snapdroid and a laptop running Snapweb.
 
@@ -14,7 +15,7 @@ MA includes a built-in Snapserver although an external server can also be used. 
 ## Features
 
 - Synchronized playback across all Snapcast devices
-- Lossless audio quality. Default is 48 kHz / 16-bit PCM. Higher sample rates and 24-bit are only available when using an external Snapserver (see Settings)
+- Lossless audio quality. The default is 48 kHz / 16-bit. Higher sample rates and 24-bit are available only when Music Assistant is connected to a compatible external Snapserver (see Settings)
 
 ## Configuration
 
@@ -32,55 +33,16 @@ In the `Show Advanced Settings` toggle is enabled this will allow the use of an 
 - <b>Snapcast Server IP.</b> The IP address of the external Snapcast server (e.g. `192.168.1.200`)
 - <b>Snapcast Control Port.</b> The port the external Snapcast server can be reached on
 - <b>Idle threshold stream parameter.</b> (default 60000ms) The stream state will switch from playing to idle after receiving this many milliseconds of silence
-- <b>Snapcast stream sample rate.</b> (default `48000`) Only shown when **Use existing Snapserver** is enabled. Sets how many samples per second Music Assistant sends into Snapcast (`48000`, `96000`, or `192000`). Your Snapcast clients must support the rate you choose. After changing it, reload the Snapcast provider.
-- <b>Snapcast stream bit depth.</b> (default `16`) Only shown when **Use existing Snapserver** is enabled. Sets how many bits per sample Music Assistant sends (`16` or `24`). **24-bit does not work with Music Assistant’s built-in Snapserver**, and not with Snapservers installed from normal packages/releases. See “Using higher sample rates and 24-bit” below.
+- <b>Snapcast stream sample rate.</b> (default `48000`) Only shown when **Use existing Snapserver** is enabled. Choose `48000`, `96000`, or `192000`. Your Snapcast clients must support the rate you choose. After changing it, reload the Snapcast provider
+- <b>Snapcast stream bit depth.</b> (default `16`) Only shown when **Use existing Snapserver** is enabled. Choose `16` or `24`. Higher rates and 24-bit need a [compatible external Snapserver](https://github.com/rwjack/snapcast/tree/feature/tcp-packed-s24le). The built-in Snapserver always stays at 48 kHz / 16-bit
 
 The `Built-in Snapserver Settings`are as follows:
 
-- <b>Buffer Size.</b> (default 1000ms) How far ahead the server works. This is why there is a pause of about a second after you press play, or skip, or pause. Lowering it shortens that delay but makes dropouts more likely
-- <b>Chunk Size.</b> (default 26ms) How much audio the server prepares at a time. The default suits FLAC, which is what is used unless you change it. Leave it alone unless you have changed the codec and are having trouble
+- <b>Buffer Size.</b> (default 1000ms) is the total buffer size (or better buffer duration) between recording the signal on the server and playing it out on the client. This can be translated directly to the total latency of the audio signal. If play is pressed or a track is paused or skipped, a delay of 1000ms will be noticed because of this buffer
+- <b>Chunk Size.</b> (default 26ms). The server will continously read this number of milliseconds from the source into buffer and pass this buffer to the encoder. The encoded buffer is sent to the clients. Some codecs have a higher latency and will need more data, e.g. FLAC will need ~26ms chunks and thus this is the default
 - <b>Snapserver Initial Volume.</b> The initial volume for new clients
 - <b>Send audio to muted clients.</b> Maintains a stream to muted clients
 - <b>Snapserver default transport codec.</b> Options are FLAC [default], OGG, OPUS, and PCM
-
-### Using higher sample rates and 24-bit (external Snapserver only)
-
-With the built-in Snapserver, Music Assistant always streams at 48 kHz / 16-bit. The sample rate and bit depth settings only appear after you enable **Use existing Snapserver**.
-
-**Higher sample rates (still 16-bit)** need Snapcast clients that support that rate.
-
-**24-bit** needs more: Music Assistant sends packed 24-bit PCM, which a normal Snapserver cannot ingest. Until that support ships in an official Snapcast release (and Music Assistant’s built-in server can use it), build an external Snapserver from the branch that adds packed 24-bit PCM ingest:
-
-```sh
-# Debian / Raspberry Pi OS / Ubuntu
-sudo apt-get update
-sudo apt-get install -y git build-essential cmake ninja-build ccache \
-  alsa-utils avahi-daemon libasound2-dev libavahi-client-dev libboost-dev \
-  libexpat1-dev libflac-dev libopus-dev libsoxr-dev libssl-dev \
-  libvorbis-dev libvorbisidec-dev
-
-git clone --branch feature/tcp-packed-s24le --single-branch \
-  https://github.com/rwjack/snapcast.git
-cd snapcast
-mkdir build && cd build
-cmake .. -DBUILD_CLIENT=OFF
-cmake --build .
-
-sudo install -m 755 ../bin/snapserver /usr/local/bin/snapserver
-snapserver -v
-```
-
-Then:
-
-1. Run that `snapserver` on a host on your network (stop any old Snapserver first).
-2. In Music Assistant → Snapcast provider → Advanced Settings:
-   - enable **Use existing Snapserver**
-   - set **Snapcast Server IP** and **Control Port**
-   - set **Snapcast stream sample rate** / **bit depth** as needed
-3. Reload the Snapcast provider.
-4. Point your Snapcast clients at that **external** server (not Music Assistant’s built-in Snapweb on port 1780).
-
-Support for higher rates / 24-bit on the built-in Snapserver is planned once the required Snapcast support is available upstream.
 
 ### Player
 
@@ -98,10 +60,10 @@ In addition to the [Individual Player Settings](/settings/individual-player/), S
 - The built-in Snapserver can only accept connections from Music Assistant
 - If it is necessary to adjust the latency of a client, it must be done from another interface such as Snapdroid or Snapweb
 - If muted players go out of sync or exhibit undesirable rebuffer delays when subsequently unmuted, or shutdown while muted then try turning on the option `Send audio to muted clients`
-- Snapcast has no real pause, so Music Assistant stops and restarts instead. Pausing works, but the player never actually shows as paused
+- Pausing has been implemented as best as can be achieved with the limitations of Snapcast. MA issues a STOP and RESUME command to achieve the pause effect but this means the resulting player state never changes to paused.
 - Occasionally after a stream change (pause, skip or seek) Snapweb can go silent. This can be fixed by selecting stop then play in the Snapweb UI
 - The Snapcast app for iOS is broken as it uses an old version of Snapclient. Using it brings problems with this provider
 - Ensure that the ports 1704 and 1705 on the Snapserver host are open. Also make sure that the ports between 4953 and 5153 inclusive are open
 - Try the default Snapcast settings and then make changes as necessary
-- Stream sample rate and bit depth settings are only available with an external Snapserver. The built-in Snapserver always uses 48 kHz / 16-bit for now. 24-bit additionally requires an external Snapserver built with packed 24-bit PCM support as described above. Changing these settings requires a provider reload.
+- Leave the stream sample rate and bit depth at the defaults unless you are using a compatible external Snapserver. Reload the Snapcast provider after changing them
 - The stream name must be `default`

--- a/src/content/docs/player-support/snapcast.md
+++ b/src/content/docs/player-support/snapcast.md
@@ -14,7 +14,7 @@ MA includes a built-in Snapserver although an external server can also be used. 
 ## Features
 
 - Synchronized playback across all Snapcast devices
-- Lossless audio quality; default is 48 kHz / 16-bit PCM, with optional higher sample rates and 24-bit (see Settings)
+- Lossless audio quality. Default is 48 kHz / 16-bit PCM. Higher sample rates and 24-bit are only available when using an external Snapserver (see Settings)
 
 ## Configuration
 
@@ -32,8 +32,8 @@ In the `Show Advanced Settings` toggle is enabled this will allow the use of an 
 - <b>Snapcast Server IP.</b> The IP address of the external Snapcast server (e.g. `192.168.1.200`)
 - <b>Snapcast Control Port.</b> The port the external Snapcast server can be reached on
 - <b>Idle threshold stream parameter.</b> (default 60000ms) The stream state will switch from playing to idle after receiving this many milliseconds of silence
-- <b>Snapcast stream sample rate.</b> (default 48000) Maximum PCM sample rate Music Assistant sends into the Snapcast TCP source. Options are `48000`, `96000`, and `192000`. Higher rates require Snapcast clients that support them
-- <b>Snapcast stream bit depth.</b> (default 16) Maximum PCM bit depth for those TCP sources. Options are `16` and `24`. 24-bit requires a Snapserver build with packed `s24le` TCP ingest support (see [snapcast/snapcast#1532](https://github.com/snapcast/snapcast/pull/1532))
+- <b>Snapcast stream sample rate.</b> (default `48000`) Only shown when **Use existing Snapserver** is enabled. Sets how many samples per second Music Assistant sends into Snapcast (`48000`, `96000`, or `192000`). Your Snapcast clients must support the rate you choose. After changing it, reload the Snapcast provider.
+- <b>Snapcast stream bit depth.</b> (default `16`) Only shown when **Use existing Snapserver** is enabled. Sets how many bits per sample Music Assistant sends (`16` or `24`). **24-bit does not work with Music Assistant’s built-in Snapserver**, and not with Snapservers installed from normal packages/releases. See “Using higher sample rates and 24-bit” below.
 
 The `Built-in Snapserver Settings`are as follows:
 
@@ -42,6 +42,45 @@ The `Built-in Snapserver Settings`are as follows:
 - <b>Snapserver Initial Volume.</b> The initial volume for new clients
 - <b>Send audio to muted clients.</b> Maintains a stream to muted clients
 - <b>Snapserver default transport codec.</b> Options are FLAC [default], OGG, OPUS, and PCM
+
+### Using higher sample rates and 24-bit (external Snapserver only)
+
+With the built-in Snapserver, Music Assistant always streams at 48 kHz / 16-bit. The sample rate and bit depth settings only appear after you enable **Use existing Snapserver**.
+
+**Higher sample rates (still 16-bit)** need Snapcast clients that support that rate.
+
+**24-bit** needs more: Music Assistant sends packed 24-bit PCM, which a normal Snapserver cannot ingest. Until that support ships in an official Snapcast release (and Music Assistant’s built-in server can use it), build an external Snapserver from the branch that adds packed 24-bit PCM ingest:
+
+```sh
+# Debian / Raspberry Pi OS / Ubuntu
+sudo apt-get update
+sudo apt-get install -y git build-essential cmake ninja-build ccache \
+  alsa-utils avahi-daemon libasound2-dev libavahi-client-dev libboost-dev \
+  libexpat1-dev libflac-dev libopus-dev libsoxr-dev libssl-dev \
+  libvorbis-dev libvorbisidec-dev
+
+git clone --branch feature/tcp-packed-s24le --single-branch \
+  https://github.com/rwjack/snapcast.git
+cd snapcast
+mkdir build && cd build
+cmake .. -DBUILD_CLIENT=OFF
+cmake --build .
+
+sudo install -m 755 ../bin/snapserver /usr/local/bin/snapserver
+snapserver -v
+```
+
+Then:
+
+1. Run that `snapserver` on a host on your network (stop any old Snapserver first).
+2. In Music Assistant → Snapcast provider → Advanced Settings:
+   - enable **Use existing Snapserver**
+   - set **Snapcast Server IP** and **Control Port**
+   - set **Snapcast stream sample rate** / **bit depth** as needed
+3. Reload the Snapcast provider.
+4. Point your Snapcast clients at that **external** server (not Music Assistant’s built-in Snapweb on port 1780).
+
+Support for higher rates / 24-bit on the built-in Snapserver is planned once the required Snapcast support is available upstream.
 
 ### Player
 
@@ -64,5 +103,5 @@ In addition to the [Individual Player Settings](/settings/individual-player/), S
 - The Snapcast app for iOS is broken as it uses an old version of Snapclient. Using it brings problems with this provider
 - Ensure that the ports 1704 and 1705 on the Snapserver host are open. Also make sure that the ports between 4953 and 5153 inclusive are open
 - Try the default Snapcast settings and then make changes as necessary
-- Leaving the stream sample rate / bit depth at the defaults (48 kHz / 16-bit) is recommended unless you know your Snapserver and clients support the chosen format. Changing these settings requires a provider reload (and a Snapserver restart when using the built-in server)
+- Stream sample rate and bit depth settings are only available with an external Snapserver. The built-in Snapserver always uses 48 kHz / 16-bit for now. 24-bit additionally requires an external Snapserver built with packed 24-bit PCM support as described above. Changing these settings requires a provider reload.
 - The stream name must be `default`

--- a/src/content/docs/player-support/snapcast.md
+++ b/src/content/docs/player-support/snapcast.md
@@ -15,7 +15,7 @@ MA includes a built-in Snapserver although an external server can also be used. 
 ## Features
 
 - Synchronized playback across all Snapcast devices
-- Lossless audio quality. The default is 48 kHz / 16-bit. Higher sample rates and 24-bit are available only when Music Assistant is connected to a compatible external Snapserver (see Settings)
+- Lossless audio quality. The default is 48 kHz / 16-bit. Higher sample rates and 24-bit are available only when Music Assistant is connected to a [compatible external Snapserver](https://github.com/rwjack/snapcast/tree/feature/tcp-packed-s24le).
 
 ## Configuration
 

--- a/src/content/docs/player-support/snapcast.md
+++ b/src/content/docs/player-support/snapcast.md
@@ -14,7 +14,7 @@ MA includes a built-in Snapserver although an external server can also be used. 
 ## Features
 
 - Synchronized playback across all Snapcast devices
-- Lossless audio quality with options for 48kHz / 16bits PCM
+- Lossless audio quality; default is 48 kHz / 16-bit PCM, with optional higher sample rates and 24-bit (see Settings)
 
 ## Configuration
 
@@ -32,6 +32,8 @@ In the `Show Advanced Settings` toggle is enabled this will allow the use of an 
 - <b>Snapcast Server IP.</b> The IP address of the external Snapcast server (e.g. `192.168.1.200`)
 - <b>Snapcast Control Port.</b> The port the external Snapcast server can be reached on
 - <b>Idle threshold stream parameter.</b> (default 60000ms) The stream state will switch from playing to idle after receiving this many milliseconds of silence
+- <b>Snapcast stream sample rate.</b> (default 48000) Maximum PCM sample rate Music Assistant sends into the Snapcast TCP source. Options are `48000`, `96000`, and `192000`. Higher rates require Snapcast clients that support them
+- <b>Snapcast stream bit depth.</b> (default 16) Maximum PCM bit depth for those TCP sources. Options are `16` and `24`. 24-bit requires a Snapserver build with packed `s24le` TCP ingest support (see [snapcast/snapcast#1532](https://github.com/snapcast/snapcast/pull/1532))
 
 The `Built-in Snapserver Settings`are as follows:
 
@@ -62,4 +64,5 @@ In addition to the [Individual Player Settings](/settings/individual-player/), S
 - The Snapcast app for iOS is broken as it uses an old version of Snapclient. Using it brings problems with this provider
 - Ensure that the ports 1704 and 1705 on the Snapserver host are open. Also make sure that the ports between 4953 and 5153 inclusive are open
 - Try the default Snapcast settings and then make changes as necessary
+- Leaving the stream sample rate / bit depth at the defaults (48 kHz / 16-bit) is recommended unless you know your Snapserver and clients support the chosen format. Changing these settings requires a provider reload (and a Snapserver restart when using the built-in server)
 - The stream name must be `default`

--- a/src/content/docs/player-support/snapcast.md
+++ b/src/content/docs/player-support/snapcast.md
@@ -1,5 +1,5 @@
 ---
-title: Snapcast Player Provider
+title: "Snapcast"
 description: Details for the Snapcast Player Provider
 ---
 


### PR DESCRIPTION
## Summary
- Documents the new Snapcast advanced settings for stream sample rate and bit depth
- Companion docs for music-assistant/server#5140

## Notes
- Default remains 48 kHz / 16-bit
- 24-bit requires Snapserver packed s24le support (snapcast/snapcast#1532)
