### PR TITLE
Drop the crosses from the player table and enlarge the type

### DIFF
--- a/src/components/PlayerCapabilities.astro
+++ b/src/components/PlayerCapabilities.astro
@@ -239,17 +239,7 @@ const rateLines = (rate: string | string[]) =>
                       </svg>
                     </span>
                   ) : (
-                    <span class="caps__no" role="img" aria-label="No">
-                      <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-                        <path
-                          d="M4 4 12 12 M12 4 4 12"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2.5"
-                          stroke-linecap="round"
-                        />
-                      </svg>
-                    </span>
+                    <span class="caps__sronly">No</span>
                   )}
                   {(capabilities.notes?.[column.id] ?? []).map((note) => (
                     <sup class="caps__ref">
@@ -327,14 +317,20 @@ const rateLines = (rate: string | string[]) =>
   /* The type here is smaller than the rest of the page on purpose. Eleven
      columns only clear the content column — 690px once the page shows its table
      of contents — if the headings are small enough not to set the width
-     themselves. Enlarging any of this brings back the sideways scroll. */
+     themselves.
+
+     The headings are what to leave alone. They set the width of the nine tick
+     columns, so a quarter of a rem on them costs more than the same on the body
+     text, which sits in columns already sized by something else. At the sizes
+     below the table needs 660px and has 30px in hand; taking the headings to
+     0.75rem spends all of it. */
   .caps table {
     width: 100%;
     /* Separate rather than collapse: collapsed borders are painted by the cell
        that scrolls under the sticky first column, and disappear beneath it. */
     border-collapse: separate;
     border-spacing: 0;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     line-height: 1.3;
   }
 
@@ -391,13 +387,15 @@ const rateLines = (rate: string | string[]) =>
     position: sticky;
     left: 0;
     z-index: 1;
-    /* The longest name, "Music Player Daemon (MPD)", needs 122px to fall on two
-       lines rather than three, which makes its row half again as tall as the
-       others. 8.5rem keeps room on top of that for the platforms whose system
-       font renders wider than the one this was measured in, and is also what
-       lets "Bose SoundTouch" and "Home Assistant" sit on one line. */
-    width: 8.5rem;
-    min-width: 8.5rem;
+    /* The longest name, "Music Player Daemon (MPD)", needs 141px at this size to
+       fall on two lines rather than three, which would make its row half again
+       as tall as the others. 9.5rem is 152px, so it has 11px in hand for the
+       platforms whose system font renders wider than the one this was measured
+       in, and it is also the width at which "Bose SoundTouch" and "Home
+       Assistant" sit on one line. The table needs 669px at this width and the
+       content column is 690px, so there is no more to give. */
+    width: 9.5rem;
+    min-width: 9.5rem;
     text-align: left;
     box-shadow: 1px 0 0 var(--sl-color-gray-5);
   }
@@ -437,7 +435,7 @@ const rateLines = (rate: string | string[]) =>
   }
 
   .caps tbody .caps__rate {
-    font-size: 0.7rem;
+    font-size: 0.8rem;
   }
 
   /* Left to size themselves, these columns come out anywhere between 32px and
@@ -453,27 +451,30 @@ const rateLines = (rate: string | string[]) =>
     display: block;
   }
 
-  .caps__yes,
-  .caps__no {
+  .caps__yes {
     display: inline-block;
     vertical-align: middle;
+    color: var(--sl-color-green);
   }
 
-  .caps__yes svg,
-  .caps__no svg {
+  .caps__yes svg {
     display: block;
     width: 0.95rem;
     height: 0.95rem;
   }
 
-  /* A tick and a cross, not two colours of the same mark: the shape has to
-     carry the meaning on its own. */
-  .caps__yes {
-    color: var(--sl-color-green);
-  }
-
-  .caps__no {
-    color: var(--sl-color-red);
+  /* Read out but never shown: the "No" in an empty cell. A cross in every one
+     of these cells is noise across nine columns and twenty rows, and the tick
+     is what anyone is scanning for, but an empty cell tells a screen reader
+     nothing at all, so the word stays in the markup. */
+  .caps__sronly {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
   }
 
   .caps__ref {

--- a/src/components/PlayerCapabilities.astro
+++ b/src/components/PlayerCapabilities.astro
@@ -314,16 +314,10 @@ const rateLines = (rate: string | string[]) =>
     outline-offset: 2px;
   }
 
-  /* The type here is smaller than the rest of the page on purpose. Eleven
-     columns only clear the content column — 690px once the page shows its table
-     of contents — if the headings are small enough not to set the width
-     themselves.
-
-     The headings are what to leave alone. They set the width of the nine tick
-     columns, so a quarter of a rem on them costs more than the same on the body
-     text, which sits in columns already sized by something else. At the sizes
-     below the table needs 660px and has 30px in hand; taking the headings to
-     0.75rem spends all of it. */
+  /* Smaller than the rest of the page on purpose: eleven columns only clear the
+     690px content column if the headings stay small, since it is the headings
+     that size the nine tick columns. Body text costs far less. As set here the
+     table needs 669px. */
   .caps table {
     width: 100%;
     /* Separate rather than collapse: collapsed borders are painted by the cell
@@ -387,13 +381,9 @@ const rateLines = (rate: string | string[]) =>
     position: sticky;
     left: 0;
     z-index: 1;
-    /* The longest name, "Music Player Daemon (MPD)", needs 141px at this size to
-       fall on two lines rather than three, which would make its row half again
-       as tall as the others. 9.5rem is 152px, so it has 11px in hand for the
-       platforms whose system font renders wider than the one this was measured
-       in, and it is also the width at which "Bose SoundTouch" and "Home
-       Assistant" sit on one line. The table needs 669px at this width and the
-       content column is 690px, so there is no more to give. */
+    /* "Music Player Daemon (MPD)" needs 141px here to wrap onto two lines
+       rather than three. 9.5rem is 152px, leaving room for wider system fonts,
+       and is also where "Bose SoundTouch" fits on one line. */
     width: 9.5rem;
     min-width: 9.5rem;
     text-align: left;
@@ -463,10 +453,9 @@ const rateLines = (rate: string | string[]) =>
     height: 0.95rem;
   }
 
-  /* Read out but never shown: the "No" in an empty cell. A cross in every one
-     of these cells is noise across nine columns and twenty rows, and the tick
-     is what anyone is scanning for, but an empty cell tells a screen reader
-     nothing at all, so the word stays in the markup. */
+  /* The "No" in an empty cell: read out, never shown. A cross in every empty
+     cell is noise across nine columns, but a blank tells a screen reader
+     nothing. */
   .caps__sronly {
     position: absolute;
     width: 1px;

--- a/src/content/docs/faq/stream-to.mdx
+++ b/src/content/docs/faq/stream-to.mdx
@@ -17,9 +17,10 @@ drives it.
 
 ## Comparing players side by side
 
-The table below summarises what every player provider can do. Note that DLNA and Home Assistant
-players can suffer from poor implementation of the required standards. If one of those does not
-work well and your device supports another protocol, use the other protocol.
+The table below summarises what every player provider can do. Green ticks mark a supported
+capability. Note that DLNA and Home Assistant players can suffer from poor implementation of the
+required standards. If one of those does not work well and your device supports another protocol,
+use the other protocol.
 
 <PlayerCapabilities />
 


### PR DESCRIPTION
The crosses were the one thing left where this table and the music source one disagreed, and the feedback on the music table was that a cross in every empty cell is noise. Nine columns and twenty rows makes for a lot of it, and the tick is what anyone is scanning for. The word "No" stays in the markup for screen readers, since an empty cell tells them nothing.

The body type goes from 12px to 14px and the sample rates from 11px to 13px. The headings stay at 11px on purpose: they set the width of the nine tick columns, so a quarter of a rem there costs several times what the same costs on text sitting in a column sized by something else. The table needs 669px of the 690px it has.

The provider column widens to 9.5rem so that "Music Player Daemon (MPD)" still falls on two lines rather than three at the larger size, with 11px to spare for platforms whose system font renders wider. That also keeps "Bose SoundTouch" on one line.

The page now says green ticks mark a supported capability, which the Listen To page already said, and which matters more now that the alternative to a tick is a blank.


Claude-Session: https://claude.ai/code/session_01TKp83w5RPqccAyLTpviQLC

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [ ] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
