### PR TITLE
Add the OpenAI Compatible plugin page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -225,6 +225,10 @@ export default defineConfig({
                   slug: "plugins/listenbrainz_scrobble",
                 },
                 { label: "Music Quiz", slug: "plugins/music-quiz" },
+                {
+                  label: "OpenAI Compatible",
+                  slug: "plugins/openai_compatible",
+                },
                 { label: "Party", slug: "plugins/party" },
                 { label: "Plex Connect", slug: "plugins/plex-connect" },
                 { label: "Smart Playlist", slug: "plugins/smart_playlist" },

--- a/src/content/docs/plugins/ai-radio.md
+++ b/src/content/docs/plugins/ai-radio.md
@@ -28,7 +28,7 @@ AI Radio is currently in beta. The show editor, prompt presets, generated output
 
 - The **AI Radio** plugin must be enabled in **Settings → Plugins → Add a Plugin**.
 - At least one playlist with playable tracks.
-- A configured provider that supports AI queries, such as the [Home Assistant plugin](/ha-plugin/) with LLM access.
+- A configured provider that supports AI queries, either the [OpenAI Compatible plugin](/plugins/openai_compatible/) or the [Home Assistant plugin](/ha-plugin/) with LLM access.
 - A configured provider that supports TTS, such as the [Home Assistant plugin](/ha-plugin/) with a working text-to-speech service.
 - For live playback, an enabled and available Music Assistant player.
 
@@ -40,7 +40,9 @@ AI Radio generates new speech each time a show is started. The exact wording can
 
 ### Setting up AI and TTS with Home Assistant
 
-AI Radio does not contain its own LLM or TTS engine. It asks Music Assistant for providers that expose AI-query and text-to-speech features. The most common setup is to use the [Home Assistant plugin](/ha-plugin/) as the bridge to Home Assistant's Assist/LLM and TTS services.
+AI Radio does not contain its own LLM or TTS engine. It asks Music Assistant for providers that expose AI-query and text-to-speech features. The [Home Assistant plugin](/ha-plugin/) can supply both, as the bridge to Home Assistant's Assist/LLM and TTS services, and the steps below cover that setup.
+
+If you would rather not go through Home Assistant for the AI half, the [OpenAI Compatible plugin](/plugins/openai_compatible/) provides the AI engine on its own, using OpenAI, Groq, OpenRouter, Together or a local server such as Ollama or LM Studio. You still need a text-to-speech provider for spoken shows.
 
 Before configuring AI Radio:
 

--- a/src/content/docs/plugins/music-quiz.md
+++ b/src/content/docs/plugins/music-quiz.md
@@ -34,7 +34,7 @@ Music Quiz is experimental. Its game types, settings, and behavior may change be
 - For **Venue mode**, an available, enabled Music Assistant player, stereo pair, or group
 - For **Remote mode**, the Sendspin provider must be available; each player also needs a device and browser that can play web audio
 - For **Music Timeline**, enough unique tracks with usable release years: one initial anchor plus one track per configured round
-- For **Music Trivia**, a configured plugin that supports AI queries, such as the Home Assistant plugin with LLM access, and enough selected tracks with usable metadata
+- For **Music Trivia**, a configured plugin that supports AI queries, either the [OpenAI Compatible plugin](/plugins/openai_compatible/) or the Home Assistant plugin with LLM access, and enough selected tracks with usable metadata
 
 :::note
 Music Trivia is only shown in the game picker when a compatible AI plugin is loaded. Guess the Song and Music Timeline do not require AI.

--- a/src/content/docs/plugins/openai_compatible.md
+++ b/src/content/docs/plugins/openai_compatible.md
@@ -1,0 +1,63 @@
+---
+title: OpenAI Compatible
+description: Use OpenAI, Groq, OpenRouter, Together or a local AI server such as Ollama or LM Studio for Music Assistant's AI features.
+---
+
+# OpenAI Compatible
+
+Some Music Assistant features are powered by an AI model: **AI Radio**, the **Trivia** quiz type, the AI answer suggestions in **Music Quiz**, and the AI-written descriptions for **Smart Playlists**.
+
+Until now those features needed Home Assistant, because its AI Task integration was the only thing that could answer them. This plugin lets Music Assistant talk to an AI service directly, so the features also work without Home Assistant.
+
+It works with any service that speaks the OpenAI API, which is nearly all of them:
+
+- Hosted services such as **OpenAI**, **Groq**, **OpenRouter** and **Together AI**
+- AI servers you run yourself, such as **Ollama**, **LM Studio**, **llama.cpp** and **vLLM**
+
+:::caution[Beta]
+This plugin is currently marked as **beta**. It works, but it has not been tested against every service yet.
+:::
+
+## Features
+
+- One plugin for every service that speaks the OpenAI API, hosted or self-hosted
+- Each model you select becomes a separate choice in the AI features, so a small, cheap model can handle simple jobs while a stronger one is used where it matters
+- Multiple instances, so a local server and a hosted service can be used side by side
+
+## Installation
+
+Add the plugin in **Settings → Providers → Add Provider → Plugins** and pick **OpenAI Compatible**.
+
+### Choose a service
+
+Pick your service from the list and its address is filled in for you. Choose **Something else** if your service is not listed.
+
+### Connection details
+
+- **API base URL** — the address of the service, including the version path, for example `https://api.openai.com/v1`. Change this if the service does not run where it normally would, for example when Ollama runs on a different machine than Music Assistant, or when Music Assistant runs in a container and cannot reach `localhost`.
+- **API key** — the key from your service. Leave it empty for a local server that does not ask for one.
+
+Music Assistant checks the address and key before finishing, so a typo is caught here rather than later.
+
+### Choose your models
+
+The plugin does not offer any models until you pick them. Open the plugin under **Settings → Providers**, and select the models you want under **Models**.
+
+The list is read from your service. If your service does not publish a list of its models, the field lets you type the model names yourself.
+
+Each model you select shows up as its own choice wherever an AI engine can be picked, listed as `OpenAI Compatible | <model>`.
+
+## Choosing a model
+
+The AI features ask for different things, so it pays to select more than one model:
+
+- **Trivia** and **AI answer suggestions** ask for a strict JSON answer. Use a capable model here — small local models often word their answer in a way Music Assistant cannot read, and the question or the suggestions are then dropped.
+- **AI Radio** writes spoken presenter text. Any model that writes well in your language works, and this is where a larger model is most noticeable.
+- **Smart Playlist descriptions** are one or two sentences. The cheapest, fastest model is fine.
+
+## Known Issues / Notes
+
+- **Costs.** Hosted services bill you per request. AI Radio in particular asks for text for every segment it announces, so keep an eye on your usage.
+- **Speed.** A local model running without a graphics card can take a long time to answer. Requests are given up on after two minutes.
+- **Reasoning models.** Models that think out loud before answering are supported, and the thinking is stripped from the answer. They are slower and, for the features that need strict JSON, not always more reliable.
+- **Which models are offered.** The list comes straight from your service and can be long, and it may include models that cannot answer a chat request at all, such as image or speech models. Select only the ones you intend to use.

--- a/src/content/docs/plugins/openai_compatible.md
+++ b/src/content/docs/plugins/openai_compatible.md
@@ -41,7 +41,7 @@ Music Assistant checks the address and key before finishing, so a typo is caught
 
 ### Choose your models
 
-The plugin does not offer any models until you pick them. Open the plugin under **Settings → Providers**, and select the models you want under **Models**.
+The plugin does not offer any models until you pick them. Open the plugin under **Settings → Plugins**, and select the models you want under **Models**.
 
 The list is read from your service. If your service does not publish a list of its models, the field lets you type the model names yourself.
 

--- a/src/content/docs/plugins/openai_compatible.md
+++ b/src/content/docs/plugins/openai_compatible.md
@@ -26,7 +26,7 @@ This plugin is currently marked as **beta**. It works, but it has not been teste
 
 ## Installation
 
-Add the plugin in **Settings → Providers → Add Provider → Plugins** and pick **OpenAI Compatible**.
+Add the plugin in **Settings → Plugins → Add a Plugin** and pick **OpenAI Compatible**.
 
 ### Choose a service
 


### PR DESCRIPTION
## What does this change?

Documents the new OpenAI Compatible plugin, which lets the AI features (AI Radio, Trivia, quiz answer suggestions, Smart Playlist descriptions) use OpenAI, Groq, OpenRouter, Together or a local server such as Ollama or LM Studio, so they no longer need Home Assistant.

Server pull request: music-assistant/server#5261 (merged)

Also updates the AI Radio and Music Quiz pages, which both named the Home Assistant plugin as the way to get an AI engine.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`

### Only if you are adding a music source or a player provider

- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories
- [ ] The page opens with a short description of the service, then what the Music Assistant source gets you

