### PR TITLE
Add beta docs for the MilkDrop visualizer plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -225,6 +225,10 @@ export default defineConfig({
                   label: "Listenbrainz Scrobbler",
                   slug: "plugins/listenbrainz_scrobble",
                 },
+                {
+                  label: "MilkDrop Visualizer",
+                  slug: "plugins/milkdrop-visualizer",
+                },
                 { label: "Music Quiz", slug: "plugins/music-quiz" },
                 {
                   label: "OpenAI Compatible",

--- a/src/content/docs/plugins/milkdrop-visualizer.md
+++ b/src/content/docs/plugins/milkdrop-visualizer.md
@@ -1,0 +1,46 @@
+---
+title: MilkDrop Visualizer Plugin
+description: Render a MilkDrop (Butterchurn) music visualizer behind the now-playing views, reacting live to the audio.
+---
+
+# MilkDrop Visualizer Plugin
+
+This plugin renders a <a href="https://github.com/jberg/butterchurn" target="_blank" rel="noopener noreferrer">Butterchurn</a> (MilkDrop 2) music visualizer behind the now-playing views in the Music Assistant web interface, reacting live to whatever is playing. It replaces the usual gradient background with animated visuals driven by the actual audio.
+
+> [!CAUTION]
+> This plugin is marked experimental. Functionality may change and bugs may occur.
+
+## Features
+
+- A full-screen visualizer behind the fullscreen player, the now-playing dashboard, and the party screen
+- The complete Butterchurn preset library, with favourites and random or fixed preset selection
+- Optional preset switching on the beat, using Music Assistant's beat analysis
+- Per-user controls for blur, opacity and render quality
+- Reacts to the audio of whichever player you are viewing, in time with playback
+
+## Configuration
+
+- The visualizer follows a [Sendspin](/player-support/sendspin/) player, so you need at least one. Sendspin is built into Music Assistant, and the web player in your browser is one
+- In Music Assistant, go to `SETTINGS >> PLUGINS >> ADD A PLUGIN` and select `MILKDROP VISUALIZER`
+- Once enabled, a `MilkDrop` entry appears in the sidebar leading to its settings page, and a droplet toggle appears in the fullscreen player menu
+- Turn the visualizer on from the player menu (or the party screen), play something on a Sendspin player, and the visuals appear behind the now-playing view
+
+### Settings
+
+- <b>Render quality.</b> Low / Medium / High / Native. Higher tiers render sharper visuals at more GPU and CPU cost. Use a lower tier on tablets and TVs. Default `High`.
+- <b>Preset selection.</b> How the visualizer chooses a preset:
+    - <b>Random from all presets</b> - picks from the whole library.
+    - <b>Random from favourites</b> - picks only from presets you have starred.
+    - <b>Fixed preset</b> - always shows the one you choose.
+- <b>Switch preset on downbeat.</b> Automatically change preset on a downbeat, using Music Assistant's beat analysis. Takes precedence over a fixed preset.
+- <b>Minimum time between switches.</b> How long a preset stays on screen before a downbeat may switch it.
+- <b>Blur</b> and <b>opacity</b> are adjusted per user from the visualizer menu in the fullscreen player.
+
+Favourite the preset currently showing with the star next to the preset picker in the fullscreen player.
+
+## Known Issues / Notes
+
+- The visualizer requires a browser with WebGL2. Displays that lack it keep their normal background rather than showing the visualizer
+- Google Cast receivers do not support WebGL, so casting a dashboard to a Chromecast keeps the normal background. To run the visualizer on a TV, open a now-playing dashboard in the TV's own browser or a kiosk browser app
+- Beat-driven preset switching uses the track's beat analysis from the [Smart Fades](/audio-analysis/smart-fades) provider when available; it may be unavailable until the analysis has been computed, or on lower-powered devices
+- Butterchurn is the WebGL implementation of MilkDrop 2, originally created by Ryan Geiss; the presets are the work of the MilkDrop preset community

--- a/src/content/docs/plugins/milkdrop-visualizer.md
+++ b/src/content/docs/plugins/milkdrop-visualizer.md
@@ -43,7 +43,3 @@ Favourite the preset currently showing with the star next to the preset picker i
 - If the normal background still shows after enabling this plugin, your browser is likely too old to run the visualizer; try a current one. (You can check yours at <a href="https://get.webgl.org/webgl2/" target="_blank" rel="noopener noreferrer">get.webgl.org/webgl2</a>.)
 - Google Cast receivers do not support this plugin, so casting a dashboard to a Chromecast keeps the normal background. To run the visualizer on a TV, open a now-playing dashboard in the TV's own browser or a kiosk browser app
 - Beat-driven preset switching uses the track's beat analysis from the [Smart Fades](/audio-analysis/smart-fades) provider when available; it may be unavailable until the analysis has been computed, or on lower-powered devices
-
----
-
-Rendering by Butterchurn, the WebGL implementation of MilkDrop 2 originally created by Ryan Geiss. Presets are the work of the MilkDrop preset community.

--- a/src/content/docs/plugins/milkdrop-visualizer.md
+++ b/src/content/docs/plugins/milkdrop-visualizer.md
@@ -1,9 +1,9 @@
 ---
-title: MilkDrop Visualizer Plugin
+title: MilkDrop Visualizer
 description: Render a MilkDrop (Butterchurn) music visualizer behind the now-playing views, reacting live to the audio.
 ---
 
-# MilkDrop Visualizer Plugin
+# MilkDrop Visualizer
 
 This plugin renders a <a href="https://github.com/jberg/butterchurn" target="_blank" rel="noopener noreferrer">Butterchurn</a> (MilkDrop 2) music visualizer behind the now-playing views in the Music Assistant web interface, reacting live to whatever is playing. It replaces the usual gradient background with animated visuals driven by the actual audio.
 
@@ -40,7 +40,10 @@ Favourite the preset currently showing with the star next to the preset picker i
 
 ## Known Issues / Notes
 
-- The visualizer requires a browser with WebGL2. Displays that lack it keep their normal background rather than showing the visualizer
-- Google Cast receivers do not support WebGL, so casting a dashboard to a Chromecast keeps the normal background. To run the visualizer on a TV, open a now-playing dashboard in the TV's own browser or a kiosk browser app
+- If the normal background still shows after enabling this plugin, your browser is likely too old to run the visualizer; try a current one. (You can check yours at <a href="https://get.webgl.org/webgl2/" target="_blank" rel="noopener noreferrer">get.webgl.org/webgl2</a>.)
+- Google Cast receivers do not support this plugin, so casting a dashboard to a Chromecast keeps the normal background. To run the visualizer on a TV, open a now-playing dashboard in the TV's own browser or a kiosk browser app
 - Beat-driven preset switching uses the track's beat analysis from the [Smart Fades](/audio-analysis/smart-fades) provider when available; it may be unavailable until the analysis has been computed, or on lower-powered devices
-- Butterchurn is the WebGL implementation of MilkDrop 2, originally created by Ryan Geiss; the presets are the work of the MilkDrop preset community
+
+---
+
+Rendering by Butterchurn, the WebGL implementation of MilkDrop 2 originally created by Ryan Geiss. Presets are the work of the MilkDrop preset community.


### PR DESCRIPTION
<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->
Adds documentation for the proposed MilkDrop plugin provider

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
