### PR TITLE
Add the new iOS mobile-app id

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -5,6 +5,10 @@
       {
         "appID": "5J5R9QK64D.io.music-assistant.client",
         "paths": ["/app/*"]
+      },
+      {
+        "appID": "GUYFAK8DC6.io.music-assistant.mobile-client",
+        "paths": ["/app/*"]
       }
     ]
   }


### PR DESCRIPTION
## What does this change?

This adds the new iOS mobile app's id to the apple app site association file. We can remove the old iOS mobile-app id once that test flight has been fully closed down.

## Checklist

- [X] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
