### PR TITLE
Home page: rewritten copy, plus install buttons

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -303,6 +303,7 @@ export default defineConfig({
               label: "Plugins",
               collapsed: true,
               items: [
+                { label: "Overview", slug: "plugins" },
                 { label: 'AI Radio', slug: 'plugins/ai-radio' },
                 { label: "AirPlay Receiver", slug: "plugins/airplay-receiver" },
                 { label: "Ariacast Receiver", slug: "plugins/ariacast-receiver" },

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -15,17 +15,15 @@ It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a H
 
 ## Features
 
-- Supports multiple music sources through a provider implementation
-- Many popular streaming services are supported, as well as local files
-- Matches music in library from different sources (track linking)
-- Fetches metadata for extended artist information
-- Keeps track of the entire music library in a compact database
-- Gapless, crossfade and volume normalization support for all players
-- Playback synchronisation is possible for supported players
-- Announcements during playback is supported
-- Transfer of playback between players is supported
-- Truly hassle free streaming of your favourite music to players, no advanced knowledge required
-- Rich User interface (Progressive Web App)
+- **All your music in one library.** Streaming services, your own files, radio, podcasts and audiobooks, searched together in one place
+- **Plays on almost anything.** Sonos, Chromecast, AirPlay, Squeezelite, DLNA and many more, in sync across the players that support it
+- **One album, not four.** The same release from different sources is linked together, so your library stays clean
+- **Artwork, lyrics and artist information** are filled in for you
+- **Gapless playback, crossfade and volume levelling** on every player
+- **Announcements cut over the music**, then it picks up where it left off
+- **Move playback from room to room** without losing your place in the queue
+- **Runs in any browser** and installs to your phone like an app
+- **Free and open source**, and a project of the Open Home Foundation
 
 [![Music Assistant Add-on For Home Assistant](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
 

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -20,7 +20,7 @@ It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a H
 - **One album, not four.** The same release from different sources is linked together, so your library stays clean
 - **Artwork, lyrics and artist information** are filled in for you
 - **Gapless playback, smart crossfade and volume levelling** on every player
-- **Announcements interrupt the music**, pausing or ducking it depending on the player, then it picks up where it left off
+- **Announcements interrupt the music**, pausing or ducking it, then it picks up where it left off
 - **Move playback from room to room** without losing your place in the queue
 - **Runs in any browser** and installs to your phone like an app
 - **Free and open source**. A project of the Open Home Foundation

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -19,11 +19,11 @@ It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a H
 - **Plays on almost anything.** Sonos, Chromecast, AirPlay, Squeezelite, DLNA and many more, in sync across the players that support it
 - **One album, not four.** The same release from different sources is linked together, so your library stays clean
 - **Artwork, lyrics and artist information** are filled in for you
-- **Gapless playback, crossfade and volume levelling** on every player
-- **Announcements cut over the music**, then it picks up where it left off
+- **Gapless playback, smart crossfade and volume levelling** on every player
+- **Announcements interrupt the music**, pausing or ducking it depending on the player, then it picks up where it left off
 - **Move playback from room to room** without losing your place in the queue
 - **Runs in any browser** and installs to your phone like an app
-- **Free and open source**, and a project of the Open Home Foundation
+- **Free and open source**. A project of the Open Home Foundation
 
 [![Music Assistant Add-on For Home Assistant](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
 

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -7,7 +7,11 @@ description: Music Assistant is a music library manager for local and streaming 
 
 ![Music Assistant Add-on For Home Assistant](/assets/banner.png)
 
-Music Assistant is a music library manager for your offline and online music sources which can easily stream your favourite music to a wide range of supported players and be combined with the power of Home Assistant!
+Music Assistant is a free, open source music library manager. It brings your streaming services and your own files together into one library, and plays them on almost any speaker in the house.
+
+It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a Home Assistant add-on — and you control it from any browser, or from Home Assistant with automations and voice.
+
+![Music sources flowing into Music Assistant and out to a wide range of players](/assets/MA_banner.png)
 
 ## Features
 
@@ -25,26 +29,6 @@ Music Assistant is a music library manager for your offline and online music sou
 
 [![Music Assistant Add-on For Home Assistant](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
 
-## Architecture
-
-Music Assistant consists of multiple building blocks:
-
-- Music Assistant Server ([Installation Instructions](/installation/))
-- Home Assistant Integration ([Installation Instructions](/integration/installation/))
-- [Music Sources](/music-providers/): Import your music from various sources into Music Assistant.
-- [Player Providers](/player-support/): Play your music on a wide collection of player ecosystems.
-- Plugins: These extend the functionality of Music Assistant with extras such as a [party mode](/plugins/party/) your guests can queue tracks from, a [music quiz](/plugins/music-quiz/), or [AI Radio](/plugins/ai-radio/) with a generated presenter
-
-## Music Assistant Server
-
-The Music Assistant server is a free, opensource Media library manager that connects to your streaming services and a wide range of connected speakers. The server is the beating heart, the core of Music Assistant and it keeps track of your music sources. It must run on an always-on device like a Raspberry Pi, a NAS or an Intel NUC or alike. The server can access multiple music sources and stream to multiple player types.
-
-![MA Banner](/assets/MA_banner.png)
-
-## Home Assistant Integration
-
-Connects Home Assistant to your Music Assistant Server to allow control from your HA instance, allow you to automate your music and allows voice control! The Integration also allows the exposure of HA media players to MA furthering the options you have for playback.
-
 ## Preview
 
 <a href="assets/screenshots/screen2.png"><img src="/assets/screenshots/screen2.png" alt="Preview image" style="width: 800px;"  loading="lazy" /></a>
@@ -56,6 +40,15 @@ Connects Home Assistant to your Music Assistant Server to allow control from you
 <a href="assets/screenshots/screen1.png"><img src="/assets/screenshots/screen1.png" alt="Preview image" style="width: 800px;"  loading="lazy" /></a>
 </div>
 </details>
+
+## How Music Assistant fits together
+
+- **The server** is the core. It holds your library, talks to your music sources and streams to your players. It needs to run on an always-on machine — [install it here](/installation/)
+- **[Music sources](/music-providers/)** are where the music comes from: streaming services, your own files, radio, podcasts and audiobooks
+- **[Player providers](/player-support/)** are how it reaches your speakers, from Sonos and Chromecast to something you build yourself
+- **[Metadata providers](/metadata/)** fill in the artwork, biographies and lyrics, and audio analysis works out loudness and fades from the audio itself
+- **Plugins** add extras such as [party mode](/plugins/party/), a [music quiz](/plugins/music-quiz/) or [AI Radio](/plugins/ai-radio/)
+- **The [Home Assistant integration](/integration/)** puts your players in Home Assistant, for automations, announcements and voice
 
 ## The Core Team
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -51,7 +51,7 @@ It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a H
 - **[Music sources](/music-providers/)** are where the music comes from: streaming services, your own files, radio, podcasts and audiobooks
 - **[Player providers](/player-support/)** are how it reaches your speakers, from Sonos and Chromecast to something you build yourself
 - **[Metadata providers](/metadata/)** fill in the artwork, biographies and lyrics, and audio analysis works out loudness and fades from the audio itself
-- **Plugins** add extras such as [party mode](/plugins/party/), a [music quiz](/plugins/music-quiz/) or [AI Radio](/plugins/ai-radio/)
+- **[Plugins](/plugins/)** add extras such as [party mode](/plugins/party/), a [music quiz](/plugins/music-quiz/) or [AI Radio](/plugins/ai-radio/)
 - **The [Home Assistant integration](/integration/)** puts your players in Home Assistant, for automations, announcements and voice
 
 ## The Core Team

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -3,6 +3,8 @@ title: Music Assistant
 description: Music Assistant is a music library manager for local and streaming sources
 ---
 
+import { LinkButton } from '@astrojs/starlight/components';
+
 # Music Assistant
 
 ![Music Assistant Add-on For Home Assistant](/assets/banner.png)
@@ -12,6 +14,11 @@ Music Assistant is a free, open source music library manager. It brings your str
 It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a Home Assistant add-on — and you control it from any browser, or from Home Assistant with automations and voice.
 
 ![Music sources flowing into Music Assistant and out to a wide range of players](/assets/MA_banner.png)
+
+<div class="install-buttons">
+  <LinkButton href="https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon" icon="external">Add to Home Assistant</LinkButton>
+  <LinkButton href="/installation/#docker-image" variant="secondary" icon="seti:docker">Install with Docker</LinkButton>
+</div>
 
 ## Features
 
@@ -25,7 +32,6 @@ It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a H
 - **Runs in any browser** and installs to your phone like an app
 - **Free and open source**. A project of the Open Home Foundation
 
-[![Music Assistant Add-on For Home Assistant](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
 
 ## Preview
 
@@ -50,17 +56,21 @@ It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a H
 
 ## The Core Team
 
-<a href="https://github.com/marcelveldt" title="Marcel. Creator of Music Assistant" target="_blank" rel="noopener noreferrer"><img src="/assets/team/marcel.png" alt="Marcel" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/marvinschenkel" title="Marvin. Project Lead. Author of the YouTube and Apple Music sources" target="_blank" rel="noopener noreferrer"><img src="/assets/team/marvin.png" alt="Marvin" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/maximmaxim345" title="Maxim. DSP and Sendspin Guru and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/maxim.png" alt="maxim" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/stvncode" title="Steven. Frontend Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/steven.png" alt="steven" style="width: 100px; border-radius: 50%; border: 2px solid black;" loading="lazy" /></a>
-<a href="https://github.com/chrisuthe" title="Chris. Audio Analysis Guru and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/chris.png" alt="chris" style="width: 100px;" loading="lazy" /></a>
+<div class="team-row">
+  <a href="https://github.com/marcelveldt" title="Marcel. Creator of Music Assistant" target="_blank" rel="noopener noreferrer"><img src="/assets/team/marcel.png" alt="Marcel" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/marvinschenkel" title="Marvin. Project Lead. Author of the YouTube and Apple Music sources" target="_blank" rel="noopener noreferrer"><img src="/assets/team/marvin.png" alt="Marvin" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/maximmaxim345" title="Maxim. DSP and Sendspin Guru and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/maxim.png" alt="maxim" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/stvncode" title="Steven. Frontend Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/steven.png" alt="steven" style="width: 100px; border-radius: 50%; border: 2px solid black;" loading="lazy" /></a>
+  <a href="https://github.com/chrisuthe" title="Chris. Audio Analysis Guru and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/chris.png" alt="chris" style="width: 100px;" loading="lazy" /></a>
+</div>
 
-<a href="https://github.com/OzGav" title="Gavin. Community Support, Documentation and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/gavin.png" alt="Gavin" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/jozefKruszynski" title="Jozef. Author of the Tidal music source and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/jozef.png" alt="Jozef" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/fmunkes" title="Fabian. Author of the Audiobookshelf, iTunes Podcast Search and gPodder music sources and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/fabian.png" alt="fabian" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/khers" title="Eric. Author of the Subsonic source" target="_blank" rel="noopener noreferrer"><img src="/assets/team/khers.png" alt="khers" style="width: 100px;" loading="lazy" /></a>
-<a href="https://github.com/robsonke" title="Rob. Author of the iBroadcast music source and maintainer of Soundcloud" target="_blank" rel="noopener noreferrer"><img src="/assets/team/robsonke.png" alt="robsonke" style="width: 100px;" loading="lazy" /></a>
+<div class="team-row">
+  <a href="https://github.com/OzGav" title="Gavin. Community Support, Documentation and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/gavin.png" alt="Gavin" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/jozefKruszynski" title="Jozef. Author of the Tidal music source and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/jozef.png" alt="Jozef" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/fmunkes" title="Fabian. Author of the Audiobookshelf, iTunes Podcast Search and gPodder music sources and Core Developer" target="_blank" rel="noopener noreferrer"><img src="/assets/team/fabian.png" alt="fabian" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/khers" title="Eric. Author of the Subsonic source" target="_blank" rel="noopener noreferrer"><img src="/assets/team/khers.png" alt="khers" style="width: 100px;" loading="lazy" /></a>
+  <a href="https://github.com/robsonke" title="Rob. Author of the iBroadcast music source and maintainer of Soundcloud" target="_blank" rel="noopener noreferrer"><img src="/assets/team/robsonke.png" alt="robsonke" style="width: 100px;" loading="lazy" /></a>
+</div>
 
 We also give THANKS to all the other contributors to the <a href="https://github.com/music-assistant/server/graphs/contributors" target="_blank" rel="noopener noreferrer">Server</a>, <a href="https://github.com/music-assistant/frontend/graphs/contributors" target="_blank" rel="noopener noreferrer">Frontend</a>, <a href="https://github.com/music-assistant/voice-support/graphs/contributors" target="_blank" rel="noopener noreferrer">Voice Support</a> and all of the <a href="https://github.com/orgs/music-assistant/repositories?type=all" target="_blank" rel="noopener noreferrer">Repositories</a> that make up this project!
 

--- a/src/content/docs/plugins/index.md
+++ b/src/content/docs/plugins/index.md
@@ -1,0 +1,18 @@
+---
+title: Plugins
+description: What plugins are and what they add to Music Assistant
+---
+
+# Plugins
+
+Plugins add things that sit alongside playback rather than being part of it.
+
+A [music source](/music-providers/) brings music in. A [player provider](/player-support/) sends it out to a speaker. A plugin does something else entirely: it might host a party your guests queue tracks from, run a music quiz on the TV, let another app send audio *to* Music Assistant over AirPlay or DLNA, or report what you played to Last.fm.
+
+Plugins are optional. Music Assistant works perfectly well without any of them.
+
+## Adding a plugin
+
+Go to `SETTINGS >> PLUGINS >> ADD A PLUGIN` and pick one from the list. Every plugin has its own page in this section covering what it does and how to configure it.
+
+Some plugins depend on something else being set up first. The [Home Assistant](/ha-plugin/) plugin needs the Home Assistant integration, and [AI Radio](/plugins/ai-radio/) needs the Home Assistant plugin to reach an AI and text-to-speech service.

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -221,3 +221,26 @@ main > .content-panel:has(.overview-anchor) + .content-panel {
   flex-direction: row;
   gap: 0.5rem;
 }
+/* Install buttons under the home page artwork. */
+.install-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-block: 1.5rem;
+}
+
+/* Core team: five portraits per row. In MDX each link is its own top level
+   element rather than being wrapped in a paragraph, so the rows are laid out
+   explicitly instead of relying on inline flow. */
+.team-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+.team-row a {
+  display: inline-flex;
+}
+.team-row img {
+  margin: 0;
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -225,6 +225,7 @@ main > .content-panel:has(.overview-anchor) + .content-panel {
 .install-buttons {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.75rem;
   margin-block: 1.5rem;
 }


### PR DESCRIPTION
The text improvements from #860 without the landing page rewrite. #860 is parked, not abandoned — the splash template, clickable tiles and header menu all still live on that branch.

**Kept from #860**

- The plain English description of Music Assistant now opens the page instead of sitting two thirds down under `## Music Assistant Server`, and the sources-in players-out artwork moved up to illustrate it.
- Feature list rewritten around what the reader gets rather than how it is built. `Supports multiple music sources through a provider implementation` and `Keeps track of the entire music library in a compact database` are gone.
- `## Architecture` is now `## How Music Assistant fits together`, each block says what it is *for*, and metadata and audio analysis were added — both were missing despite being sidebar groups.
- Dropped the `## Music Assistant Server` and `## Home Assistant Integration` sections, which repeated two entries from that block.

**New here**

Two install buttons directly under the opening artwork, replacing the lone Home Assistant badge that was stranded below the feature list: **Add to Home Assistant** and **Install with Docker**.

That means the page becomes `.mdx` to use Starlight's `LinkButton`. MDX renders each core team portrait as its own block rather than wrapping them in a paragraph, so the team is laid out in explicit rows of five.

**Not here:** the splash template, so the home page keeps its sidebar and stays a normal doc page.

Build green, all links verified against the built output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7LDapeMvP1N6kD7KYTnTW