### PR TITLE
Redirect the old URLs of the renamed pages

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,11 @@
+# Old URLs kept alive after page renames, so links from older Music Assistant
+# server builds (the documentation icon in settings) keep working.
+# Netlify ignores trailing slashes when matching these paths.
+
+/music-providers/filesystem   /music-providers/local-files          301
+/music-providers/radiothek    /music-providers/orf-radiothek        301
+/player-support/ha            /player-support/home-assistant        301
+/player-support/mpd           /player-support/music-player-daemon   301
+
+# The MPD provider has always pointed at a music-providers path that never existed.
+/music-providers/mpd          /player-support/music-player-daemon   301


### PR DESCRIPTION
Four pages were renamed on `beta`, but the provider manifests in the server repo hard-code the old docs URLs, so the documentation icon in beta server builds now 404s. This keeps the old paths working until the server PR ships.

Confirmed live on beta before this change: `/music-providers/filesystem/`, `/player-support/ha/` and `/player-support/mpd/` all return 404.

Netlify serves the site (`public/_headers` is already honoured), so `public/_redirects` gives real 301s:

| Old | New |
| --- | --- |
| `/music-providers/filesystem` | `/music-providers/local-files` |
| `/music-providers/radiothek` | `/music-providers/orf-radiothek` |
| `/player-support/ha` | `/player-support/home-assistant` |
| `/player-support/mpd` | `/player-support/music-player-daemon` |
| `/music-providers/mpd` | `/player-support/music-player-daemon` |

The last row fixes a long-standing break rather than a new one: the MPD manifest has always pointed at a `music-providers` path that never existed.

Targeting `beta` on purpose. On `main` the old paths still resolve to real pages, and these rules would send them to pages `main` does not have yet. The file carries over correctly when beta merges to main, and the redirects stay useful afterwards for bookmarks and for server builds that never get updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USrDwNNbiGceK9cjXJCLc2