### PR TITLE
Plain English pass over Sendspin, Alexa and the Yandex-family pages

### DIFF
--- a/src/content/docs/music-providers/audiobookshelf.md
+++ b/src/content/docs/music-providers/audiobookshelf.md
@@ -77,13 +77,10 @@ This source points Music Assistant at that server so the same collection is avai
 
 - The Audiobook search function supports searching for Authors and Narrators
 - Progress is synced both ways and obtained just ahead of playing
-- Event driven updates of podcast/ audiobook metadata in **known** libraries:
-    - A change is immediately reflected to the MA database if MA is running
-    - Newly added and just deleted items are immediately reflected as well
-    - BUT: if MA was down while changes in the ABS database occured, those will only be synced if a normal provider sync is triggered
+- Changes you make in Audiobookshelf show up in Music Assistant straight away, including anything you add or delete. If Music Assistant was switched off at the time, run a sync to pick those changes up
 - Single and multi-file audiobooks are supported
 - Supports recommendations on the [Discover view](/ui/#view---discover)
-- Playlist creation and editing are supported only when Audiobookshelf contains a single audiobook library and a single podcast library. This limitation exists because Music Assistant uses a single-library model, whereas Audiobookshelf supports multiple libraries, making library mapping ambiguous
+- Playlists can only be created and edited if Audiobookshelf has just one audiobook library and one podcast library. With more than one, Music Assistant has no way of knowing which library a new playlist belongs in
 
 ## Configuration
 
@@ -97,12 +94,12 @@ The following is needed to setup this provider:
 > [!NOTE]
 > The user must be of type user, admin or root. Guest users are neither tested nor supported
 
-- If <a href="https://www.audiobookshelf.org/guides/oidc_authentication/" target="_blank" rel="noopener noreferrer">OIDC</a> is configured:
-    - Pre version 2.26, <b>Token instead of user/password.</b> Add the token in the specified field. This token can be obtained by an admin user for any user within the ABS settings -> users
-    - From version 2.26 audiobookshelf uses the JWT token system internally. It is possible to create permanent API keys for an external application. Please follow the audiobookshelf docs at https://www.audiobookshelf.org/guides/api-keys/ to create such an API key
+- If <a href="https://www.audiobookshelf.org/guides/oidc_authentication/" target="_blank" rel="noopener noreferrer">OIDC</a> is configured, use a token instead of a username and password:
+    - On Audiobookshelf 2.26 or newer, create an API key by following the <a href="https://www.audiobookshelf.org/guides/api-keys/" target="_blank" rel="noopener noreferrer">Audiobookshelf guide</a>, and put that in the token field
+    - On older versions, an admin can get a token for any user from the Audiobookshelf settings under Users
 
 > [!NOTE]
-> Should you insert an old legacy token, your provider will not work anymore once these are removed from ABS.
+> Do not use one of the older tokens if you are on 2.26 or newer. They still work for now, but Audiobookshelf will drop them eventually and this source will stop working when it does.
 
 ### Multi-user environment
 
@@ -117,11 +114,11 @@ user please refer to [user management](/settings/user-management/#filter-progres
 
 ## Known Issues / Notes
 
-- Multi-file Audiobooks: The UI will show PCM as the source file format (as that is what is used internally) instead of the actual file format of the audiobook
+- For audiobooks made up of several files, Music Assistant shows the format as PCM rather than the format the files are actually in. The audio itself is unaffected
 - Tested currently against ABS >= 2.19.0
 - In the first instance of any problems ensure the server is running the <a href="https://github.com/advplyr/audiobookshelf/releases" target="_blank" rel="noopener noreferrer">latest version of the audiobookshelf software</a>
 
 ## Not Yet Supported
 
-- Edit provider feature is only supported for playlists, and only with the above restrictions.
-- Creation/deletion of a new library (i.e. not media items in a known library) is not reflected in an event driven way. Instead, use a normal sync
+- Editing from within Music Assistant works for playlists only, and only under the restriction described above
+- Adding or removing a whole library in Audiobookshelf does not show up on its own. Run a sync afterwards and it will appear. Changes to the contents of a library you already have are picked up straight away

--- a/src/content/docs/music-providers/kion-music.md
+++ b/src/content/docs/music-providers/kion-music.md
@@ -6,7 +6,7 @@ title: "KION Music"
 
 Music Assistant has support for [KION Music](https://music.mts.ru) (MTS Music). Contributed and maintained by [TrudenBoy](https://github.com/TrudenBoy).
 
-KION Music is a music streaming service by MTS (Mobile TeleSystems), one of the largest telecom operators in Russia and CIS countries. This source uses the [yandex-music-api](https://github.com/MarshalX/yandex-music-api) library adapted for the KION API endpoint.
+KION Music is a music streaming service run by MTS (Mobile TeleSystems), one of the largest telecoms companies in Russia and the CIS.
 
 Connecting your account puts your KION library and the wider catalogue inside Music Assistant.
 
@@ -49,17 +49,19 @@ Connecting your account puts your KION library and the wider catalogue inside Mu
 
 ## Configuration
 
-Configuration requires obtaining a token from KION Music.
+KION has no sign-in for outside apps, so a token has to be copied out of your browser.
 
-### Obtaining the Token
+1. Sign in to your account at [music.mts.ru](https://music.mts.ru)
+2. Press Ctrl+Shift+I to open the browser's developer tools
+3. Open the **Storage** tab in Firefox, or the **Application** tab in Chrome
+4. Under **Local Storage**, select the entry for `https://music.mts.ru`
+5. Find the row named `ya_token` and copy its value
+6. Paste it into the KION Music source in Music Assistant and save
 
-1. Open your browser and navigate to [music.mts.ru](https://music.mts.ru)
-2. Log in to your account
-3. Open Developer Tools (Ctrl+Shift+I)
-4. Go to the **Storage** (Firefox) or **Application** (Chrome) tab
-5. Under **Local Storage**, find the entry for `https://music.mts.ru`
-6. Copy the value of the `ya_token` key
-7. Paste this token into the Music Assistant KION Music source configuration
+> [!WARNING]
+> **Keep your token private**
+>
+> Anyone who has it can get into your KION account, so do not share it or paste it anywhere when asking for help.
 
 ### Settings
 

--- a/src/content/docs/music-providers/subsonic.md
+++ b/src/content/docs/music-providers/subsonic.md
@@ -38,7 +38,7 @@ You will need to provide the following to Music Assistant:
 - <b>Password.</b> For the account specified
 - <b>Base URL.</b> The server URL starting with http:// or https:// (e.g. https://music.domain.tld)
 - <b>Port.</b> Typically, 80 for plain http, or 443 for https, but can be any port where your server can be reached
-- <b>Server Path.</b> Path to append to the Base URL which is used to get to the Rest API (e.g. mypathroute/ if you are path routing. (Leave this blank unless you know you need it))
+- <b>Server Path.</b> Anything that comes after the address, if your server sits at something like `music.domain.tld/mypathroute/` rather than at the top level. Leave this blank unless you know you need it
 
 ### Settings
 
@@ -52,15 +52,10 @@ You will need to provide the following to Music Assistant:
 
 ## Known Issues / Notes
 
-- Not all server implementations accept an empty string as a search query, however this is considered valid input per the API documentation. If search or track enumeration fails, ask the authors of your server implementation about handling empty query strings
-- This source makes use of https://github.com/khers/py-opensonic for communicating with the server, if something is failing to work properly in Music Assistant, try to use that library to interact with your server (can you ping it?, fetch artist and albums?, can you search?)
-- This source only supports servers implementing the Open Subsonic API definition. To verify that your server is compatible, use the same setup you used to test connectivity above to hit the getOpenSubsonicExtensions() endpoint. If this endpoint is not implemented, MA cannot talk to your server
+- Searching with nothing typed in is allowed by the specification, but some servers refuse it. If search or the track list fails, that is worth raising with whoever makes your server
+- This source only works with servers that follow the Open Subsonic specification. If your server does not support the newer specification, Music Assistant cannot talk to it. Your server's own documentation should say which one it follows
 - If you find a mismatch between what is displayed by your Subsonic compatible server and Music Assistant then refer to and contribute <a href="https://github.com/music-assistant/support/issues/2192" target="_blank" rel="noopener noreferrer">here to help find a solution</a>
-- Not all Open Subsonic implementations handle tracks/albums with multiple contributing artists particularly well. If you see strange artists listed in Music Assistant, please verify that your implementation has an artist ID for all artists listed on a track or album. See the discussion <a href="https://github.com/music-assistant/support/issues/2965" target="_blank" rel="noopener noreferrer">here</a>
-- It may not be possible to playback m4a, opus, VBR encoded music, or any other formate that uses stream metadata inband with audio samples. Options to workaround this are
-    - Don't use these formats
-    - Force the subsonic server to transcode all these files before serving to a format that works
-    - Don't serve these files from a subsonic server
-    - It may be possible to force an encoder to place the moov atom at the beginning of the file. This would make the files playable, but MA provides no support for this
-- Autoplay mode (<a href="https://www.music-assistant.io/usage/#the-queue" target="_blank" rel="noopener noreferrer">described here</a>) relies on your subsonic servers implementation of the <a href="https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs/" target="_blank" rel="noopener noreferrer">getSimilarSongs</a> end point. Please ensure that you have configured your server for this to work. Both Gonic and Navidrome require the addition of a Last.fm API key to provide similar songs. Please see your subsonic server's documentation.
-- Note that this provider is for server implementations that use the Open Subsonic API definitions _only_. This means that it will not work with the original Subsonic or any of its forks (like Airsonic or Airsonic-Advanced) unless those forks have also moved to using the Open Subsonic API specification.
+- Not all servers handle tracks or albums with several contributing artists well. If you see odd artists appearing in Music Assistant, this is usually the cause. See the discussion <a href="https://github.com/music-assistant/support/issues/2965" target="_blank" rel="noopener noreferrer">here</a>
+- Some files may not play at all, most often m4a and opus, and anything encoded at a variable bitrate. These formats can hold information part way through the file rather than all of it at the start, which Music Assistant cannot work with over a Subsonic connection. Your options are to avoid these formats, to set your server to convert them to something else before sending them, or to keep those files out of your Subsonic library and reach them another way
+- Autoplay (<a href="https://www.music-assistant.io/usage/#the-queue" target="_blank" rel="noopener noreferrer">described here</a>) needs your server to be able to suggest similar songs, which not every server does out of the box. Gonic and Navidrome both need a Last.fm API key added before they can. Check your server's documentation
+- To be clear, this will not work with the original Subsonic or with anything built on it, such as Airsonic or Airsonic-Advanced, unless that software has since moved over to the Open Subsonic specification.

--- a/src/content/docs/music-providers/yandex-music.md
+++ b/src/content/docs/music-providers/yandex-music.md
@@ -13,7 +13,7 @@ Connecting your account puts your Yandex Music library, the wider catalogue and 
 > [!CAUTION]
 > This is an unofficial implementation and is not affiliated with or endorsed by Yandex.
 
-> [!WARNING]
+> [!NOTE]
 > A Yandex Music Plus subscription is required for lossless (FLAC) quality and for everything here to work.
 > Without one, some of what is described below will be unavailable.
 

--- a/src/content/docs/music-providers/yandex-music.md
+++ b/src/content/docs/music-providers/yandex-music.md
@@ -10,14 +10,12 @@ Yandex Music is the streaming service of Yandex, the Russian internet company. I
 
 Connecting your account puts your Yandex Music library, the wider catalogue and My Wave itself inside Music Assistant.
 
-This source is built on top of the [yandex-music-api](https://github.com/MarshalX/yandex-music-api) library.
-
 > [!CAUTION]
 > This is an unofficial implementation and is not affiliated with or endorsed by Yandex.
 
 > [!WARNING]
-> A Yandex Music Plus subscription is required for full functional of source and lossless (FLAC) quality.
-> Without a subscription, the source's's full-fledged operation is not guaranteed.
+> A Yandex Music Plus subscription is required for lossless (FLAC) quality and for everything here to work.
+> Without one, some of what is described below will be unavailable.
 
 > [!NOTE]
 > Full source documentation (RU/EN): **[trudenboy.github.io/ma-provider-yandex-music](https://trudenboy.github.io/ma-provider-yandex-music/)**
@@ -47,7 +45,7 @@ This source is built on top of the [yandex-music-api](https://github.com/Marshal
 - Browse is available to explore the Yandex Music catalogue
 - Lyrics are displayed when available (synced line-by-line when provided by the service, otherwise plain text)
 - Personalized recommendations (My Wave, Made for You, Chart, New Releases and more) appear in the Recommendations section on the Home screen
-- **My Wave** personalised radio with Yandex's long-lived rotor session (signals like/dislike, skips and full plays back to the recommendation algorithm)
+- **My Wave** personalised radio. Likes, dislikes, skips and tracks you hear all the way through are sent back to Yandex, so the wave keeps learning from what you do in Music Assistant
 - **Wave Modes** — 11 one-click presets for My Wave (Discover / Favorites / Popular, Calm / Active / Fun / Sad, Russian / Non-Russian / Without Words)
 - **My Presets** — save your own named combinations of diversity, mood and language, re-launch them from Browse without fiddling with settings
 - Similar tracks are available from the track context menu (used by Endless Mix); when a wave track plays, Endless Mix continues the same Yandex-curated session instead of branching into an unrelated similar-tracks stream
@@ -57,40 +55,41 @@ This source is built on top of the [yandex-music-api](https://github.com/Marshal
 
 ## Configuration
 
-The source supports three authentication methods. Device Flow is the recommended path — it's non-interactive, works on headless setups, and produces refreshable credentials.
+There are three ways to sign in. The first is the easiest and keeps working on its own, so use that one unless it fails.
 
-### Option 1: Device Flow (recommended)
+### Option 1: Sign in with a code (recommended)
 
 1. In Music Assistant, add the Yandex Music source and click **Login with device code**
-2. A short verification URL and user code appear — open the URL on any device (phone, another computer) and enter the code
+2. A short web address and a code appear. Open that address on any device, such as your phone, and type in the code
 3. Approve the request in your Yandex account
-4. Music Assistant receives the tokens automatically and finishes setup. Session tokens auto-refresh — no periodic re-login required.
+4. Music Assistant finishes the setup on its own. It will stay signed in, so there is nothing to renew later
 
 ### Option 2: QR Code
 
 1. In Music Assistant, add the Yandex Music source and click **Login with QR code**
-2. Scan the QR with the Yandex app on your phone (signed into the account you want)
-3. Approve in the app — Music Assistant picks up the credentials
+2. Scan the code with the Yandex app on your phone, signed in to the account you want to use
+3. Approve it in the app and Music Assistant does the rest
 
-### Option 3: Manual OAuth Token (advanced)
+### Option 3: Paste a token by hand (advanced)
 
-For headless setups where neither device flow nor QR works:
+Only needed if neither of the above works:
 
-1. Open your browser and navigate to [Yandex OAuth](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d)
-2. Log in with your Yandex account if prompted
-3. After authorization, you will be redirected to a URL containing `access_token=YOUR_TOKEN`
-4. Copy the token value (the part after `access_token=` and before `&`)
-5. Paste this token into the Music Assistant Yandex Music source configuration (under advanced settings)
+1. Open [this Yandex sign-in link](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d) in your browser
+2. Sign in to your Yandex account if asked
+3. You will land on a page whose web address contains `access_token=` followed by a long run of characters
+4. Copy that run of characters — everything after `access_token=` and before the next `&`
+5. Paste it into the Yandex Music source in Music Assistant, under advanced settings
+
+Note that a token pasted this way will expire and have to be replaced by hand.
 
 ### Settings
 
 - **Audio quality**: Select preferred audio quality. Options: `Efficient (AAC ~64 kbps)`, `Balanced (AAC ~192 kbps)` (default), `High (MP3 320 kbps)`, `Lossless (FLAC)` (requires Yandex Music Plus subscription)
-- **Remember session**: keeps the refresh token so tokens renew automatically (on by default for Device Flow / QR)
+- **Remember session**: stays signed in and renews the connection on its own. On by default when you sign in with a code or a QR code
 - **My Wave custom presets**: advanced-settings builder for saving named wave combinations (name + up to three dropdowns). Saved entries surface under **Radio → My Presets** in Browse
 
 ## Known Issues / Notes
 
-- Manually-obtained OAuth tokens expire and need to be refreshed periodically; Device Flow / QR setups auto-refresh
-- Lossless FLAC quality requires an active Yandex Music Plus subscription; without it the source falls back to the highest available quality
-- Lossless FLAC streams are fetched in 4 MB windows to work around Yandex CDN per-connection limits, ensuring uninterrupted playback for tracks of any length
-- Tracks played through Music Assistant currently **do not** appear in the Yandex Listening History feed — that feed is only written from an active Ynison WebSocket session. If you need Yandex-side history, play through the native Yandex app (or the companion [Yandex Music Connect (Ynison)](https://music-assistant.io/plugins/yandex-ynison/) plugin)
+- A token pasted in by hand expires and has to be replaced. Signing in with a code or a QR code avoids this
+- Lossless FLAC requires an active Yandex Music Plus subscription. Without one, Yandex Music plays at the highest quality your account allows
+- Tracks played through Music Assistant do **not** show up in your Yandex listening history. If you want them to, play through the Yandex app itself, or add the [Yandex Music Connect (Ynison)](/plugins/yandex-ynison/) plugin

--- a/src/content/docs/music-providers/zvuk.md
+++ b/src/content/docs/music-providers/zvuk.md
@@ -10,8 +10,6 @@ Zvuk is a Russian music streaming service with a large Russian language catalogu
 
 Connecting your account brings your Zvuk library and playlists into Music Assistant, and the catalogue can be searched from there.
 
-This source is built on top of the [zvuk-music](https://github.com/trudenboy/zvuk-music) library.
-
 > [!CAUTION]
 > This is an **unofficial** implementation with no affiliation to [Zvuk](https://zvuk.com) or its owners.
 
@@ -51,58 +49,20 @@ This source is built on top of the [zvuk-music](https://github.com/trudenboy/zvu
 
 ## Configuration
 
-Configuration requires obtaining an X-Auth-Token from Zvuk Music.
+Zvuk has no sign-in for outside apps, so a token has to be copied out of your browser.
 
-### Obtaining the Token
-
-The Zvuk Music source requires an authentication token (X-Auth-Token) from your Zvuk account.
-
-**Steps:**
-
-1. **Log in** to your Zvuk Music account at [zvuk.com](https://zvuk.com) using your web browser
-
-2. **Navigate** to the profile API endpoint: [https://zvuk.com/api/tiny/profile](https://zvuk.com/api/tiny/profile)
-
-   Your browser will display a JSON response containing your profile information and authentication token.
-
-3. **Locate the token** in the JSON response
-
-   The response will look similar to this:
-
-   ```json
-   {
-     "user": {
-       "id": 12345678,
-       "email": "your@email.com",
-       "token": "abc123def456ghi789jkl012mno345pqr678stu901vwx234yz",
-       ...
-     }
-   }
-   ```
-
-4. **Copy the token value**
-
-   - Find the line with `"token":` in the JSON
-   - Copy only the alphanumeric string between the quotes (not including the quotes)
-   - The token is typically a long string of random letters and numbers
-   - Example token: `abc123def456ghi789jkl012mno345pqr678stu901vwx234yz`
-
-5. **Paste the token** into Music Assistant
-
-   - Go to Music Assistant Settings → Music sources → Add a music source → Zvuk Music
-   - Paste the token into the "X-Auth-Token" field
-   - Save the configuration
+1. Sign in to your account at [zvuk.com](https://zvuk.com)
+2. In the same browser, open [zvuk.com/api/tiny/profile](https://zvuk.com/api/tiny/profile). A page of text about your account appears
+3. Find `"token":` in that text and copy the long run of letters and numbers between the quotation marks that follow it, leaving the quotation marks themselves out
+4. In Music Assistant, go to Settings → Music sources → Add a music source → Zvuk Music, paste it into the **X-Auth-Token** field and save
 
 > [!TIP]
-> **Browser Display Tips**
-> - **Chrome/Edge**: JSON will be formatted automatically for easy reading
-> - **Firefox**: JSON appears with syntax highlighting
-> - **Safari**: Enable Develop menu → Show Page Source if needed
-> - **Other browsers**: If the browser downloads a file, open it with a text editor
+> If your browser downloads a file rather than showing the text, open the file in any text editor and look for `"token":` in there.
 
 > [!WARNING]
-> **Token Security**
-> Keep your token private and do not share it. Anyone with your token can access your Zvuk Music account.
+> **Keep your token private**
+>
+> Anyone who has it can get into your Zvuk account, so do not share it or paste it anywhere when asking for help.
 
 ### Settings
 
@@ -112,13 +72,8 @@ The Zvuk Music source requires an authentication token (X-Auth-Token) from your 
 
 ## Known Issues / Notes
 
-### Authentication Issues
-
-- **Token expiration**: The token may expire and need to be refreshed periodically. If you encounter authentication errors, try obtaining a new token by following the steps above.
-- **Login required**: You must be logged in to zvuk.com before accessing the profile endpoint. If you see an error or empty response, make sure you're logged in to your account first.
-- **Invalid token format**: Ensure you copied the complete token value without any extra spaces, quotes, or line breaks.
-
-### Quality Issues
-
-- If lossless quality is unavailable (no subscription), this source will automatically fall back to the highest available quality (320 kbps)
+- The token expires after a while and has to be replaced. If Zvuk stops working, go through the steps above again to get a fresh one
+- If step 2 shows an error or an empty page, you are probably not signed in to zvuk.com. Sign in first, then try again
+- If the token is rejected, check you copied all of it and nothing else, with no stray spaces, quotation marks or line breaks
+- Without a subscription, lossless is unavailable and Zvuk plays at the highest quality your account allows (320 kbps)
 

--- a/src/content/docs/music-providers/zvuk.md
+++ b/src/content/docs/music-providers/zvuk.md
@@ -13,7 +13,7 @@ Connecting your account brings your Zvuk library and playlists into Music Assist
 > [!CAUTION]
 > This is an **unofficial** implementation with no affiliation to [Zvuk](https://zvuk.com) or its owners.
 
-> [!WARNING]
+> [!NOTE]
 > A Zvuk Prime subscription is required for full functionality of this source and for lossless (FLAC) quality.
 > Without a subscription, this source's full-fledged operation is not guaranteed.
 

--- a/src/content/docs/player-support/alexa.md
+++ b/src/content/docs/player-support/alexa.md
@@ -8,6 +8,10 @@ title: "Alexa"
 
 Music Assistant has support for Alexa devices. This component is contributed and maintained by <a href="https://github.com/alams154" target="_blank" rel="noopener noreferrer">Sameer Alam</a>.
 
+Amazon does not let anything play to an Echo the way it lets you play to a Chromecast or a Sonos. The only way in is to build your own Alexa skill, so that is what this does — your Echo devices turn up in Music Assistant as players and you can send music to them like any other speaker.
+
+Getting there is a long way from adding a provider and clicking save. You need somewhere to run a second piece of software, a web address of your own with a valid certificate on it, and an Amazon developer account to create the skill in. Set aside an evening, and read the whole of this page before you start.
+
 ## Features
 
 - Detects all Alexa devices linked to your Amazon account and registers them as players
@@ -22,10 +26,10 @@ Run with Docker Compose (recommended):
 - Copy the `docker-compose.yml` from the prototype repository (`https://github.com/alams154/music-assistant-alexa-skill-prototype`) and ensure Docker and Docker Compose are installed.
 - Create a `secrets/` directory next to your `docker-compose.yml` and add the following files (relative to the compose file):
 
-  - `./secrets/api_username.txt` — contains your API username
-  - `./secrets/api_password.txt` — contains your API password
+  - `./secrets/app_username.txt` — a username of your choosing, used to protect the setup pages
+  - `./secrets/app_password.txt` — the matching password
 
-- Edit environment variables in `docker-compose.yml` as needed (for example: `MA_HOSTNAME`, `PORT`).
+- Set the environment variables in `docker-compose.yml`. The two that matter are `SKILL_HOSTNAME`, the public address Amazon will reach this service on, and `MA_HOSTNAME`, your Music Assistant server. `MA_HOSTNAME` is required for any Echo without a screen.
 - Start the service:
 
   ```sh
@@ -33,11 +37,8 @@ Run with Docker Compose (recommended):
   ```
 
 - By default the service will be available at `http://localhost:5000` (or the IP/port you configured).
-- In your browser, open the setup UI at `http://localhost:5000/setup`. The setup page will:
-   - detect existing persistent ASK credentials (if present) and skip the browser-based auth flow
-   - guide you through the ASK CLI authorization flow if credentials are not present
-   - run the automated skill creation/update, interaction model upload, model build polling, and testing enablement.
-- In your browser, open the status UI at `http://localhost:5000/status` to check the status of the skill
+- In your browser, open the setup page at `http://localhost:5000/setup`. It will sign you in to your Amazon developer account if you are not already, then create the skill and get it ready for testing. This takes a few minutes and the page will wait for Amazon while it works.
+- Open `http://localhost:5000/status` at any point to see how the skill is getting on
 
 ### 2. Set Up a Proxy with SSL Certificates
 - Configure a reverse proxy (such as Nginx or Caddy) in front of both the skill prototype service (default port: 5000) and your Music Assistant streaming port (default port: 8097) [optional if using only APL devices]
@@ -58,8 +59,7 @@ Run with Docker Compose (recommended):
 8. Under **Interfaces**, enable the **Audio Player** and **Alexa Presentation Language** interfaces and save the changes.
 9. Go to the **Test** tab and enable testing by switching to **Development**.
 
-**Summary:**  
-The skill prototype is run as a separate server, a proxy with SSL certificates must be set up, the Alexa skill is created and configured, and then Music Assistant playback should now be enabled on your Alexa devices.
+**In short:** you run the skill service yourself, put it behind a web address with a valid certificate, create the Alexa skill and point it at that address. Your Echo devices then appear in Music Assistant as players.
 
 ### Login Process
 
@@ -79,9 +79,9 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>E-mail.</b> Amazon account linked to Echo devices
 - <b>Password.</b> Password for the Amazon account
 - <b>OTP Secret.</b> OTP secret for the Amazon account
-- <b>API URL.</b> URL of the local API used to communicate with Alexa (e.g. http://localhost:3000)
-- <b>API Basic Auth Username.</b> Username for basic auth if the API is protected
-- <b>API Basic Auth Password.</b> Password for API basic auth
+- <b>API URL.</b> Address of the skill service you set up above (e.g. http://localhost:5000)
+- <b>API Basic Auth Username.</b> The username you put in `app_username.txt`
+- <b>API Basic Auth Password.</b> The password you put in `app_password.txt`
 - <b>Alexa Language.</b> Locale used for Alexa (e.g. en-US)
 
 In addition to the [Individual Player Settings](/settings/individual-player/) the Alexa players have the following settings:

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -4,22 +4,24 @@ title: "Sendspin"
 
 # Sendspin-audio Provider  <img src="/assets/icons/sendspin-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-<a href="https://www.sendspin-audio.com/" target="_blank" rel="noopener noreferrer">Sendspin-audio</a> is an audio playback, control, and synchronization protocol developed by the <a href="https://www.openhomefoundation.org/" target="_blank" rel="noopener noreferrer">Open Home Foundation</a>. It is the **native playback protocol built into Music Assistant**, providing synchronized audio playback across multiple clients with sample-accurate timing.
+<a href="https://www.sendspin-audio.com/" target="_blank" rel="noopener noreferrer">Sendspin</a> is Music Assistant's own way of sending audio to a player. It keeps several devices playing in step with each other, closely enough that the same track can play in more than one room without any echo between them.
 
-Because Sendspin is **license-free and open source**, anyone can build apps, devices, and integrations using the protocol. The specification is available at <a href="https://github.com/Sendspin/spec" target="_blank" rel="noopener noreferrer">github.com/Sendspin/spec</a>.
+It is built into Music Assistant and switched on from the start, so there is nothing to install. The web player you use in your browser is a Sendspin player, and Sendspin speakers and apps appear on their own once they are on your network.
+
+Sendspin was developed by the <a href="https://www.openhomefoundation.org/" target="_blank" rel="noopener noreferrer">Open Home Foundation</a> and is free for anyone to build on, so the range of devices and apps that support it is growing.
 
 > [!CAUTION]
 > **Technical Preview**
 >
-> Sendspin and its implementation in Music Assistant are currently in **technical preview**. While functional, the protocol and implementation may change.
+> Sendspin is still in technical preview. It works, but expect it to change.
     
 ## Features
 
-- **Synchronized multi-room audio**: Sample-accurate playback across all connected devices
-- **Automatic discovery**: Sendspin devices on your network are automatically detected by Music Assistant
-- **Per-player DSP**: Individual equalizer and volume settings for each device
-- **Bidirectional control**: Clients can control playback (play, pause, skip, etc.)
-- **Real-time metadata**: Track info, artwork, and playback progress on all devices
+- **Synchronised multi-room audio**: every connected device stays in step
+- **Automatic discovery**: Sendspin devices on your network are found on their own
+- **Per-player audio settings**: each device gets its own equaliser and volume
+- **Control from the device**: play, pause and skip can be driven from the player as well as from Music Assistant
+- **Track information**: title, artwork and progress appear on every device
 
 ## Configuration
 
@@ -31,31 +33,17 @@ Individual Sendspin players will appear automatically when clients connect
 
 Standard [player settings](/settings/player-provider/) apply. Specific settings available for this player type are:
 
-- <b>Manual IP addresses for discovery.</b> Normally Sendspin clients are automatically discovered via mDNS. If automatic discovery does not work due to the network setup, the IP address or hostname of a Sendspin client can be manually entered. Accepted values are a plain IP address or hostname, optionally with a port, such as `192.168.1.50`, `speaker.local`, or `speaker.local:8928`. For clients using a non-default path or protocol, enter the full WebSocket URL, such as `ws://speaker.local:8928/sendspin` or `wss://speaker.example.com/sendspin`. If only an IP address or hostname is entered, Music Assistant assumes the default Sendspin client endpoint `ws://<host>:8928/sendspin`. Music Assistant will connect to the configured clients directly and keep retrying if a client is offline when MA starts.
+- <b>Manual IP addresses for discovery.</b> Sendspin players are normally found on their own. If yours is not, add its IP address or network name here, for example `192.168.1.50` or `speaker.local`. Music Assistant will then connect to it directly, and keep trying if the device is switched off when MA starts
 - <b>Sync delay (ms).</b> Not all devices allow this correction but when available is allows a for static delay to be applied for audio synchronisation
 - <b>Output channel mode.</b> The default is `Stereo` but other options are `Left channel only`, `Right channel only` or `Mono (both channels)`
 
 ## Known Issues / Notes
 
-- The Sendspin provider is added by default
-- The web player appears automatically in the player list
+- Audio is sent to Sendspin players as 16 bit, so higher resolution material is converted on the way out
+- Artwork clears briefly when you pause, seek, or move on to the next track
+- Only one Music Assistant server on a network can use Sendspin
+- Players must be on the same network as Music Assistant to connect directly. Listening from elsewhere works through the web player, and Home Assistant Cloud gives the most reliable connection through a firewall
 - If using Sendspin on a Chromecast device, be aware that, due to the lack of reported metadata, the Home Assistant media player entity may show 'idle' with no track details even while audio is playing correctly; check the Music Assistant UI for the true playback state
-
-### Limitations
-
-- **Technical preview**: The protocol is still evolving
-- **Network requirements**: For direct connections, devices must be on the same network as Music Assistant
-- **WebRTC requirements**: For remote access via WebRTC, Home Assistant Cloud (Nabucasa) provides optimal TURN server support for reliable connections through firewalls
-
-### Specification Compliance and Deviations
-
-There are some gaps between this implementation and the specification at <a href="https://github.com/Sendspin/spec" target="_blank" rel="noopener noreferrer">github.com/Sendspin/spec</a>. Both are subject to change. Known deviations include:
-
-- Player Format Changes through `stream/request-format` are not yet supported
-- The `paused` `playback_state` is never used - only `playing` and `stopped` are sent to clients
-- All streams are ended immediately when playback stops, skipping to the next track, or when seeking. Artwork is also cleared during pause, seek, or loading of the next track
-- Multi Server Support messages are implemented but not fully utilized - only a single server per network is supported
-- Only 16-bit audio formats are supported
 
 ## Supported Clients
 
@@ -69,38 +57,25 @@ Several client types can connect to Music Assistant via Sendspin:
 | **<a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>** | Bridges Bluetooth speakers as MA players — multi-device, multiroom sync, web dashboard. Deploys as HA addon, Docker, or LXC |
 | **<a href="https://www.sendspin-audio.com/code/" target="_blank" rel="noopener noreferrer"> Various Sendspin Clients</a>** | Clients are becoming available for various platforms |
 
-## How It Works
+## The Web Player
 
-### Automatic Discovery
+The player built into the Music Assistant web interface is itself a Sendspin player. On your own network it connects straight to the server, which sounds best. From anywhere else it connects over the internet instead, which still works but at a lower quality.
 
-Sendspin devices on the local network are automatically discovered via mDNS and will appear in Music Assistant. If mDNS discovery is unavailable or unreliable, add the client's IP address or hostname to the provider's manual discovery setting.
+The sync delay can be adjusted under **Settings → User Interface → Sendspin sync delay**. Music Assistant picks a value to suit your device, but it may need adjusting.
 
-### The Web Player
+Audio quality in the web player depends on where you are listening from:
 
-The built-in web player in the Music Assistant frontend uses Sendspin for audio playback. When on a local network, the web player will attempt to use a direct WebSocket connection for best performance; otherwise it falls back to WebRTC.
-
-The sync delay can be adjusted under **Settings → User Interface → Sendspin sync delay**. This value is auto-selected based on the platform but may need manual adjustment.
-
-#### Codec Support
-
-The audio codec used depends on the connection and platform:
-
-- **Local connections** (on the same network): FLAC (lossless) is used on desktop browsers and Android. iOS, iPadOS, and Safari use Opus.
-- **Remote connections** (via WebRTC): All browsers use Opus.
+- **On your own network**: lossless FLAC on desktop browsers and Android. iPhone, iPad and Safari use Opus
+- **From anywhere else**: every browser uses Opus
 
 > [!NOTE]
-> Firefox on Android does not support remote (WebRTC) playback.
+> Firefox on Android cannot play from outside your own network.
 
-### Connection Methods
+## Connecting Other Sendspin Players
 
-Sendspin supports two connection methods:
+Sendspin players on your network are found automatically, so there is usually no address to enter anywhere.
 
-1. **Direct WebSocket**: Used automatically by clients on the same local network as Music Assistant, including the web player and hardware devices.
-2. **WebRTC**: Used for remote access when not on the local network. Works across networks and through firewalls. The web player falls back to this method when a direct connection isn't possible.
-
-#### Connecting External Sendspin Clients
-
-Sendspin clients on the local network are discovered automatically, so most users never need to enter a URL. However, if a third-party client asks for a server URL (or you are developing your own client), the Sendspin server listens on the `/sendspin` WebSocket endpoint on port `8927`. A full connection URL looks like `ws://192.168.1.100:8927/sendspin` (replacing the IP address with that of your Music Assistant server).
+If a player does ask you for a server address, or you are building a client of your own, Music Assistant listens at `ws://192.168.1.100:8927/sendspin` — replace the IP address with that of your Music Assistant server. The specification is published at <a href="https://github.com/Sendspin/spec" target="_blank" rel="noopener noreferrer">github.com/Sendspin/spec</a>.
 
 > [!NOTE]
-> The `/sendspin` path also exists on the main web interface port (8095), but that is an authenticated proxy used internally by the web player and external clients connecting there will be rejected.
+> The same `/sendspin` path exists on the main web interface port (8095), but that one is reserved for the built-in web player and will reject other clients.

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -34,7 +34,7 @@ Individual Sendspin players will appear automatically when clients connect
 Standard [player settings](/settings/player-provider/) apply. Specific settings available for this player type are:
 
 - <b>Manual IP addresses for discovery.</b> Sendspin players are normally found on their own. If yours is not, add its IP address or network name here, for example `192.168.1.50` or `speaker.local`. Music Assistant will then connect to it directly, and keep trying if the device is switched off when MA starts
-- <b>Sync delay (ms).</b> Not all devices allow this correction but when available is allows a for static delay to be applied for audio synchronisation
+- <b>Sync delay (ms).</b> Not all devices allow this correction but when available it allows for a static delay to be applied for audio synchronisation
 - <b>Output channel mode.</b> The default is `Stereo` but other options are `Left channel only`, `Right channel only` or `Mono (both channels)`
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -53,7 +53,7 @@ Several client types can connect to Music Assistant via Sendspin:
 |--------|-------------|
 | **Web Browser** | The built-in Music Assistant web player uses Sendspin for local playback |
 | **[Google Cast (Sendspin mode)](/player-support/google-cast/)** | Experimental Sendspin mode for Chromecast devices |
-| **<a href="https://esphome.github.io/home-assistant-voice-pe-alpha/" target="_blank" rel="noopener noreferrer">Home Assistant Voice PE</a>** | Alpha firmware for the Home Assistant Voice Preview Edition |
+| **<a href="https://esphome.github.io/home-assistant-voice-pe/" target="_blank" rel="noopener noreferrer">Home Assistant Voice PE</a>** | Built into recent Voice PE firmware. Update the device with the official installer, choosing a pre-release build if the current stable one does not show up as a player |
 | **<a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>** | Bridges Bluetooth speakers as MA players — multi-device, multiroom sync, web dashboard. Deploys as HA addon, Docker, or LXC |
 | **<a href="https://www.sendspin-audio.com/code/" target="_blank" rel="noopener noreferrer"> Various Sendspin Clients</a>** | Clients are becoming available for various platforms |
 

--- a/src/content/docs/plugins/vban-receiver.md
+++ b/src/content/docs/plugins/vban-receiver.md
@@ -5,46 +5,46 @@ description: Features and Notes for the VBAN Receiver Plugin
 
 # VBAN Receiver <img src="/assets/icons/vban-icon.svg" alt="Preview image" style="width: 126px; float: right;"  loading="lazy" />
 
-The VBAN Receiver plugin gives Music Assistant a network-based auxiliary input - audio playing on another device can be sent into MA and treated as a standard streaming source. Typical use cases include transmitting system audio, audio from individual applications, or audio captured from soundcard inputs such as microphones or line-in devices on a remote machine. Contributed and maintained by <a href="https://github.com/sprocket-9" target="_blank" rel="noopener noreferrer">sprocket-9</a>
+This plugin lets another computer on your network send its audio to Music Assistant, which then plays it on any of your speakers. It behaves like an aux input: whatever the other machine is playing turns up in Music Assistant as something you can choose to listen to. Contributed and maintained by <a href="https://github.com/sprocket-9" target="_blank" rel="noopener noreferrer">sprocket-9</a>
 
-VBAN itself is an audio-over-IP protocol from <a href="https://vb-audio.com/Voicemeeter/vban.htm" target="_blank" rel="noopener noreferrer">VB-Audio</a> that uses UDP to transmit high-quality, native PCM audio over a local network. See the [VBAN Senders section below](#vban-senders) for examples of compatible sender implementations.
+That can be everything coming out of the other computer, the sound from one particular application, or something plugged into it such as a microphone or a turntable on a line-in.
+
+VBAN is the method used to carry the audio across the network. It comes from <a href="https://vb-audio.com/Voicemeeter/vban.htm" target="_blank" rel="noopener noreferrer">VB-Audio</a> and sends the sound uncompressed, so nothing is lost on the way. The sending computer needs software that can speak it — see [VBAN Senders](#vban-senders) below for the usual choices.
 
 ## Features
 
-- Ingest audio from any VBAN sender on the network as a standard MA streaming source
-- Play system audio, individual applications, microphones or line-in inputs from a remote machine to any MA player
-- Multiple instances can be added, one per incoming stream
+- Take in audio from any VBAN sender on your network and play it like any other source
+- Send everything from another computer, or just one application, a microphone or a line-in
+- Add the plugin more than once, one for each incoming feed
 
 ## Configuration
 
-The plugin is multi-instance, so ensure each instance of the plugin is listening on its own unique UDP port and configured to match the stream parameters as set by the VBAN Sender.
+Most of these settings have to match what you set on the sending computer, or no sound will come through. Fill in the sender's side first, then copy the same values here.
+
+If you add the plugin more than once, give each one its own port number.
 
 ### Settings
 
-The VBAN Receiver plugin provides several configuration options that define how it connects to and receives audio from a remote VBAN sender. These settings ensure proper communication, format compatibility, and reliable playback performance.
-
-The available settings are:
-
-- <b>Receiver: UDP Port.</b> Defines the UDP port that the VBAN receiver listens on for incoming connections. Ensure that the server is reachable at the specified IP address and UDP port by remote VBAN senders
-- <b>Sender: VBAN Stream Name.</b> Specifies the VBAN stream name to expect from the remote VBAN sender. This value must match the session name configured on the sender; otherwise, audio streaming will fail. The name is limited to a maximum of 16 ASCII characters
-- <b>Sender: VBAN Sender hostname/IP address.</b> Sets the hostname or IP address of the remote VBAN sender device
-- <b>PCM audio format.</b> Defines the VBAN PCM audio format expected from the remote sender. This must exactly match the format configured on the sender to ensure successful audio streaming
-- <b>PCM sample rate.</b> Sets the VBAN PCM sample rate expected from the sender. This must match the sender’s configuration to maintain proper synchronization and playback
-- <b>Channels.</b> Specifies the number of audio channels to be received (i.e. 1 or 2)
+- <b>Receiver: UDP Port.</b> The port Music Assistant listens on. The sending computer needs to be able to reach your Music Assistant server on this port
+- <b>Sender: VBAN Stream Name.</b> The name given to the feed on the sending computer. It has to match exactly or nothing will come through. Up to 16 characters, letters and numbers only
+- <b>Sender: VBAN Sender hostname/IP address.</b> The address of the computer sending the audio
+- <b>PCM audio format.</b> Match this to the sending computer
+- <b>PCM sample rate.</b> Match this to the sending computer
+- <b>Channels.</b> `1` for mono or `2` for stereo
 
 In the ADVANCED section:
 
-- <b>Receiver: Bind to IP/interface.</b> Determines which network interface or IP address the VBAN receiver should bind to. Use `0.0.0.0` to listen on all available interfaces (default). This is an advanced option and typically does not require adjustment in standard setups
-- <b>Receiver: VBAN queue strategy.</b> Configures the behavior when the receiver’s internal packet queue becomes full. This setting defines how packet overflow is handled during high-load conditions. The options are `Clear entire queue`, `Clear the oldest half of the queue` and `Remove single oldest queue entry`
-- <b>Receiver: VBAN packets queue size.</b> Defines the maximum number of packets that can be queued before processing. This setting may be increased on systems with limited processing power but generally should not require modification
+- <b>Receiver: Bind to IP/interface.</b> Which of your server's network connections to listen on. The default `0.0.0.0` means all of them, which is almost always what you want
+- <b>Receiver: VBAN queue strategy.</b> What to do when audio arrives faster than it can be dealt with. The options are `Clear entire queue`, `Clear the oldest half of the queue` and `Remove single oldest queue entry`
+- <b>Receiver: VBAN packets queue size.</b> How much audio can wait to be dealt with. Raising it may help on a slower server, but most people never need to touch it
 
 ## Known Issues / Notes
 
 - To listen to the plugin audio, navigate to the desired player’s NOW PLAYING view and then in the menu in the top right, select Source, and choose the desired VBAN Receiver
-- Although VBAN is designed for real-time audio transmission, this plugin’s primary objective is to route remote system audio into MA rather than to achieve real-time playback. The plugin functions as an intermediary, forwarding incoming packets from the VBAN Sender directly to MA for processing as they are received. Since MA is optimized to process audio from plugins with minimal delay, overall latency should remain low. However, the audio buffering mechanisms employed by the various Players supported by MA also contribute to the total delay, resulting in a slight but unavoidable latency in the final audio output.
-- The plugin transmits audio using connectionless UDP packets, making network quality a significant factor in performance. Factors such as the use of wired versus wireless connections, packet loss, network latency, and jitter can all affect audio reliability. Because UDP does not support retransmission of lost packets, degraded network conditions may cause interruptions or artifacts in playback.
-- Performance may also be impacted if the VBAN Sender device operates under limited processing power or high system load, as this can delay packet transmission and lead to choppy or inconsistent audio.
-- This plugin exclusively supports the VBAN AUDIO subprotocol type and does not accommodate any other VBAN subprotocols.
+- Expect a small delay between the sound leaving the other computer and coming out of your speakers. Most of it comes from the player at the end rather than from this plugin, so how much you get depends on which speakers you are using. This is not meant for anything where the sound has to line up with a picture
+- Audio sent this way is not resent if any of it goes missing on the way, so the quality of your network matters. A wired connection is far more reliable than wi-fi. On a congested or weak network you may hear dropouts or crackling
+- A sending computer that is slow or busy can also cause the sound to break up
+- Only the audio part of VBAN is supported, not its other functions
 
 ## VBAN Senders
 

--- a/src/content/docs/plugins/yandex-smarthome.md
+++ b/src/content/docs/plugins/yandex-smarthome.md
@@ -35,14 +35,15 @@ Once set up, you can say things like «Alice, pause in the kitchen» or «Alice,
 | «Alice, turn up / turn down on \<name\>» | Volume up / down (±10) |
 | «Alice, set volume to 50 on \<name\>» | Set volume to 50% |
 | «Alice, pause on \<name\>» | Pause |
+| «Alice, mute \<name\>» | Mute, on players that support it |
 | «Alice, next / previous on \<name\>» | Next / previous track |
 | «Alice, switch \<name\> source to \<one…ten\>» | Switch to a source by number. This covers both the player's own sources and any playlists you have set up (see [Starting a playlist by voice](#starting-a-playlist-by-voice)) |
-
-Muting only works on players that support it.
 
 ## Configuration
 
 Go to **Settings → Plugins → Add a Plugin** and add **Yandex Smart Home**. The rest of the setup happens in the plugin's own settings dialog, described below.
+
+The Yandex service behind all of this is <a href="https://yandex.ru/dev/dialogs/smart-home/" target="_blank" rel="noopener noreferrer">Yandex Dialogs Smart Home</a>, which is where any skill you create lives.
 
 There are three ways the plugin can connect. Pick the one that suits your setup:
 

--- a/src/content/docs/plugins/yandex-smarthome.md
+++ b/src/content/docs/plugins/yandex-smarthome.md
@@ -12,7 +12,7 @@ Once set up, you can say things like «Alice, pause in the kitchen» or «Alice,
 > [!CAUTION]
 > This is an unofficial implementation and is not affiliated with or endorsed by Yandex.
 
-> [!WARNING]
+> [!NOTE]
 > **Alice cannot pick a song for you**
 >
 > Yandex does not let outside devices be asked for a particular song or album, so «Alice, play music» only resumes whatever is already queued in Music Assistant.

--- a/src/content/docs/plugins/yandex-smarthome.md
+++ b/src/content/docs/plugins/yandex-smarthome.md
@@ -5,24 +5,26 @@ description: Features and Notes for the Yandex Smart Home Plugin
 
 # Yandex Smart Home
 
-Music Assistant can expose its players to <a href="https://alice.yandex.ru/smart-home" target="_blank" rel="noopener noreferrer">Yandex Smart Home</a>, so they can be controlled by Alice voice assistant as smart home multimedia devices. Contributed and maintained by <a href="https://github.com/trudenboy" target="_blank" rel="noopener noreferrer">Mikhail Nevskiy</a>
+This plugin adds your Music Assistant players to <a href="https://alice.yandex.ru/smart-home" target="_blank" rel="noopener noreferrer">Yandex Smart Home</a> so you can control them by voice with Alice, the same way you would a lamp or a socket. Contributed and maintained by <a href="https://github.com/trudenboy" target="_blank" rel="noopener noreferrer">Mikhail Nevskiy</a>
 
-Cloud connection modes use the <a href="https://yaha-cloud.ru/" target="_blank" rel="noopener noreferrer">yaha-cloud.ru</a> relay.
-The implementation follows the <a href="https://github.com/dext0r/yandex_smart_home" target="_blank" rel="noopener noreferrer">dext0r/yandex_smart_home</a> reference integration.
+Once set up, you can say things like «Alice, pause in the kitchen» or «Alice, set volume to 50 in the kitchen» and Music Assistant will do it. No audio goes through Yandex — this only carries the commands.
 
 > [!CAUTION]
 > This is an unofficial implementation and is not affiliated with or endorsed by Yandex.
 
 > [!WARNING]
-> The Yandex Smart Home API does not support `play_media` for third-party devices, so Alice cannot start an arbitrary song or album by voice through this plugin alone.
-> «Alice, play music» on its own only resumes the current Music Assistant queue. As a workaround, you can pre-pick up to 10 playlists in the plugin settings — they map to fixed `mode(input_source)` slots `one`..`ten`, and Alice triggers them by ordinal: «Alice, switch \<player\> source to **five**». See [Playlists as voice-triggered input sources](#playlists-as-voice-triggered-input-sources).
+> **Alice cannot pick a song for you**
+>
+> Yandex does not let outside devices be asked for a particular song or album, so «Alice, play music» only resumes whatever is already queued in Music Assistant.
+>
+> There is a way round it for playlists: choose up to ten of them in the plugin settings and Alice can start any of them by number — «Alice, switch \<player\> source to **five**». See [Starting a playlist by voice](#starting-a-playlist-by-voice).
 
 ## Features
 
-- Any MA player can be exposed to Yandex Alice for voice control as a smart home media device
-- Automatic creation of the private Yandex Dialogs Smart Home skill for `cloud_plus` and `direct` modes — no manual setup in the Yandex.Dialogs console
-- Pre-picked MA library playlists exposed as `mode(input_source)` slots `one`..`ten`, so Alice can start a specific playlist by ordinal voice command (workaround for the lack of `play_media` in the Yandex Smart Home API)
-- Resumable auto-create flow: transient failures (Device Flow timeout, Yandex moderation 5xx) checkpoint the partial state and the next click resumes from the last completed step
+- Any Music Assistant player can be controlled by voice through Alice
+- For the Cloud Plus and Direct modes, the plugin sets up your private Yandex skill for you, so there is nothing to do by hand on the Yandex developer site
+- Up to ten of your playlists can be started by voice, by number
+- If setting up the skill fails part way through, clicking the button again picks up where it left off rather than starting over
 
 ### Supported voice commands
 
@@ -34,97 +36,81 @@ The implementation follows the <a href="https://github.com/dext0r/yandex_smart_h
 | «Alice, set volume to 50 on \<name\>» | Set volume to 50% |
 | «Alice, pause on \<name\>» | Pause |
 | «Alice, next / previous on \<name\>» | Next / previous track |
-| «Alice, switch \<name\> source to \<one…ten\>» | Select input source by ordinal — covers both the player's native source list and pre-picked playlists (see [Playlists as voice-triggered input sources](#playlists-as-voice-triggered-input-sources)) |
+| «Alice, switch \<name\> source to \<one…ten\>» | Switch to a source by number. This covers both the player's own sources and any playlists you have set up (see [Starting a playlist by voice](#starting-a-playlist-by-voice)) |
 
-### Yandex Smart Home capabilities
-
-| Yandex capability | Mapped MA action | Notes |
-|---|---|---|
-| `on_off` | `play()` / `stop()` | "power on" resumes the current queue, "power off" stops |
-| `range(volume)` | `volume_set()` | Absolute and relative (±) |
-| `toggle(mute)` | `volume_mute()` | Only if the player supports mute |
-| `toggle(pause)` | `play()` / `pause()` | |
-| `range(channel)` | `next_track()` / `previous_track()` | Relative only: +1 = next, -1 = prev |
-| `mode(input_source)` | `select_source()` or `play_media()` (playlist) | Native player sources first, then pre-picked playlists fill the remaining slots up to 10 |
+Muting only works on players that support it.
 
 ## Configuration
 
 Go to **Settings → Plugins → Add a Plugin** and add **Yandex Smart Home**. The rest of the setup happens in the plugin's own settings dialog, described below.
 
-The service this plugin talks to is <a href="https://yandex.ru/dev/dialogs/smart-home/" target="_blank" rel="noopener noreferrer">Yandex Dialogs Smart Home</a>, and it authenticates with a Yandex OAuth token. The plugin exposes players for voice control and does not stream any audio itself.
+There are three ways the plugin can connect. Pick the one that suits your setup:
 
-The plugin supports three connection modes — pick the one that matches your network setup:
+- **Cloud** — the simplest. Everything goes through the shared <a href="https://yaha-cloud.ru/" target="_blank" rel="noopener noreferrer">Yaha Cloud</a> service, so your Music Assistant does not need to be reachable from the internet. Only one thing per Yandex account can use it, so if you already have Yaha Cloud linked to something else such as Home Assistant, use Cloud Plus instead. See [Cloud setup](#cloud-setup).
+- **Cloud Plus** — the same service, but with your own private skill rather than the shared one. Use this if Yaha Cloud is already taken on your account. See [Setting up your skill](#setting-up-your-skill) and then [Cloud Plus setup](#cloud-plus-setup).
+- **Direct** — Yandex talks to your Music Assistant server itself, with nothing in between. Nothing shared, but your server has to be reachable from the internet over HTTPS. See [Setting up your skill](#setting-up-your-skill) and then [Direct setup](#direct-setup).
 
-- **Cloud** — uses the public <a href="https://yaha-cloud.ru/" target="_blank" rel="noopener noreferrer">yaha-cloud.ru</a> skill as a relay. Easiest setup, no public URL required. Only one instance per Yandex account — if Yaha Cloud is already linked (e.g. from Home Assistant), use **Cloud Plus** instead. Follow [Cloud setup](#cloud-setup) below.
-- **Cloud Plus** — uses a private skill via the same relay. Required for multi-integration setups on the same account. Follow [Automatic skill creation](#automatic-skill-creation-cloud-plus--direct) and then [Cloud Plus setup](#cloud-plus-setup) below.
-- **Direct** — Yandex calls your MA server directly over HTTPS. No relay required, but your Music Assistant webserver must be reachable on a public HTTPS URL. Follow [Automatic skill creation](#automatic-skill-creation-cloud-plus--direct) and then [Direct setup](#direct-setup) below.
+### Setting up your skill
 
-### Automatic skill creation (Cloud Plus / Direct)
+Cloud Plus and Direct both need a private skill on Yandex. The plugin creates it for you, so you do not have to go anywhere near the Yandex developer site:
 
-For `cloud_plus` and `direct` modes the plugin creates the private Yandex Dialogs Smart Home skill for you — no copy-paste into the Yandex.Dialogs console is required. The flow:
+1. The plugin asks you to sign in at `ya.ru/device`. A small window opens with a code to confirm.
+2. It then creates the skill on Yandex and sets everything up.
+3. The **Skill ID** field fills in on its own. You still have to fetch the **Skill OAuth Token** yourself, which is a separate step described below.
 
-1. The config form asks you to sign in at `ya.ru/device` via OAuth Device Flow (a short popup with a verification code).
-2. The plugin then drives `dialogs.yandex.ru/developer/app-store-api` end-to-end: create the skill, upload the logo, update the draft, create and attach an OAuth app, and request deploy.
-3. The skill UUID is written back into **Skill ID** automatically. You still need to paste the **Skill OAuth Token** yourself (that flow is separate).
-
-Partial failures are resumable — the action button label flips between *Create…* / *Retry* / *Continue* / *Re-create* based on the current pipeline state, and the plugin persists step-level artifacts so a retry continues from the last completed step rather than starting over. The cached Yandex Passport token is reused on subsequent runs, so you only confirm the Device Code once.
+If any of that fails part way through, just click the button again — it carries on from where it stopped rather than starting over, and you only have to confirm the sign-in code once.
 
 > [!NOTE]
-> Automatic skill creation uses an undocumented Yandex.Dialogs API. If Yandex changes it and auto-create fails, the config form continues to expose manual fields (Skill ID, Skill OAuth Token, Backend URL) so you can finish the setup by hand without leaving Music Assistant settings. The dev-console URL is shown alongside, including a deep-link to the created skill.
+> This relies on part of Yandex that they do not publish or promise to keep stable. If it ever stops working, the Skill ID, Skill OAuth Token and Backend URL fields are still there in the settings so you can fill them in yourself, and a link to the Yandex developer site is shown alongside them.
 
 ### Cloud setup
 
-The simplest mode — no skill creation, no public URL. You register your MA instance against the shared Yaha Cloud skill and link it in the Yandex app with a one-time code:
+Nothing to create, nothing to expose to the internet. You sign your Music Assistant up to the shared Yaha Cloud service and then link it in the Yandex app with a one-off code:
 
-1. Add the **Yandex Smart Home** plugin in Music Assistant settings and select `cloud` as the connection type.
-2. Click **Register with cloud** — the plugin creates an instance on the `yaha-cloud.ru` relay.
-3. Click **Get OTP code** to receive a one-time linking code.
-4. In the Yandex app on your phone: **Devices → Add device → Smart Home**, find **Yaha Cloud** and enter the OTP.
+1. Add the **Yandex Smart Home** plugin in Music Assistant settings and set the connection type to `cloud`.
+2. Click **Register with cloud**.
+3. Click **Get OTP code** to get a one-off linking code.
+4. In the Yandex app on your phone go to **Devices → Add device → Smart Home**, find **Yaha Cloud** and type in the code.
 
 ### Cloud Plus setup
 
-Use this when Yaha Cloud is already linked on your Yandex account (e.g. from Home Assistant) or when you want a private skill on the relay. The config form is split into three numbered steps and walks you through creating a private skill, registering on the relay and linking it in the Yandex app:
+Use this if Yaha Cloud is already linked to something else on your Yandex account, or if you would rather have your own private skill. The settings form takes you through three steps, and each one only appears once you have finished the one before it:
 
-1. **Register with cloud** — creates an instance on the `yaha-cloud.ru` relay.
-2. **Auto-create Smart Home skill** — launches the automatic skill-creation flow described above (Device Flow login + skill creation). On success the **Skill ID** is filled in automatically. Open the OAuth-token URL shown in the form (a pre-filled `oauth.yandex.ru/authorize?...` link), approve access, then copy the resulting `access_token` value into **Skill OAuth Token**.
-3. **Get OTP code + link in Yandex app** — click **Get OTP code**, then in the Yandex app: **Devices → Add device → Smart Home**, find your private skill and enter the OTP.
-
-Each step only appears once the previous one is complete. Later steps are hidden until they're actually relevant.
+1. **Register with cloud** — signs your Music Assistant up to the service.
+2. **Auto-create Smart Home skill** — creates your private skill, as described above. The **Skill ID** fills in on its own. The form then shows a Yandex link — open it, approve access, and copy the long value that comes back into **Skill OAuth Token**.
+3. **Get OTP code + link in Yandex app** — click **Get OTP code**, then in the Yandex app go to **Devices → Add device → Smart Home**, find your own skill and type in the code.
 
 ### Direct setup
 
-No relay involved — Yandex calls your MA server directly, so you need a publicly reachable HTTPS URL. Your MA acts as the skill backend; the plugin still creates the private skill for you and you only need to link the account in the Yandex app at the end:
+Yandex talks to your Music Assistant server itself, so your server has to be reachable from the internet over HTTPS. The plugin still creates the skill for you:
 
-1. Add the **Yandex Smart Home** plugin and select `direct`. Ensure your MA **Base URL** (Settings → Core → Webserver → Base URL) is a publicly reachable HTTPS URL — or set the plugin-local **External Base URL** override to expose only Yandex via a reverse proxy while keeping the global Base URL local.
-2. Click **Auto-create Smart Home skill** — the plugin runs the automatic skill-creation flow (Device Flow login + skill creation) against Yandex.Dialogs using your MA server as the backend. On success the form shows the OAuth-token URL — open it, approve access, then copy the resulting `access_token` value into **Skill OAuth Token** and save.
-3. Link the account in the Yandex app: **Devices → Add device → Smart Home** → select your published skill.
+1. Add the **Yandex Smart Home** plugin and set the connection type to `direct`. Your **Base URL** (Settings → Core → Webserver → Base URL) needs to be an address reachable from the internet over HTTPS. If you would rather keep that pointing at your local address, put the public one in the plugin's own **External Base URL** setting instead — only Yandex will use it.
+2. Click **Auto-create Smart Home skill**. When it finishes, the form shows a Yandex link — open it, approve access, copy the long value that comes back into **Skill OAuth Token** and save.
+3. In the Yandex app go to **Devices → Add device → Smart Home** and pick your skill.
 
 ### Settings
 
-- **Instance Name** — how this MA instance appears in the Yandex Smart Home app. Alice uses this name to address devices.
+- **Instance Name** — the name this Music Assistant is given in the Yandex Smart Home app.
 - **Connection Type** — `cloud`, `cloud_plus`, or `direct` (see above).
-- **External Base URL** — `direct`-mode only. Optional public HTTPS URL override for Yandex callbacks. Lets you keep MA's global Base URL pointing at the local address (so Home Assistant Ingress / local UI keep working) while exposing a public HTTPS URL only to Yandex via a reverse proxy.
-- **Exposed Players** — select which MA players to expose to Alice. Leave empty to expose all players.
-- **Exposed Playlists** — multi-select of playlists from your MA library (any music provider), capped at 10. Each picked playlist becomes a `mode(input_source)` slot `one`..`ten` on every exposed player, in the order you select them. If your MA library is empty when the form opens, save and reopen once your music providers have finished syncing. See [Playlists as voice-triggered input sources](#playlists-as-voice-triggered-input-sources) for the full flow.
-- **Skill ID** and **Skill OAuth Token** — required for `cloud_plus` and `direct` modes. **Skill ID** is filled in automatically after auto-create succeeds; **Skill OAuth Token** is obtained by opening the OAuth URL shown in the form (a pre-filled `oauth.yandex.ru/authorize?...` link tied to the Yandex.Dialogs skill-management OAuth app), approving access, and pasting the resulting `access_token` here.
+- **External Base URL** — for `direct` only. A public HTTPS address for Yandex to use, so your normal Base URL can stay pointing at your local address and your Home Assistant and local web interface keep working as they are.
+- **Exposed Players** — which players Alice can control. Leave it empty for all of them.
+- **Exposed Playlists** — up to ten playlists from your library, from any music source, that Alice can start by number. If the list comes up empty, save and open the settings again once your music sources have finished syncing. See [Starting a playlist by voice](#starting-a-playlist-by-voice).
+- **Skill ID** and **Skill OAuth Token** — needed for `cloud_plus` and `direct`. The Skill ID fills in on its own once the skill has been created. For the token, open the Yandex link shown in the form, approve access, and paste the long value that comes back in here.
 
-### Playlists as voice-triggered input sources
+### Starting a playlist by voice
 
-Because the Yandex Smart Home API has no `play_media` for third-party devices, the plugin uses the `mode(input_source)` capability as a workaround for voice-triggered playlist playback. The mechanism is **ordinal-only**: Alice recognises the fixed mode values `one`, `two`, …, `ten` and there is no way to assign a custom voice phrase to a specific slot — neither in the API nor in the *Home with Alice* app. You need to remember which playlist you put in which slot.
+Alice cannot be asked for a playlist by name, because Yandex only lets outside devices offer a fixed set of sources numbered `one` to `ten`. There is no way to give those numbers your own names, either in the Yandex app or anywhere else. So you pick the playlists in advance and remember which is which.
 
-1. In the plugin settings, pick up to 10 playlists in **Exposed Playlists**. Native player sources keep priority and fill the first slots; playlists fill the remainder up to 10. The order you pick them in **is** the order Alice will address them by ordinal.
-2. Say «Alice, switch \<player\> source to **five**» (or whichever ordinal corresponds to the playlist's slot). The plugin powers the player on if needed and starts the corresponding playlist via `mass.player_queues.play_media`.
+1. In the plugin settings, choose up to ten playlists under **Exposed Playlists**. If the player has sources of its own those come first, and your playlists fill whatever is left up to ten. The order you pick them in is the order Alice will know them by.
+2. Say «Alice, switch \<player\> source to **five**», using whichever number that playlist ended up as. The player switches on if it needs to and the playlist starts.
 
 > [!TIP]
-> Keep your **Exposed Playlists** list short and stable, and use a memorable order (most-used playlist as `one`, second-most as `two`, …). If you reshuffle the multi-select, the ordinals shift with it.
-
-> [!NOTE]
-> Why ordinals only: the Yandex Smart Home API for `mode(input_source)` only accepts a fixed catalogue of values (`one`..`ten`) — `ModeValue` has no `display_name`/`alias`/`synonym` field, and the *Home with Alice* app does not let users rename mode values. This is a Yandex-side constraint, not a plugin limitation.
+> Keep the list short and leave it alone once you are happy with it. Put the playlist you use most first, the next most second, and so on. Reordering the list changes all the numbers.
 
 ## Known Issues / Notes
 
-- `play_media` is not supported by the Yandex Smart Home API for arbitrary songs or albums. The plugin works around this for **playlists** via `mode(input_source)`, but the trigger is ordinal only (`one`..`ten`) — the Yandex app has no UI to alias mode values, and `ModeValue` in the API has no `display_name`/`synonym` field. See [Playlists as voice-triggered input sources](#playlists-as-voice-triggered-input-sources). For free-form voice search-and-play, install the <a href="https://github.com/trudenboy/ma-provider-yandex-alice" target="_blank" rel="noopener noreferrer">Yandex Alice plugin</a>.
-- Seek is not supported by the Yandex Smart Home API for third-party media devices.
-- Track name, artist and artwork cannot be pushed to Yandex — the API does not expose those fields for third-party devices.
-- Direct mode requires a publicly reachable HTTPS endpoint for the MA webserver (via port forwarding, reverse proxy or similar); otherwise use one of the cloud modes.
-- Automatic skill creation uses an undocumented Yandex.Dialogs API; manual fallback fields stay available in the config form if it breaks.
+- Alice cannot be asked for a particular song or album, only for a playlist by number. If you want to ask for music by name, use the <a href="https://github.com/trudenboy/ma-provider-yandex-alice" target="_blank" rel="noopener noreferrer">Yandex Alice plugin</a> instead.
+- Alice cannot skip to a point within a track.
+- The track name, artist and artwork are not passed to Yandex, so they will not show up there.
+- Direct mode needs your Music Assistant server to be reachable from the internet over HTTPS. If it is not, use one of the cloud options.
+- Creating the skill relies on part of Yandex that they do not publish. If it breaks, the settings still let you fill everything in yourself.

--- a/src/content/docs/plugins/yandex-ynison.md
+++ b/src/content/docs/plugins/yandex-ynison.md
@@ -5,9 +5,9 @@ description: Features and Notes for the Yandex Music Connect (Ynison) Plugin
 
 # Yandex Music Connect (Ynison)
 
-Music Assistant can expose its players as playback devices in the official [Yandex Music](https://music.yandex.ru) app via the **Ynison** protocol (Yandex's equivalent of Spotify Connect). Contributed and maintained by [TrudenBoy](https://github.com/TrudenBoy).
+This plugin makes your Music Assistant players show up inside the official [Yandex Music](https://music.yandex.ru) app, in the same list you would pick a speaker from. Choose one there and the music plays on it, the way Spotify Connect works. Contributed and maintained by [TrudenBoy](https://github.com/TrudenBoy).
 
-This plugin depends on the [Yandex Music](/music-providers/yandex-music/) source, which must be configured first — Ynison only handles the player/device side, while audio streaming and quality are driven by the linked Yandex Music provider.
+Set up the [Yandex Music](/music-providers/yandex-music/) source first. This plugin only handles the player side of things — the music itself comes from that source, and so does the sound quality.
 
 > [!CAUTION]
 > This is an unofficial implementation and is not affiliated with or endorsed by Yandex.
@@ -25,8 +25,7 @@ This plugin depends on the [Yandex Music](/music-providers/yandex-music/) source
 |           |                     |
 |:-----------------------|:---------------------:|
 | Exposes MA players to the Yandex Music app | Yes |
-| Protocol | Ynison (JSON over WebSocket) |
-| Maximum Stream Quality | Lossless FLAC (inherited from Yandex Music source) |
+| Maximum Stream Quality | Lossless FLAC (set on the Yandex Music source) |
 | Transport controls | play / pause / seek / next / previous |
 | Radio / My Wave queues | Yes |
 | Multiple instances | Yes |
@@ -51,29 +50,28 @@ This plugin depends on the [Yandex Music](/music-providers/yandex-music/) source
 
 1. In Music Assistant, add the **Yandex Music Connect (Ynison)** plugin from the providers list.
 2. For **Yandex Music source**, either:
-   - select an existing **Yandex Music** instance to borrow its OAuth token (recommended — token refresh stays automatic), or
-   - select **Use own token (manual entry)** and paste a Yandex Music token obtained from [Yandex OAuth](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d).
-3. Select the **Connected Music Assistant Player** that should receive audio when the device is picked in the Yandex Music app. Use `Auto` to prefer a currently playing player.
-4. Save the configuration — the device name from **Device name in Yandex Music** will then appear in the Yandex Music app's playback-target list.
+   - pick your existing **Yandex Music** source, so the plugin can use the sign-in you already have (recommended, and it stays signed in on its own), or
+   - pick **Use own token (manual entry)** and paste a token from [Yandex](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d).
+3. Choose the **Connected Music Assistant Player** that should play the music when this device is picked in the Yandex Music app. `Auto` will use whichever player is already playing.
+4. Save. The name you gave under **Device name in Yandex Music** now appears in the Yandex Music app when you go to choose a speaker.
 
-Multiple plugin instances may be added (one per target player) — each needs its own `mass_player_id`.
+You can add the plugin more than once, one for each player you want to appear in the app.
 
 ### Settings
 
-- **Yandex Music source** — borrow the OAuth token from an existing Yandex Music provider instance, or switch to manual-token entry.
-- **Yandex Music Token** — only shown when not borrowing. Paste an OAuth token manually; note that token refresh is **not** automatic in this mode.
-- **Connected Music Assistant Player** — the MA player that acts as the playback target for this device. `Auto` picks a currently playing player, falling back to the first available one.
-- **Allow manual player switching** — when enabled, selecting this plugin as a source on any MA player switches playback to that player. When disabled, playback is fixed to the configured default player.
-- **Output sample rate** (advanced) — PCM sample rate sent to the MA player. `Auto` selects 44.1 kHz for lossy sources and 48 kHz for lossless. Options: `Auto`, `44100`, `48000`, `96000`.
-- **Output bit depth** (advanced) — PCM bit depth. `Auto` selects 16-bit for lossy sources and 24-bit for lossless. Options: `Auto`, `16`, `24`.
-- **Device name in Yandex Music** (advanced) — how this device appears in the Yandex Music app's playback-target list.
+- **Yandex Music source** — use the sign-in from an existing Yandex Music source, or paste your own token instead.
+- **Yandex Music Token** — only appears if you chose to paste your own. A token entered here will expire and have to be replaced by hand.
+- **Connected Music Assistant Player** — the player that music will come out of. `Auto` picks whichever player is already playing, or the first available one if none is.
+- **Allow manual player switching** — with this on, picking this plugin as the source on any Music Assistant player moves playback to that player. With it off, playback stays on the player set above.
+- **Output sample rate** (advanced) — leave on `Auto` unless you have a reason not to. Options: `Auto`, `44100`, `48000`, `96000`.
+- **Output bit depth** (advanced) — leave on `Auto` unless you have a reason not to. Options: `Auto`, `16`, `24`.
+- **Device name in Yandex Music** (advanced) — the name this device is given in the Yandex Music app.
 
 ## Known Issues / Notes
 
-- The plugin requires a configured [Yandex Music](/music-providers/yandex-music/) source — it cannot stream audio on its own.
-- Manually entered OAuth tokens do not auto-refresh; borrow credentials from a Yandex Music instance to keep tokens refreshed automatically.
-- Playback quality is controlled by the linked Yandex Music source — change the **Audio quality** setting there to switch between lossy and lossless.
-- Yandex controls the queue (passive-player model): Music Assistant signals track completion and waits for the Yandex Music app or Ynison backend to push the next track. The only exception is Radio / My Wave, where the plugin replenishes the queue via the Yandex Music REST API.
-- Ynison connections are long-lived WebSockets; brief reconnects (with exponential backoff) may occur and are handled transparently.
-- Announcements will interrupt the Ynison stream; playback resumes afterwards where supported by the MA player.
-- Only one Yandex account is used per plugin instance; add more instances to target additional players, but each instance still maps to a single Yandex account.
+- A [Yandex Music](/music-providers/yandex-music/) source has to be set up first. This plugin cannot play anything by itself.
+- A token you pasted in yourself will expire. Using the sign-in from a Yandex Music source avoids this.
+- Sound quality is set on the Yandex Music source, under its **Audio quality** setting.
+- The Yandex Music app decides what plays next, not Music Assistant, so the queue lives on the Yandex side. My Wave and radio are the exception, where this plugin keeps the queue topped up itself.
+- Announcements interrupt playback. It picks up again afterwards on players that support it.
+- Each copy of the plugin uses one Yandex account. Add more copies for more players, but they each still use a single account.

--- a/src/content/docs/plugins/yandex-ynison.md
+++ b/src/content/docs/plugins/yandex-ynison.md
@@ -12,7 +12,7 @@ Set up the [Yandex Music](/music-providers/yandex-music/) source first. This plu
 > [!CAUTION]
 > This is an unofficial implementation and is not affiliated with or endorsed by Yandex.
 
-> [!WARNING]
+> [!NOTE]
 > A Yandex Music Plus subscription is required for lossless (FLAC) quality.
 > Without a subscription, playback falls back to the highest quality available for the account.
 

--- a/src/content/docs/plugins/yandex-ynison.md
+++ b/src/content/docs/plugins/yandex-ynison.md
@@ -63,8 +63,8 @@ You can add the plugin more than once, one for each player you want to appear in
 - **Yandex Music Token** — only appears if you chose to paste your own. A token entered here will expire and have to be replaced by hand.
 - **Connected Music Assistant Player** — the player that music will come out of. `Auto` picks whichever player is already playing, or the first available one if none is.
 - **Allow manual player switching** — with this on, picking this plugin as the source on any Music Assistant player moves playback to that player. With it off, playback stays on the player set above.
-- **Output sample rate** (advanced) — leave on `Auto` unless you have a reason not to. Options: `Auto`, `44100`, `48000`, `96000`.
-- **Output bit depth** (advanced) — leave on `Auto` unless you have a reason not to. Options: `Auto`, `16`, `24`.
+- **Output sample rate** (advanced) — `Auto` uses 44.1 kHz for compressed music and 48 kHz for lossless, which suits almost everyone. Options: `Auto`, `44100`, `48000`, `96000`.
+- **Output bit depth** (advanced) — `Auto` uses 16 bit for compressed music and 24 bit for lossless. Options: `Auto`, `16`, `24`.
 - **Device name in Yandex Music** (advanced) — the name this device is given in the Yandex Music app.
 
 ## Known Issues / Notes
@@ -73,5 +73,6 @@ You can add the plugin more than once, one for each player you want to appear in
 - A token you pasted in yourself will expire. Using the sign-in from a Yandex Music source avoids this.
 - Sound quality is set on the Yandex Music source, under its **Audio quality** setting.
 - The Yandex Music app decides what plays next, not Music Assistant, so the queue lives on the Yandex side. My Wave and radio are the exception, where this plugin keeps the queue topped up itself.
+- The connection to Yandex is a long-lived one and will drop and re-establish itself from time to time. This is normal and handled for you.
 - Announcements interrupt playback. It picks up again afterwards on players that support it.
 - Each copy of the plugin uses one Yandex account. Add more copies for more players, but they each still use a single account.


### PR DESCRIPTION
These pages were written from the implementation rather than from what a user needs to do, and several of them restate the same mechanism three times over.

Sendspin: rewrite the opening around what it is for, drop the specification-deviation list in favour of the four things it actually means for a listener, collapse the duplicated discovery and connection sections, and cut the WebSocket URL schemes out of the manual-IP setting.

Yandex Smart Home: delete the capability mapping table, which paired Yandex API strings with internal function names and told a reader nothing. Rewrite the setup flows, the playlist-by-voice section and the notes without the API vocabulary.

Yandex Music, Ynison, KION, Zvuk: drop the upstream library credits from the opening paragraphs, rewrite the token and sign-in steps as steps, and remove notes that describe internals with no user-visible effect. Zvuk no longer prints a JSON response for the reader to parse, and the four-browser guide to viewing JSON goes with it. Fix two typos in the Yandex Music subscription warning.

Alexa: add an opening that says why the setup is this involved, and correct two details against the prototype repository - the secrets files are app_username.txt and app_password.txt, and the service listens on port 5000, not the 3000 given in the API URL example.


Claude-Session: https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [X] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [X] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
