### PR TITLE
Plain English pass over SoundCloud, MSX Bridge, FastMCP, DI.fm and tw…

### DIFF
--- a/src/content/docs/music-providers/digitally-incorporated.md
+++ b/src/content/docs/music-providers/digitally-incorporated.md
@@ -24,32 +24,30 @@ This source connects Music Assistant to your subscription so the channels from t
 | Similar Artists Support                         |            No                      |
 | Similar Tracks Support                          |            No                      | 
 | Maximum Stream Quality | MP3 320kbps |
-| Login Method | API Key |
+| Login Method | Listen Key |
 
 ### Other
 
 - All six networks are available with the one subscription and the provider allows selection of which network(s) are desired to be subscribed to
 - Hundreds of curated radio streams from the six networks are available to browse and search
 - Channel artwork, genre information, and detailed channel descriptions are available
-- The library is populated with the favorite stations marked on the DI network websites. Favorites are **read-only** in Music Assistant — they are added or removed from the settings/favorites panel of any site in the network, and the change is synced into Music Assistant
-
 ### Managing Favorites
 
-- Favorite stations are loaded from each selected network and added to the library
-- Favorites are read-only within Music Assistant. The stations that appear are changed by adding or removing favorites on the website of any network in the DI.fm family
-- Changes made on the website may take a few minutes to appear in Music Assistant, as favorites are cached for 5 minutes
+- Your library is filled with whatever you have marked as a favourite on the network websites
+- Favourites are read-only in Music Assistant. To change which stations appear, add or remove favourites on the website of any network in the DI.fm family
+- A change made on the website takes a few minutes to reach Music Assistant
 
 ## Configuration
 
-- An API key must be added and the desired networks selected in the configuration
+Add your listen key and tick the networks you want.
 
 > [!NOTE]
-> This provider requires a premium subscription and a "listen key" which is retrievable from the settings panel of any of the sites in the network. The key from all sites is identical and subscribing to one provides access to all. The listen key is used both for playback and for loading favorites.
+> This source needs a premium subscription and your **listen key**, which you will find in the settings on any of the network's websites. There is only one key and it is the same on every site, so a subscription to one gets you all six. The same key both plays the stations and fetches your favourites.
 
 ## Known Issues / Notes
 
-- Only one stream at a time from a network is supported. If an attempt is made to play a stream and it stops playing after 30 seconds, this indicates another stream is already playing from the network. Currently playing streaming clients can be found on the settings page of any member in the network
+- You can only listen to one station at a time across the whole network. If a station plays for 30 seconds and then stops, something else is already using your subscription. Any of the network's websites will show you what is currently playing under its settings
 
 ## Not Yet Supported
 
-- More metadata is available in the API but is not yet exposed
+- The networks provide more information about each station than Music Assistant currently shows

--- a/src/content/docs/music-providers/gpodder.md
+++ b/src/content/docs/music-providers/gpodder.md
@@ -51,10 +51,10 @@ To setup this functionality you need:
 - <b>Device ID.</b>
 
 > [!NOTE]
-> The Device ID can be any ASCII string, but keep in mind, that this is used for syncing. Other clients must use the same Device ID
+> The Device ID can be anything you like, as long as it is plain letters and numbers. What matters is that every app you want to keep in step uses exactly the same one.
 
 > [!NOTE]
-> `gpodder.net` is deliberately _not_ supported. The provider relies on frequent API calls, and the service hosted there is known to be either slow or fully unresponsive, which will slow down MA. Consider using a locally hosted alternative.
+> `gpodder.net` is deliberately _not_ supported. This source checks in with the server often, and the service hosted there is known to be either slow or completely unresponsive, which would hold Music Assistant up. Run one of the alternatives yourself instead.
 
 ### nextcloud-gpodder
 The provider supports <a href="https://apps.nextcloud.com/apps/gpoddersync" target="_blank" rel="noopener noreferrer">nextcloud-gpodder/gpoddersync</a>.

--- a/src/content/docs/music-providers/soundcloud.md
+++ b/src/content/docs/music-providers/soundcloud.md
@@ -28,19 +28,17 @@ Connecting your account puts what you have liked and followed on SoundCloud into
 
 ## Configuration
 
