### PR TITLE
Plainer wording in the MDX note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,7 +210,7 @@ Keep PNGs small. They are served as they are, with no resizing, and they are dis
 ## Editing an `.mdx` page
 
 Most pages are `.md`. A few are `.mdx` because they use components. MDX is stricter than
-markdown and two things bite:
+markdown, and two things catch people out:
 
 - `<` starts a tag, so a bare `<100` breaks the build. Write `&lt;100`.
 - Every tag must be closed, so `<br>` must be `<br />`.


### PR DESCRIPTION
"Two things bite" is a shade too colloquial for a page a first-time contributor reads. "Two things catch people out" says the same thing plainly.

One line, no change in meaning. Follows #872, which was merged before this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USrDwNNbiGceK9cjXJCLc2