### PR TITLE
Note that the HA integration needs an admin account when signing in

### DIFF
--- a/src/content/docs/integration/installation.md
+++ b/src/content/docs/integration/installation.md
@@ -15,6 +15,9 @@ The Integration to connect Music Assistant to Home Assistant is available as an 
 - If for some reason you need to add the integration manually then go to HA SETTINGS >> DEVICES & SERVICES >> INTEGRATIONS and click the big `+ ADD INTEGRATION` button. Search for Music Assistant and click to add it. You will need to add the server IP and port (usually 8095). This is the local network address of the machine running Music Assistant, for example `192.168.1.27`. If unsure, search for the `Starting server on ...` line in the server logs. Note: if MA is running as a Home Assistant App, the logs may show an internal address such as `172.30.32.1`. In that case use the normal network IP address of your Home Assistant machine instead.
 - Click SUBMIT and the Music Assistant integration is ready for use.
 
+> [!IMPORTANT]
+> When the integration asks you to log in to Music Assistant (this happens when MA does not run as a Home Assistant App), sign in with an **admin** account. The integration keeps using that account for everything it does, and some actions - such as `music_assistant.play_media` resolving which user started the playback - are only available to admins. Signing in with a regular user account leads to permission errors later on.
+
 > [!NOTE]
 > The HA integration will create new media_player entities for those player types which are supported natively by MA. To see the names of those players go to `HA SETTINGS >>  DEVICES & SERVICES >> INTEGRATIONS >> MUSIC ASSISTANT` and view the entities. It is these players that need to be targeted in automations and scripts
 


### PR DESCRIPTION
When Music Assistant does not run as a Home Assistant App, the Home Assistant integration asks you to sign in and then keeps using that account for everything it does. Some actions are admin-only, so signing in with a regular user account causes permission errors later on - most visibly `music_assistant.play_media`, which resolves which user started the playback.

- Add a note to the integration installation page to sign in with an admin account.

Related: https://github.com/music-assistant/server/pull/5410