-Two fields need to be completed to use this source, Client id and Authorization. To obtain these proceed as follows:
+SoundCloud has no sign-in for outside apps, so two values have to be copied out of your browser while you log in. You need a **Client id** and an **Authorization**.
 
-1. Delete your cookies for Soundcloud.
-2. Go to <a href="https://soundcloud.com" target="_blank" rel="noopener noreferrer">Soundcloud</a>.
-3. Open the `Inspect` tool (F12 on most browsers).
-4. Go to the page `Network` on the inspect terminal.
-5. Login.
-6. Search for `auth`.
-7. In one of the requests you will find the `client_id`
-8. And for the OAuth token we need the `oauth_token` cookie on the soundcloud.com domain prepended with "OAuth "
+1. Clear your SoundCloud cookies, so that logging in again produces the requests you need to see
+2. Go to <a href="https://soundcloud.com" target="_blank" rel="noopener noreferrer">SoundCloud</a> but do not log in yet
+3. Press F12 to open your browser's developer tools, and go to the **Network** tab
+4. Now log in. A long list of entries will appear
+5. Type `auth` in the filter box to narrow the list down
+6. Look through those entries for `client_id`. It is a run of 32 letters and numbers. Copy it
+7. Now find the `oauth_token` cookie for soundcloud.com and copy its value. In Music Assistant this goes in the **Authorization** field with `OAuth ` typed in front of it, including the space
 
-`client_id`: string of 32 bytes alphanumeric
-`oauth_token`: string inside the cookie value
+The screenshots below show where each of these appears.
 
 ### Client id
 <img src="/assets/screenshots/soundcloud-clientid.jpg" alt="screenshot" style="width: 1005px; float: center;"  loading="lazy" />
@@ -48,7 +46,7 @@ Two fields need to be completed to use this source, Client id and Authorization.
 ### OAuth token
 <img src="/assets/screenshots/soundcloud-token.jpg" alt="screenshot" style="width: 1005px; float: center;"  loading="lazy" />
 
-Example snippet for the Music Source configuration step (OAuth and client_id are NOT real, use yours):
+Filled in, the two fields should look like this. These values are made up — use your own:
 
 ```
 client_id = 5Hvc9wa0Ejf092wj3f3920w3F920asuL
@@ -56,5 +54,4 @@ Authorization = OAuth 2-26432-21446-asdif2309fQ
 ```
 ## Known Issues / Notes
 
-- Artists synced from Soundcloud are actually Soundcloud users.
-- If a song by artist X is uploaded by user Y, this song belongs to the artist Y in Music Assistant
+- What SoundCloud calls an artist is really whoever holds the account, so that is what appears as the artist in Music Assistant. If someone else uploads a track by an artist, it will be filed under the uploader rather than under the artist

--- a/src/content/docs/player-support/msx-bridge.md
+++ b/src/content/docs/player-support/msx-bridge.md
@@ -16,14 +16,14 @@ Music Assistant has support for streaming music to Smart TVs via the <a href="ht
 
 ## Features
 
-- **Dynamic player registration**: Each TV is automatically registered as a player when it connects — no manual setup required
-- **Multi-TV support**: Multiple TVs can play simultaneously, each with independent control
-- **Library browsing on TV**: Browse albums, artists, playlists, and tracks directly on the TV screen via MSX native UI
-- **Search**: Full-text search through the Music Assistant library from the TV
-- **WebSocket push notifications**: Bidirectional real-time communication between MA and the TV (play, pause, resume, stop, seek, position reporting)
-- **Player grouping** *(experimental)*: Group multiple MSX TVs to play the same track simultaneously
-- **Browser web player**: Access the provider via any web browser at `http://<ma-ip>:8099/web`
-- **Idle timeout cleanup**: Inactive players are automatically unregistered after a configurable timeout
+- **Nothing to set up**: each TV appears as a player as soon as it connects
+- **More than one TV**: several can play at once, each controlled separately
+- **Browse on the TV**: albums, artists, playlists and tracks, on the screen
+- **Search**: search your whole Music Assistant library from the TV
+- **Control from either end**: play, pause, stop and skip work from Music Assistant or from the TV, and each keeps up with what the other is doing
+- **Player grouping** *(experimental)*: play the same track on several TVs at once
+- **In a browser too**: open `http://<ma-ip>:8099/web` on any computer
+- **Tidies up after itself**: a TV that has been left alone for a while drops off the player list, and comes back when you use it again
 - **Player removal**: Players can be manually removed from the MA UI
 
 ## Requirements
