### PR TITLE
Say in House style that pages are written for the user

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,9 @@ there to search.
   **one on what the Music Assistant source gets you**. Keep both to a few sentences.
 - Do not restate the Features table in prose. The table already says what is supported.
 - Plain English. Write as you would explain it to someone in person.
+- **Write for the person using Music Assistant, not the person building it.** Keep the page to
+  what a reader needs to know or can act on. How it works inside — the API calls it makes, how it
+  caches, what the sync does behind the scenes — belongs in the code, not on the page.
 - On a music source or player provider page, keep every standard `Features` table row even
   where the answer is `No`, so the pages line up with each other.
 - Use `## Configuration`, `## Known Issues / Notes` and the other standard headings at the same


### PR DESCRIPTION
House style told you to use plain English, but never said who the page is for. Pages have picked up passages describing what a provider does internally — API calls, caching, what the sync does — which a reader can neither use nor act on.

Adds one bullet:

> **Write for the person using Music Assistant, not the person building it.** Keep the page to what a reader needs to know or can act on. How it works inside — the API calls it makes, how it caches, what the sync does behind the scenes — belongs in the code, not on the page.

The same bullet is on #874 so the copy landing on `main` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USrDwNNbiGceK9cjXJCLc2