### PR TITLE
State the country tag rule plainly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,13 +125,13 @@ Four things, and the build will tell you if you miss the last one.
 
 ### Country categories
 
-**These are about the language people will hear, not where the company is registered.** Tag a
-source with a country when most of what it carries is in that country's language. Deezer and
-Qobuz are both French companies, but their catalogues are international, so neither is tagged
-France. Sveriges Radio broadcasts in Swedish, so it is tagged Sweden.
+**Tag a country only when the source's content is predominantly or only from that country.** Not
+where the company is registered, and not where it sells. Deezer and Qobuz are French companies
+with international catalogues, so neither is tagged France. Sveriges Radio broadcasts in Swedish,
+so it is tagged Sweden.
 
-One source can carry more than one language. Storytel is tagged both Sweden and Denmark, because
-it is sold in Denmark as Mofibo with a full Danish catalogue.
+This is why the large international services carry no country tag at all. A source can be tagged
+with more than one country where that genuinely holds.
 
 **If the language you need is not on the list, add it.** Three small pieces, in
 `src/data/music-sources.ts` unless stated:


### PR DESCRIPTION
Tag a country only when the content is predominantly or only from that country. Not company registration, not where the service sells.

The old wording turned on the language of the content, which did not explain why an international service with a local catalogue in each market stays untagged.

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [X] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [X] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