@@ -61,20 +61,20 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - **Player Idle Timeout (minutes)**. Automatically unregister MSX players after this many minutes of inactivity. Default: `30`
 - **Show notification before closing player**. Show a confirmation dialog on the TV when stopping playback from MA. Default: off
 - **Enable player grouping (experimental)**. Allow grouping multiple MSX TVs to play the same track simultaneously. Default: off
-- **Group Stream Mode**. How to stream audio to grouped players. `Independent` (default) creates a separate stream per TV. `Shared Buffer` uses one ffmpeg process for all group members (less CPU, better sync)
+- **Group Stream Mode**. How audio is sent to grouped TVs. `Independent` (default) sends each TV its own copy. `Shared Buffer` prepares the audio once and sends the same thing to all of them, which is easier on your server and keeps the TVs better in step
 
 ## How It Works
 
-1. The provider runs an embedded HTTP server (default port 8099) inside Music Assistant
-2. The MSX app on the TV connects to this server and loads a native JSON-based UI for browsing the MA library
-3. When a track is played, the TV requests the audio stream from the provider, which fetches audio from MA, encodes it via ffmpeg, and streams it to the TV
-4. A WebSocket connection provides real-time bidirectional control: MA can send play/pause/stop/seek commands to the TV, and the TV reports playback position back to MA
-5. The status dashboard is available at `http://<ma-ip>:8099/`
+Music Assistant runs a small web server of its own on port 8099. The MSX app on your TV connects to it, and that is what draws the browsing screens you see on the TV. When you play something, the TV asks for the audio and Music Assistant converts it to a format the TV can handle as it sends it.
+
+The connection stays open both ways, so buttons pressed in Music Assistant reach the TV and the TV keeps Music Assistant up to date with where it has got to in the track.
+
+You can check on all of this at `http://<ma-ip>:8099/`.
 
 ## Known Issues / Notes
 
-- **Audio format**: MP3 is the most compatible format across all TV platforms. AAC offers slightly better quality at the same bitrate. FLAC is lossless but Content-Length cannot be determined in advance, which may cause issues on some TVs
-- **Player grouping**: This is experimental. The `Shared Buffer` mode provides better synchronization between TVs but requires all grouped TVs to use the same audio format
-- **Network**: The TV and MA server must be on the same local network. There is no remote/cloud access support
-- **Idle timeout**: If a TV is powered off or the MSX app is closed, the player will be automatically removed after the configured idle timeout (default 30 minutes). It will reappear when the TV reconnects
-- Crossfade is not supported — MSX uses its native media player which does not support crossfading between tracks
+- **Audio format**: MP3 works on every TV, which is why it is the default. AAC sounds slightly better for the same file size. FLAC is lossless, but Music Assistant cannot tell the TV in advance how long the audio will be, and some TVs do not cope with that
+- **Player grouping**: This is experimental. `Shared Buffer` keeps the TVs better in step, but every TV in the group has to be set to the same audio format
+- **Network**: The TV and Music Assistant have to be on the same network. There is no way to reach a TV from outside your home
+- **Idle timeout**: If a TV is switched off or the MSX app is closed, it disappears from the player list after the idle timeout, 30 minutes by default. It comes back as soon as the TV connects again
+- Crossfade is not supported, because the TV does its own playing and cannot fade one track into the next

--- a/src/content/docs/plugins/fastmcp-server.md
+++ b/src/content/docs/plugins/fastmcp-server.md
@@ -15,7 +15,7 @@ Music Assistant has the ability to expose its library, queue, playback and playe
 - Any MCP-aware AI client can connect to your Music Assistant library through a single URL
 - One-click Connect Wizard with ready-to-paste configuration for Claude Desktop, Claude Code, Cursor, Windsurf, VSCode, ChatGPT Connectors, Codex CLI, Gemini CLI, Cline, Zed, OpenClaw and Hermes
 - Each connected client gets its own access token, revocable individually under Profile → Long-lived access tokens
