### PR TITLE
Show what a badly named file does to the menu

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,10 +155,6 @@ Both generated menus sort by **filename**, while the label a reader sees comes f
 it and they drift apart: `ha.md` sorted before `heos.md` while showing as Home Assistant, which
 belongs after HEOS.
 
-`sidebar.order` does not rescue a page that has landed in the wrong place. A page carrying `order`
-sorts ahead of **every** page without one, so it leaps to the top of the group rather than down a
-slot. Ordering one page means ordering all of them. The filename is the only local fix.
-
 ## Adding a plugin, metadata provider or audio analysis provider
 
 These do not follow a fixed structure, so there is no template to match and nothing to register

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,10 @@ Four things, and the build will tell you if you miss the last one.
    There is no sidebar entry to add. The `Music Sources` menu is generated from this folder, so
    the file lands in the menu on its own. Two things follow from that: **name the file after the
    source**, because the menu is sorted by filename, and **set `title` to the name people know it
-   by**, because that is the label they will see. If the page needs a different title from its
-   menu label, add `sidebar: { label: ... }` to the frontmatter. See
-   [Naming the file](#naming-the-file) for why the two have to agree.
+   by**, because that is the label they will see. Abbreviate the filename and the two drift apart:
+   `ha.md` sorted before `heos.md` while showing as Home Assistant, which belongs after HEOS. If
+   the page needs a different title from its menu label, add `sidebar: { label: ... }` to the
+   frontmatter.
 2. **The icon**, in `public/assets/icons/`. See [Icons](#icons).
 3. **The tile entry**, in `src/data/music-sources.ts`, alphabetical by `name`:
 
@@ -147,13 +148,6 @@ there are `commercial` for devices sold ready to use, and `diy` for software you
 There is no sidebar entry to add here either. The `Player Providers` menu is generated from that
 folder, so the same two rules apply: name the file after the provider, because the menu is sorted
 by filename, and set `title` to the name people know it by, because that is the label.
-
-## Naming the file
-
-Both generated menus sort by **filename**, while the label a reader sees comes from the page
-**title**. Name the file after the thing it documents and the two agree on their own. Abbreviate
-it and they drift apart: `ha.md` sorted before `heos.md` while showing as Home Assistant, which
-belongs after HEOS.
 
 ## Adding a plugin, metadata provider or audio analysis provider
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,8 @@ Four things, and the build will tell you if you miss the last one.
    the file lands in the menu on its own. Two things follow from that: **name the file after the
    source**, because the menu is sorted by filename, and **set `title` to the name people know it
    by**, because that is the label they will see. If the page needs a different title from its
-   menu label, add `sidebar: { label: ... }` to the frontmatter.
+   menu label, add `sidebar: { label: ... }` to the frontmatter. See
+   [Naming and renaming pages](#naming-and-renaming-pages) for why the two have to agree.
 2. **The icon**, in `public/assets/icons/`. See [Icons](#icons).
 3. **The tile entry**, in `src/data/music-sources.ts`, alphabetical by `name`:
 
@@ -146,6 +147,25 @@ there are `commercial` for devices sold ready to use, and `diy` for software you
 There is no sidebar entry to add here either. The `Player Providers` menu is generated from that
 folder, so the same two rules apply: name the file after the provider, because the menu is sorted
 by filename, and set `title` to the name people know it by, because that is the label.
+
+## Naming and renaming pages
+
+Both generated menus sort by **filename**, while the label a reader sees comes from the page
+**title**. Name the file after the thing it documents and the two agree on their own. Abbreviate
+it and they drift apart: `ha.md` sorted before `heos.md` while showing as Home Assistant, which
+belongs after HEOS, and `mpd.md` sorted before `msx-bridge.md` while showing as Music Player
+Daemon. Both were renamed, to `home-assistant.md` and `music-player-daemon.md`.
+
+`sidebar.order` does not rescue a single entry that has landed in the wrong place. A page carrying
+`order` sorts ahead of **every** page without one, so it leaps to the top of the group rather than
+down a slot. Ordering one page means ordering all of them. Renaming the file is the fix.
+
+**Renaming an existing page changes its URL, and that is not free.** Every provider in the server
+repo carries a `documentation` URL in its `manifest.json`, and that URL is what the documentation
+icon in the Music Assistant settings opens. Nothing here warns you when a rename breaks one. So if
+you rename a page under `music-providers/` or `player-support/`, add a 301 to `public/_redirects`
+so the old URL keeps working, and say so on the pull request — the server side needs a matching
+change, and it ships on its own schedule.
 
 ## Adding a plugin, metadata provider or audio analysis provider
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,8 +153,7 @@ by filename, and set `title` to the name people know it by, because that is the 
 Both generated menus sort by **filename**, while the label a reader sees comes from the page
 **title**. Name the file after the thing it documents and the two agree on their own. Abbreviate
 it and they drift apart: `ha.md` sorted before `heos.md` while showing as Home Assistant, which
-belongs after HEOS, and `mpd.md` sorted before `msx-bridge.md` while showing as Music Player
-Daemon. Both are now named in full.
+belongs after HEOS.
 
 `sidebar.order` does not rescue a page that has landed in the wrong place. A page carrying `order`
 sorts ahead of **every** page without one, so it leaps to the top of the group rather than down a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ Four things, and the build will tell you if you miss the last one.
    source**, because the menu is sorted by filename, and **set `title` to the name people know it
    by**, because that is the label they will see. If the page needs a different title from its
    menu label, add `sidebar: { label: ... }` to the frontmatter. See
-   [Naming and renaming pages](#naming-and-renaming-pages) for why the two have to agree.
+   [Naming the file](#naming-the-file) for why the two have to agree.
 2. **The icon**, in `public/assets/icons/`. See [Icons](#icons).
 3. **The tile entry**, in `src/data/music-sources.ts`, alphabetical by `name`:
 
@@ -148,24 +148,17 @@ There is no sidebar entry to add here either. The `Player Providers` menu is gen
 folder, so the same two rules apply: name the file after the provider, because the menu is sorted
 by filename, and set `title` to the name people know it by, because that is the label.
 
-## Naming and renaming pages
+## Naming the file
 
 Both generated menus sort by **filename**, while the label a reader sees comes from the page
 **title**. Name the file after the thing it documents and the two agree on their own. Abbreviate
 it and they drift apart: `ha.md` sorted before `heos.md` while showing as Home Assistant, which
 belongs after HEOS, and `mpd.md` sorted before `msx-bridge.md` while showing as Music Player
-Daemon. Both were renamed, to `home-assistant.md` and `music-player-daemon.md`.
+Daemon. Both are now named in full.
 
-`sidebar.order` does not rescue a single entry that has landed in the wrong place. A page carrying
-`order` sorts ahead of **every** page without one, so it leaps to the top of the group rather than
-down a slot. Ordering one page means ordering all of them. Renaming the file is the fix.
-
-**Renaming an existing page changes its URL, and that is not free.** Every provider in the server
-repo carries a `documentation` URL in its `manifest.json`, and that URL is what the documentation
-icon in the Music Assistant settings opens. Nothing here warns you when a rename breaks one. So if
-you rename a page under `music-providers/` or `player-support/`, add a 301 to `public/_redirects`
-so the old URL keeps working, and say so on the pull request — the server side needs a matching
-change, and it ships on its own schedule.
+`sidebar.order` does not rescue a page that has landed in the wrong place. A page carrying `order`
+sorts ahead of **every** page without one, so it leaps to the top of the group rather than down a
+slot. Ordering one page means ordering all of them. The filename is the only local fix.
 
 ## Adding a plugin, metadata provider or audio analysis provider
 


### PR DESCRIPTION
CONTRIBUTING already tells you to name the file after the source, because the menu is sorted by filename. It does not show what goes wrong when you do not, and the failure is not one you would guess: the file sorts by its own name while the menu shows the page title, so an abbreviated filename puts the entry somewhere the label does not belong.

Adds one sentence to the music source steps, with `ha.md` sorting before `heos.md` as the example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USrDwNNbiGceK9cjXJCLc2