### PR TITLE
Redirect automatically after signing in to a music service

### DIFF
--- a/public/callback/index.html
+++ b/public/callback/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Music Assistant oAuth Redirect</title>
+    <title>Music Assistant</title>
     <style>
         body {
             font-family: Arial, sans-serif;
             display: flex;
             justify-content: center;
             align-items: center;
-            height: 100vh;
+            min-height: 100vh;
             margin: 0;
             background-color: #f0f0f0;
         }
@@ -18,16 +18,18 @@
             text-align: center;
             background-color: white;
             padding: 2rem;
+            margin: 1rem;
+            max-width: 30rem;
             border-radius: 8px;
             box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
         }
-        #manual-link, #error {
-            display: none;
+        .fallback {
             margin-top: 1rem;
         }
         a {
             color: #1DB954;
             text-decoration: none;
+            font-weight: bold;
         }
         a:hover {
             text-decoration: underline;
@@ -36,54 +38,60 @@
 </head>
 <body>
     <div class="container">
-        <h1>Music Assistant oAuth Redirect</h1>
-        <p>Processing your request...</p>
-        <div id="manual-link">
-            <p>If you are not redirected automatically, please click the link below:</p>
-            <a href="#" id="redirect-link">Complete Authentication</a>
+        <h1>Music Assistant</h1>
+        <p id="status"></p>
+        <div class="fallback" id="manual-link" hidden>
+            <a href="#" id="redirect-link">Continue to Music Assistant</a>
         </div>
-        <div id="error">
+        <div class="fallback" id="error" hidden>
             <p>This page was opened without a valid Music Assistant address to return to,
                so the sign-in cannot be completed. Close this window and start the sign-in
                again from within Music Assistant.</p>
         </div>
+        <noscript>
+            <p class="fallback">JavaScript is required to complete the sign-in.
+               Enable it and start the sign-in again from within Music Assistant.</p>
+        </noscript>
     </div>
-
-  <footer>
 
     <script>
       'use strict';
-      // Music providers only allow pre-registered redirect URIs, so they all send the
-      // browser here. The Music Assistant instance that started the sign-in passes its
-      // own (session specific) callback URL along in `state`: forward everything the
-      // provider returned - the authorization code, or an error - to that URL.
-      const signInHosts = ['spotify.com', 'google.com', 'microsoftonline.com', 'live.com'];
-      const urlParams = new URLSearchParams(window.location.search);
-      const redirectUrl = urlParams.get('state') || '';
-      urlParams.delete('state');
-      const query = urlParams.toString();
-      const finalUrl = query ? redirectUrl + '?' + query : redirectUrl;
-      const referrerHost = document.referrer ? new URL(document.referrer).hostname : '';
-      const validOrigin = signInHosts.some(
-        (host) => referrerHost === host || referrerHost.endsWith('.' + host),
-      );
-      // only forward to something shaped like a Music Assistant callback URL, and never
-      // to a Home Assistant ingress URL (which needs the ingress session to be reachable)
-      const validDest =
-        /^https?:\/\/[^/?#@\s]+\/(?:[^?#\s]*\/)?callback\/[A-Za-z0-9_.-]+$/.test(redirectUrl) &&
-        !redirectUrl.includes('hassio_ingress');
-      if (!validDest) {
-        document.getElementById('error').style.display = 'block';
+      // OAuth providers only accept pre-registered redirect URIs, so Spotify, Google and
+      // Microsoft all send the browser here. The Music Assistant instance that started the
+      // sign-in passes its own (session specific) callback URL along in `state`: forward
+      // everything the provider returned - the authorization code, or an error - to it.
+      const params = new URLSearchParams(window.location.search);
+      const returnUrl = params.get('state') || '';
+      params.delete('state');
+      const query = params.toString();
+      const finalUrl = query ? returnUrl + '?' + query : returnUrl;
+
+      // Only forward to something shaped like a Music Assistant callback URL. Both the
+      // current `/setup_flow/callback/<id>` and the older `/callback/<id>` shape are in
+      // use, and the base URL may carry a path prefix when MA sits behind a reverse proxy.
+      const isCallbackUrl =
+        /^https?:\/\/[^/?#@\s]+\/(?:[^?#\s]*\/)?callback\/[A-Za-z0-9_.-]+$/.test(returnUrl);
+      // Home Assistant ingress URLs are only reachable from within the HA frontend, so
+      // offer those as a link instead of navigating there on the user's behalf.
+      const isIngress = returnUrl.includes('hassio_ingress');
+
+      // the status line starts out empty so that it never promises a redirect that a
+      // browser without JavaScript is not going to make
+      const status = document.getElementById('status');
+      if (!isCallbackUrl) {
+        document.getElementById('error').hidden = false;
       } else {
-        if (validOrigin) {
+        // render the link before navigating: it is the fallback for when the browser
+        // refuses the automatic navigation, and is already on screen if that happens
+        document.getElementById('redirect-link').href = finalUrl;
+        document.getElementById('manual-link').hidden = false;
+        if (isIngress) {
+          status.textContent = 'One more step to finish signing in:';
+        } else {
+          status.textContent = 'Returning you to Music Assistant…';
           window.location.replace(finalUrl);
         }
-        // manual fallback for when we cannot tell which sign-in page the browser came
-        // from, or when the browser refuses the automatic redirect
-        document.getElementById('manual-link').style.display = 'block';
-        document.getElementById('redirect-link').href = finalUrl;
       }
     </script>
-  </footer>
 </body>
 </html>


### PR DESCRIPTION
Signing in to Spotify, Google Drive or OneDrive sends the browser to `music-assistant.io/callback`, which should hand you straight back to your own Music Assistant. It never did — you always had to click "Complete Authentication" first.

The page only forwarded when the browser reported it came from one of the sign-in hosts. OAuth providers deliberately suppress that on the redirect carrying the authorization code, so the check never passed, for any provider.

- Forward as soon as `state` holds a valid Music Assistant callback address, instead of checking where the browser came from
- Render the fallback link before navigating, so a browser that refuses the redirect still leaves a way forward
- Home Assistant ingress addresses now get that link too, instead of the "no valid address" error screen — they are only reachable from inside the HA frontend, so they still are not redirected automatically
- Status line only claims a redirect when one is actually happening

Security: the page will now forward to any callback-shaped address without a click. It already rendered that same address as a clickable link and asked the user to click it, so the change is one click on an existing path. Closing it properly means signing `state` server-side, which is a change in the server repo.