-- Fine-grained permission toggles let you decide what each connected AI client may do — browse the library, control playback, manage queues, edit playlists, remove favourites, and choose which URI-addressable resources the client can see
+- Detailed permission toggles let you decide what each connected AI client may do — browse the library, control playback, manage queues, edit playlists, remove favourites, and how much of your library it can see at all
 - Two optional, off-by-default capability namespaces for power users: a **debug** namespace (introspection for troubleshooting) and a **config** namespace (view and edit Music Assistant settings over MCP)
 - Optional confirmation prompt before destructive actions like clearing a queue or removing a track from the library
 - Reuses the Music Assistant webserver — no extra port to open, works behind reverse proxies and Home Assistant ingress out of the box
@@ -23,7 +23,7 @@ Music Assistant has the ability to expose its library, queue, playback and playe
 
 ## Configuration
 
-The plugin is single-instance. Add it via `SETTINGS >> PLUGINS >> ADD A PLUGIN`.
+Add the plugin via `SETTINGS >> PLUGINS >> ADD A PLUGIN`. You only ever need one copy of it, however many AI clients you connect.
 
 ### Connecting an AI client
 
@@ -31,12 +31,12 @@ Once the plugin has been added, the Connect Wizard becomes available from the pl
 
 1. Open the plugin settings and click **Open Connect Wizard**.
 2. Pick your AI client from the list.
-3. The wizard mints a long-lived token, names it after the client (for example `MCP — Claude Desktop`), and shows a ready-to-paste configuration snippet.
-4. Paste the snippet into your client's MCP configuration, or — for Cursor — click the **Add to Cursor** deep-link.
+3. The wizard creates an access token, names it after the client (for example `MCP — Claude Desktop`), and shows you a block of configuration ready to copy.
+4. Paste it into your client's MCP configuration, or for Cursor click the **Add to Cursor** link.
 
-Regenerating the snippet for a client revokes the previous token for that same client, so stale credentials are never left behind.
+Generating the block again for the same client cancels its previous token, so old credentials are never left lying around.
 
-For multi-agent orchestrators the wizard emits the native form for each: an `openclaw mcp set …` command for OpenClaw and a `~/.hermes/config.yaml` block for Hermes. Both point at the same streamable-HTTP endpoint with the minted bearer token, exactly like every other client.
+For OpenClaw and Hermes the wizard gives you the form each of those expects — an `openclaw mcp set …` command and a `~/.hermes/config.yaml` block. Both connect the same way as everything else.
 
 ### Settings
 
