### PR TITLE
Add the pull request template to main, with the sidebar checklist corrected

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!--
+Thanks for contributing. The checklist below is short but the build enforces most
+of it, so ticking it off saves a round trip.
+
+Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
+-->
+
+## What does this change?
+
+<!-- A sentence or two. Link the server pull request if there is one. -->
+
+## Checklist
+
+- [ ] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
+- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers
+
+### Only if you are adding a music source or a player provider
+
+<!-- Plugins, metadata providers and audio analysis providers do not need these. -->
+
+- [ ] File named after the source or provider, since the menu is sorted by filename
+- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
+- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories
+
+---
+
+Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
+click the link to see your change on the site. If it is red, click `Details`, read the error at
+the bottom of the log and push a fix to the same branch. There is no need to open a new pull
+request.


### PR DESCRIPTION
The template only lived on `beta`. GitHub serves the pull request template from the default branch, which is `main`, so contributors opening a pull request were not being shown it.

This adds the `beta` copy to `main`, with three corrections.

**The sidebar checkbox was wrong for the most common contribution.** It asked for a sidebar entry in `astro.config.mjs` for any new page, but the Music Sources and Player Providers menus have been autogenerated from their folders for a while now. Contributors kept following it, and the entry then conflicted on merge — that is what put #799, #824 and #848 into a conflicting state, all three fixed the same way.

**A filename checkbox replaces it for those two menus**, since an autogenerated menu is sorted by filename. This is the thing that actually bites: abbreviate the filename and the sort order drifts from the label.

**The checkbox asking contributors to confirm their page opens with a description of the service is gone.** The template promises that "the build enforces most of it", which was never true of that one — it is a prose judgement a contributor cannot self-certify. The guidance itself stays in `CONTRIBUTING.md`, which is already correct on all of this.

### Note on merging into `beta`

`beta` already has its own copy of this file with no shared history for it, so merging `main` into `beta` will report an add/add conflict on `.github/pull_request_template.md`. Take `main`'s version. After that the two branches share the file and it will merge cleanly from then on.