### PR TITLE
Trim four things from the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,6 @@ document something readers cannot use.
 If you are not sure, open it against `beta` and say so. Moving a pull request to the other branch
 afterwards is one click for a maintainer.
 
-One thing to watch on `beta`: if your branch was taken before the last release it will be missing
-files the build now expects, and you will get errors that have nothing to do with your change. If
-that happens, say so on the pull request and a maintainer will bring your branch up to date.
-
 ## Checking your change
 
 You do not need to install anything or build the site yourself. Open the pull request and the
@@ -71,11 +67,10 @@ Four things, and the build will tell you if you miss the last one.
 > than Yes or No. Wording after the answer, like `Yes (with limitations)`, becomes a footnote
 > under the comparison rather than being lost.
 >
-> Two things there cannot be read from a page, and live in `src/data/music-summary.ts`. If a
-> source has genuinely nothing to compare — no subscription, no login, no stream quality of its
-> own — its slug goes in `EXCLUDED`. And if `Maximum Stream Quality` does not say whether it is
-> Hi-Res, CD or lossy, the build asks you to settle it in `QUALITY_TIER_OVERRIDES` rather than
-> guessing.
+> Two things there cannot be read from a page, and live in `src/data/music-summary.ts`. To keep a
+> source out of the comparison, put its slug in `EXCLUDED`; it still gets a tile. And if
+> `Maximum Stream Quality` does not say whether it is Hi-Res, CD or lossy, the build asks you to
+> settle it in `QUALITY_TIER_OVERRIDES` rather than guessing.
 
 1. **The page**, at `src/content/docs/music-providers/<slug>.md`. Copy an existing page and work
    from that. Structure is covered under [House style](#house-style) below.
@@ -118,7 +113,7 @@ Four things, and the build will tell you if you miss the last one.
    for recordings of live shows, `classical` for orchestral, chamber and operatic music, and
    `children` for audio aimed at younger listeners.
 
-   Last are the country categories, covered just below. These are the ones people forget.
+   Last are the country categories, covered just below.
 
    The full list of valid categories is at the top of `src/data/music-sources.ts`, and the build
    lists them if you use one that does not exist.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,9 @@ with more than one country where that genuinely holds.
    every national flag is available as an SVG, or from the MIT licensed
    [flag-icons](https://flagicons.lipis.dev/) set. Prefer a plain one over a highly detailed
    version: the existing flags are a few hundred bytes each and are only shown about 34 pixels
-   tall. Any aspect ratio is fine and the page draws the border for you.
+   tall. Keep it a similar shape to the ones already there, which are all wider than they are
+   tall and mostly close to 3:2. Check it looks right against its neighbours on the built
+   page rather than measuring it; the page draws the border for you.
 
 Then tag your source with it. The build fails if the flag file is missing, and also if a category
 exists that no source uses, so all three have to land together.


### PR DESCRIPTION
## What does this change?

Four edits to `CONTRIBUTING.md`, no other files touched.

- Removed the paragraph warning that a branch taken before the last release will be missing files the build expects.
- Removed "These are the ones people forget." from the country categories step.
- Simplified the `EXCLUDED` sentence. It described the circumstances under which you might want a source left out of the comparison rather than saying what the list does. It now reads: "To keep a source out of the comparison, put its slug in `EXCLUDED`; it still gets a tile."
- Replaced "Any aspect ratio is fine" in the flag guidance. The flags sit in a row together, so a square or tall one looks out of place next to the rest, which run from about 1.3 to 2.0 and cluster at 3:2. It now asks for a similar shape and for a look at the built page rather than a measurement.

The first, second and fourth also apply to `main` and are in a companion pull request. The `EXCLUDED` change is `beta` only, since the comparison table it describes is not on `main` yet.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

Not applicable, no source or provider added.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL)_