@@ -48,8 +48,8 @@ For multi-agent orchestrators the wizard emits the native form for each: an `ope
 
 Both namespaces ship entirely off by default — a standard installation exposes no debug or config tools at all. Enable a toggle only for the capability you need, and prefer leaving them off in production.
 
-- <b>Debug.</b> Five toggles (`Debug: inspect`, `Debug: logs`, `Debug: events`, `Debug: providers`, `Debug: reload`) expose read-mostly introspection for troubleshooting a running instance over MCP: raw player/queue/provider state, a tail of `musicassistant.log` (with common secrets redacted), a bounded ring buffer of recent events, a provider/health roll-up, and — gated separately — reloading a provider instance. The event buffer's capacity is configurable in the ADVANCED section.
-- <b>Config.</b> Five toggles (`Config: read settings`, `Config: edit provider settings`, `Config: edit core settings`, `Config: edit player settings`, and `Config: allow writing secret values`) let a client view and edit Music Assistant core, provider and player configuration over MCP. Reads mask `SECURE_STRING` values; writes are validated and delegated to Music Assistant's own atomic save (validate → encrypt → persist → reload, with rollback), so the plugin never hand-rolls persistence. Writing a secret value requires the dedicated secret flag in addition to the relevant category flag.
+- <b>Debug.</b> Five toggles (`Debug: inspect`, `Debug: logs`, `Debug: events`, `Debug: providers`, `Debug: reload`) let a client help you troubleshoot a running Music Assistant: the current state of your players, queues and providers, the end of the log file with passwords and the like blanked out, a list of what has happened recently, a summary of provider health, and — switched on separately — restarting a provider. How much recent activity is kept can be set in the ADVANCED section.
+- <b>Config.</b> Five toggles (`Config: read settings`, `Config: edit provider settings`, `Config: edit core settings`, `Config: edit player settings`, and `Config: allow writing secret values`) let a client look at and change your Music Assistant settings. Passwords and tokens are hidden when read, and changing one needs the separate secret toggle switched on as well as the toggle for that group of settings. Changes go through the same checks as if you had made them yourself, and are undone if anything goes wrong.
 
 In the ADVANCED section:
 
@@ -57,7 +57,7 @@ In the ADVANCED section:
 - <b>Enforce token audience (RFC 8707).</b> Rejects tokens that are not bound to this MCP server's URL. Leave off until Music Assistant issues audience-bound tokens by default.
 - <b>Additional allowed Origins (CSV).</b> Comma-separated list of additional Origin headers to accept, on top of the Music Assistant hosts that are auto-detected.
 - <b>Connect Wizard external URL (fallback).</b> Explicit base URL the Connect Wizard should use in the generated snippets. Only needed when the wizard cannot detect the public URL from the active client's request headers.
-- <b>Debug: event buffer capacity.</b> Maximum number of recent events kept in memory when the `Debug: events` toggle is enabled. Older events are dropped FIFO; has no effect when events are off.
+- <b>Debug: event buffer capacity.</b> How many recent events to keep when `Debug: events` is on. Once the limit is reached the oldest are discarded. Has no effect when events are off.
 
 ## Known Issues / Notes
 

--- a/src/content/docs/plugins/lastfm_scrobble.md
+++ b/src/content/docs/plugins/lastfm_scrobble.md
@@ -28,9 +28,9 @@ For LibreFM, or to use your own LastFM API application, open the advanced settin
 ### Settings
 
 - <b>Provider.</b> Select `Last.FM` for LastFM scrobbling or `LibreFM` for LibreFM scrobbling
-- <b>API Key.</b> Advanced setting to override the built-in LastFM API key. Required for LibreFM
-- <b>Shared secret.</b> Advanced setting to override the built-in LastFM shared secret. Required for LibreFM
-- <b>Suffix version to track names.</b> This adds the version, as stored in the Music Assistant database, to the end of the track name when it is sent to Last.fm. This may be useful if Musicbrainz IDs are not available to disambiguate same named tracks from an artist
+- <b>API Key.</b> Advanced setting, only needed for LibreFM or if you would rather use your own Last.fm application
+- <b>Shared secret.</b> As above, and required for LibreFM
+- <b>Suffix version to track names.</b> Adds the version of the track, such as a remix or live version, to the end of its name when it is sent to Last.fm. Worth turning on if an artist has several different tracks with the same name and they are being counted together
 - <b>Scrobble for users.</b> This allows selection of which logged-in user will be scrobbled by this plugin. Multiple instances of this plugin can be added
 - <b>Scrobble for players.</b> This allows selection of which players will register scrobbles
 


### PR DESCRIPTION
…o smaller pages

SoundCloud: the two lines describing what to copy said only 'string of 32 bytes alphanumeric' and 'string inside the cookie value'. Rewrite the whole extraction as steps that say where to look and what to expect, and say up front why the cookies need clearing first. State the artist caveat once instead of as two half-overlapping bullets.

MSX Bridge: turn the feature list from a list of mechanisms into a list of things the TV can do, and rewrite How It Works as prose without the JSON UI, the ffmpeg call and the WebSocket. Explain the FLAC caveat by its cause rather than by naming Content-Length.

FastMCP: this page's readers are configuring AI clients, so the MCP vocabulary stays. Trimmed only what nothing follows from - the ring buffer, the FIFO eviction, the atomic-save sequence, SECURE_STRING, 'URI-addressable resources' and 'streamable-HTTP endpoint with the minted bearer token'.

DI.fm: the key was called an API key in the Features table and the Configuration line, and a listen key in the note below them. Settled on listen key, which is what the websites call it. Folded the duplicated favourites bullet into the section that already covered it.

gPodder and LastFM Scrobbler: small wording fixes only.


Claude-Session: https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [X] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [X] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
