### PR TITLE
Update Voice Control for built-in Home Assistant support

### DIFF
--- a/src/content/docs/integration/voice.md
+++ b/src/content/docs/integration/voice.md
@@ -4,19 +4,42 @@ title: "Voice Control"
 
 # Voice Control <img src="/assets/icons/voice-icon.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-Home Assistant has very limited (intent) support for music/media control and there is no support for initiating playback of music by voice. While this is on the horizon to be added, there is still a lot to investigate about how to create a universal way to provide that support natively which works with all media player integrations. 
+Voice control means asking Home Assistant Assist to play something, out loud, instead of picking it in the Music Assistant app. You say "play Rumours in the kitchen", Assist works out what you meant, and the music starts on a Music Assistant player.
 
-Currently, there is no built-in support in Home Assistant or the Music Assistant integration for initiating music playback by voice. But don't give up hope because in the interim a (community driven) repository has been created with all of the building blocks needed to add that support. The repository can be found at https://github.com/music-assistant/voice-support
+Starting playback by voice is now built into Home Assistant. It arrived in HA 2025.6 as the Search and Play intent, which was created with Music Assistant in mind, and it needs no blueprints, no custom sentences and no LLM. Music Assistant players work with it out of the box.
+
+The community blueprints described further down are still worth having, but they are no longer the starting point. Reach for them when you want something the built-in sentences cannot express.
 
 > [!NOTE]
 > Queue behaviour when adding items by Assist will follow the settings in MA SETTINGS>> SYSTEM>> PLAYER QUEUES.
 
-## Play Media Action
+## What you need
 
-The Music Assistant Integration allows the use of custom intents for initiating playback that are kept completely local. Blueprints have been developed to make it easy to get going. If new to Blueprints then review the HA documentation <a href="https://www.home-assistant.io/docs/automation/using_blueprints/" target="_blank" rel="noopener noreferrer">Using Automation Blueprints</a> 
+- **Home Assistant 2025.6 or later.** Later versions understand more sentences.
+- **The Music Assistant integration**, which is part of Home Assistant. See the [integration page](/integration/).
+- **Your Music Assistant players exposed to Assist**, in HA SETTINGS >> VOICE ASSISTANTS >> EXPOSE. Assist only targets entities you have exposed to it, so a player that is not exposed cannot be asked to play anything.
 
-Instructions are in the <a href="https://github.com/music-assistant/voice-support" target="_blank" rel="noopener noreferrer">MA Voice Support Repository</a>. There are options for completely local or LLM based request recognition.
+## Starting playback by voice
 
-## Other Media Player Actions
+Say something like "play Rumours", or name where you want it — "play Rumours in the kitchen", "play Rumours on the kitchen speaker". You can narrow the search by naming the type of item, as in "play the album Rumours", which is worth doing because it stops a track winning when you wanted the album.
 
-The core HA voice intents support NEXT TRACK, PREVIOUS TRACK, PAUSE, UNPAUSE and VOLUME to a specific player or to an area. HA does not intend to add any more media player actions at this time so you will need to use custom sentences to cover any other of your requirements. See this <a href="https://github.com/orgs/music-assistant/discussions/2176" target="_blank" rel="noopener noreferrer">discussion for how</a>.
+If you do not name a player or an area, Home Assistant plays on a player in the area of the device you spoke to. So a voice satellite in the kitchen plays in the kitchen without being told.
+
+Two things are specific to Music Assistant here. The search covers your Music Assistant library **and** every streaming provider you have connected, so you are not limited to what you have already added. And playback starts on the first result: Assist does not read out a list and ask which one you meant, it commits to its best match, so a more specific request gets you a better match.
+
+Home Assistant handles the rest of the playback controls too — next and previous track, pause and resume, volume, and mute. For the current list of what Assist understands, and the exact phrasings in your language, see the Home Assistant documentation on <a href="https://www.home-assistant.io/voice_control/builtin_sentences/" target="_blank" rel="noopener noreferrer">what can Assist do</a>. That list is the authoritative one and it grows with each release, so we do not repeat it here.
+
+## Going further with blueprints
+
+The built-in sentences cover the common request well, but they are deliberately simple. They cannot express "play the album Rumours **by Fleetwood Mac**", they have no way to turn shuffle on as part of the request, and they have no radio mode.
+
+For those, the community maintains a set of blueprints in the <a href="https://github.com/music-assistant/voice-support" target="_blank" rel="noopener noreferrer">MA Voice Support repository</a>. They build on the `music_assistant.play_media` action and give you a good deal more control over the request. There are three options: a fully local one using custom sentences, one that adds an LLM to interpret looser phrasing, and one that exposes playback as a tool your LLM conversation agent can call. The repository has the setup steps, the sentences each option accepts, and translations for several languages.
+
+If you are new to blueprints, read the Home Assistant documentation on <a href="https://www.home-assistant.io/docs/automation/using_blueprints/" target="_blank" rel="noopener noreferrer">Using Automation Blueprints</a> first.
+
+> [!NOTE]
+> The repository's own README still describes Home Assistant as having no way to start playback by voice. That was written before HA 2025.6 and is now out of date. The blueprints themselves work as documented.
+
+## Custom sentences
+
+Home Assistant does not intend to add further media player actions beyond the ones above, so anything else — shuffle, repeat, clearing the queue, stopping a player, grouping players — needs a sentence you write yourself, wired to a Music Assistant action. See this <a href="https://github.com/orgs/music-assistant/discussions/2176" target="_blank" rel="noopener noreferrer">discussion for how</a>.


### PR DESCRIPTION
Home Assistant has been able to start music playback by voice since 2025.6, when the Search and Play intent landed. The page still said no such support existed and pointed at the community blueprints as the only route.

Music Assistant players work with the intent as they are: the handler requires SEARCH_MEDIA and PLAY_MEDIA, and the integration declares both.

Say what the built-in support does and what it needs, keep the blueprints as the step up for requests it cannot express, and link to Home Assistant for the list of sentences rather than repeating it here, since that list grows every release.