### PR TITLE
Revise Spotify setup instructions for authorization

### DIFF
--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -49,7 +49,12 @@ Connecting your account puts your saved music and playlists into Music Assistant
 
 1. Add the Spotify source via `SETTINGS >> MUSIC SOURCES >> ADD A MUSIC SOURCE`.
 2. Click the `AUTHENTICATE WITH SPOTIFY` button. A new tab opens on Spotify's own website where you give Music Assistant permission to access your account, so make sure your browser allows pop-ups. Use a device that is on the same home network as your MA server and is not connected to a VPN (see [Networking Basics](/faq/networking/)); if the button appears to do nothing, this is the most likely cause.
-3. Click `SAVE` on the Spotify settings page. The setup will fail if you skip this step. If your device closes the MA page before you can click `SAVE` (this can happen on mobile devices), retry from a laptop or PC.
+
+3. Click `AUTHORISE PLAYBACK`. Using your mobile device which is on the same network as the MA server, open the Spotify App. Start playing a track. Find the icon that allows you to transfer the music to another device, press it and then select 'Music Assistant'. Return to the Music Assistant UI and you should find the source is authorized. If this fails for any reason try the `AUTHORIZE IN BROWSER' option.
+
+4. If you use the `AUTHORIZE IN BROWSER` option be aware that it is normal to get a failed to load page during the setup process. When on that page you need to copy the entire URL and paste that into the field in the MA UI that asks for it.
+
+4. Click `SAVE` on the Spotify settings page. The setup will fail if you skip this step. If your device closes the MA page before you can click `SAVE` (this can happen on mobile devices), retry from a laptop or PC.
 
 Spotify will now work, but consider the optional step below.
 


### PR DESCRIPTION
Updated the Spotify setup instructions to include the new authorization steps and clarified the process for mobile devices.

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [X] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
