### PR TITLE
Document the two Spotify playback engines

### DIFF
--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -19,9 +19,6 @@ Spotify audio can be played through two different engines. You choose one while 
 
 **Spotify Soloist (official)** — Spotify's own playback engine for devices without a screen. It works with **every** Premium account, including accounts created since December 2024, and can deliver lossless audio. Setting it up needs a personal API key from the Spotify developer website and a one-off pairing with your Spotify app; the setup guides you through both.
 
-> [!IMPORTANT]
-> Spotify only publishes Soloist for Linux, so it is unavailable on a Windows or macOS server. Music Assistant will tell you so and ask you to choose librespot instead. This does not affect the Home Assistant add-on or the Docker container.
-
 > [!NOTE]
 > Music Assistant may not distribute Soloist as part of its own installation, so it is downloaded from Spotify's servers on your behalf (after your consent in the setup) and updated automatically. Spotify's terms do not clearly allow using Soloist this way — using it through Music Assistant is at your own risk.
 
@@ -32,7 +29,6 @@ Spotify audio can be played through two different engines. You choose one while 
 |  | Spotify Soloist | librespot |
 |:--|:--|:--|
 | Accounts created since December 2024 | Works | Usually will not play |
-| Runs on | Linux only | Any system |
 | Best audio quality | Lossless, up to 24-bit/44.1 kHz | Ogg Vorbis 320kbps |
 | Setup | Terms, an API key and pairing | A one-time playback approval |
 | Starting a queue, and seeking | A few seconds | Quick |
@@ -146,7 +142,6 @@ Crossfade is not set here — enable it for the player as usual and, with Solois
 
 - Premium is required, including Duo and Family. Free accounts will not work
 - Accounts created around December 2024 and later generally cannot play through librespot, and some older accounts are affected too. If playback fails and you see `Key Error` messages in the log, that is the symptom — choose Spotify Soloist instead
-- Spotify Soloist is available for Linux servers only
 - Each Spotify Soloist account plays one thing at a time. Starting Spotify on a second player asks you to stop the first one; a second Spotify account added as its own source has a session of its own
 - While Spotify Soloist is playing, Music Assistant shows up as a device in your Spotify app. Pausing or skipping there interferes with playback, so use Music Assistant's own controls
 - With Spotify Soloist, starting a queue and seeking take a few seconds because Spotify sends the audio at playback speed. Consecutive songs are not affected, but a podcast episode, an audiobook chapter or a repeated song each start fresh

--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -8,7 +8,7 @@ Music Assistant has full support for Spotify media listing and playback.
 
 Spotify is the largest of the music streaming services, with a catalogue of around 100 million tracks alongside podcasts and audiobooks.
 
-Connecting your account puts your saved music and playlists into Music Assistant and makes the catalogue searchable. Your players do not need to support Spotify Connect.
+Connecting your account puts your saved music and playlists into Music Assistant and makes the catalogue searchable.
 
 > [!NOTE]
 > A Spotify Premium account is required, including Duo and Family. Free accounts will not work.
@@ -22,7 +22,7 @@ Spotify audio can be played through two different engines. You choose one while 
 > [!NOTE]
 > Music Assistant may not distribute Soloist as part of its own installation, so it is downloaded from Spotify's servers on your behalf (after your consent in the setup) and updated automatically. Spotify's terms do not clearly allow using Soloist this way — using it through Music Assistant is at your own risk.
 
-**librespot (community)** — a community-built, reverse-engineered engine, and the default. Nothing is downloaded and there is no API key or developer account involved, and it starts playing quicker. It does still need a one-time playback approval from Spotify during setup. It is intended for Premium accounts created **before December 2024** and may stop working whenever Spotify changes things on their end.
+**librespot (community)** — a community-built, reverse-engineered engine, and the default. The setup is a bit easier and it starts playing quicker, but it is intended for Premium accounts created **before December 2024** and may stop working whenever Spotify changes things on their end.
 
 ### Which one should I pick?
 
@@ -35,11 +35,9 @@ Spotify audio can be played through two different engines. You choose one while 
 | Crossfade between songs | Spotify's own crossfade | Music Assistant's crossfade |
 | Playing on two players at once | One at a time, per Spotify account | Supported |
 
-Soloist trades a little responsiveness for quality and for working with newer accounts: Spotify sends the audio at playback speed, so the **first** song of a queue takes a few seconds to start, and so does seeking within a song. Consecutive songs are prepared while the current one plays, so they follow on without a break.
+With Soloist, the **first** song of a queue takes a few seconds to start, and so does seeking. Songs after it follow on without a break — though a podcast episode, an audiobook chapter or the same song twice in a row each start fresh.
 
-That preparation only works from one song to the next. A podcast episode or an audiobook chapter is always played on its own, so each one takes those few seconds to start, and so does the same song twice in a row.
-
-If your account was created before December 2024 and you are happy with 320kbps, librespot remains the quicker, simpler option. It is preselected for a new setup, and for existing setups that were added before this choice existed.
+librespot is preselected for a new setup, and stays selected for setups added before this choice existed.
 
 ## Features
 
@@ -78,10 +76,12 @@ If your account was created before December 2024 and you are happy with 320kbps,
 
 ### librespot: the one-time playback approval
 
-Playing audio needs a separate approval from Spotify, on top of the sign-in you just completed. You can give it from the Spotify app or from a web browser.
+Playing audio needs a separate approval from Spotify, on top of the sign-in you just completed.
+
+**Use the Spotify app for this.** It is a couple of taps and it is the smoother of the two routes. The web browser alternative is there for networks where your phone cannot reach the Music Assistant server, and it is more fiddly.
 
 <details>
-<summary>I clicked - Use the Spotify App</summary>
+<summary>I clicked - Use the Spotify App (recommended)</summary>
 <div>
 
 > [!NOTE]
@@ -92,7 +92,7 @@ Playing audio needs a separate approval from Spotify, on top of the sign-in you 
 </details>
 
 <details>
-<summary>I clicked - Use a web browser instead</summary>
+<summary>I clicked - Use a web browser instead (only if the app route will not work)</summary>
 <div>
 
 > [!NOTE]
@@ -134,7 +134,7 @@ Refer to the [Library Import Control](/music-providers/#library-import-control) 
 Two extra settings appear when Spotify Soloist is the playback engine:
 
 - **Streaming quality** — the highest quality Spotify is asked to stream, defaulting to `Lossless`. This is a ceiling rather than a promise: Spotify still picks something lower on a slow connection, when a song has no file at that quality, or when your plan does not include it. Podcasts and audiobooks are always Ogg Vorbis. Takes effect the next time playback starts.
-- **Enable Spotify's volume normalization** — on by default. Spotify evens out the loudness between songs using values computed for its whole catalogue, and Music Assistant then leaves the level alone instead of correcting it twice, which also makes songs start noticeably quicker. Turn it off to have Music Assistant do it instead, the same way it does for every other music source. Either way it only applies while volume normalization is enabled for the player.
+- **Enable Spotify's volume normalization** — on by default. Spotify evens out the loudness between songs using values computed for its whole catalogue, and Music Assistant then leaves the level alone instead of correcting it twice, which also makes songs start noticeably quicker. Turn it off to have Music Assistant do it instead, the same way it does for every other music source. Either way it only applies while volume normalization is enabled for the queue.
 
 Crossfade is not set here — enable it for the player as usual and, with Soloist, Spotify's own crossfade is used between songs.
 
@@ -144,8 +144,7 @@ Crossfade is not set here — enable it for the player as usual and, with Solois
 - Accounts created around December 2024 and later generally cannot play through librespot, and some older accounts are affected too. If playback fails and you see `Key Error` messages in the log, that is the symptom — choose Spotify Soloist instead
 - Each Spotify Soloist account plays one thing at a time. Starting Spotify on a second player asks you to stop the first one; a second Spotify account added as its own source has a session of its own
 - While Spotify Soloist is playing, Music Assistant shows up as a device in your Spotify app. Pausing or skipping there interferes with playback, so use Music Assistant's own controls
-- With Spotify Soloist, starting a queue and seeking take a few seconds because Spotify sends the audio at playback speed. Consecutive songs are not affected, but a podcast episode, an audiobook chapter or a repeated song each start fresh
+- With Spotify Soloist, starting a queue or seeking takes a few seconds
 - When you first save the source, Music Assistant checks whether your account has audiobooks. If it does, audiobook options appear the next time you open the settings
 - Spotify does not give Music Assistant any recommendations, so the Discover view will have nothing from Spotify in it
 - Spotify does not tell Music Assistant what genre anything is
-- Spotify has limited what Client IDs can do on recently created accounts. If you see 403 errors in the log after adding one, take the Client ID back out by selecting `Reconfigure` and going through the setup process again

--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -10,14 +10,35 @@ Spotify is the largest of the music streaming services, with a catalogue of arou
 
 Connecting your account puts your saved music and playlists into Music Assistant and makes the catalogue searchable. Your players do not need to support Spotify Connect.
 
-> [!WARNING]
-> Spotify has blocked accounts created around 2024 and later from working with third party apps like Music Assistant, and some older accounts are also affected. If the provider does not work and you see `Key Error` messages in the log, your account is affected. There is currently no remedy; consider using [another streaming source that we support](/music-providers/) instead
+> [!NOTE]
+> A Spotify Premium account is required, including Duo and Family. Free accounts will not work.
+
+## Playback engines
+
+Spotify audio can be played through two different engines. You choose one while adding the provider and can switch later by re-running the setup.
+
+**Spotify Soloist (official)** — Spotify's own playback engine for devices without a screen. It works with **every** Premium account, including accounts created since December 2024, and can deliver lossless audio. Setting it up needs a personal API key from the Spotify developer website and a one-off pairing with your Spotify app; the setup guides you through both.
 
 > [!NOTE]
-> A Spotify Premium account is required for this music source. Free accounts will not work.
+> Music Assistant may not distribute Soloist as part of its own installation, so it is downloaded from Spotify's servers on your behalf (after your consent in the setup) and updated automatically. Spotify's terms do not clearly allow using Soloist this way — using it through Music Assistant is at your own risk.
 
-> [!NOTE]
-> Spotify has told third party products not to pursue lossless support, so do not expect it here.
+**librespot (community)** — a community-built, reverse-engineered engine. No API key, pairing or download is needed and it starts playing quicker, but it is intended for Premium accounts created **before December 2024** and may stop working whenever Spotify changes things on their end.
+
+### Which one should I pick?
+
+|  | Spotify Soloist | librespot |
+|:--|:--|:--|
+| Accounts created since December 2024 | Works | Usually will not play |
+| Best audio quality | Lossless, up to 24-bit/44.1 kHz | Ogg Vorbis 320kbps |
+| Extra setup | API key + pairing with the Spotify app | None |
+| Starting a queue, and seeking | A few seconds | Quick |
+| Songs after the first one | Follow on without a break | Follow on without a break |
+| Crossfade between songs | Spotify's own crossfade | Music Assistant's crossfade |
+| Playing on two players at once | One at a time | Supported |
+
+Soloist trades a little responsiveness for quality and for working with newer accounts: Spotify sends the audio at playback speed, so the **first** song of a queue takes a few seconds to start, and so does seeking within a song. Everything after that first song is prepared while the current one plays, so the rest of the queue follows on without a break.
+
+If your account was created before December 2024 and you are happy with 320kbps, librespot remains the quicker, simpler option. It is preselected for a new setup, and for existing setups that were added before this choice existed.
 
 ## Features
 
@@ -32,7 +53,7 @@ Connecting your account puts your saved music and playlists into Music Assistant
 | Artist Top Tracks Support                       |            Yes                     |
 | Similar Artists Support                         |            No                      |
 | Similar Tracks Support                          |            Yes                      |
-| Maximum Stream Quality | OGG Vorbis 320kbps |
+| Maximum Stream Quality | Soloist: lossless, up to 24-bit/44.1 kHz. librespot: OGG Vorbis 320kbps |
 | Login Method | OAuth |
 
 ### Other
@@ -74,7 +95,23 @@ Connecting your account puts your saved music and playlists into Music Assistant
 </div>
 </details>
 
-Spotify will now work, but consider the optional step below or click `Finish` and then `Done`.
+3. Choose how Spotify audio should be played. Pick `librespot (community)` to finish here, or `Spotify Soloist (official)` to continue with the extra steps below.
+
+Spotify will now work, but consider the optional step further below or click `Finish` and then `Done`.
+
+### Setting up Spotify Soloist
+
+Choosing Soloist adds three steps to the setup:
+
+1. **Read and accept the terms.** Soloist is downloaded from Spotify's servers and run on your behalf, and Spotify's terms do not clearly allow this. You have to agree before the setup continues.
+2. **Create your API key.** Open the <a href="https://developer.spotify.com/dashboard/soloist" target="_blank" rel="noopener noreferrer">Soloist API key page</a>, sign in, accept Spotify's terms if asked, choose `Generate API Key` and paste the key into Music Assistant. Creating the key needs a Premium account. Music Assistant stores it encrypted and only shares it with the Soloist app — your Spotify password is never asked for.
+3. **Pair with your Spotify app.** Music Assistant advertises itself as `Music Assistant Pairing`. In the Spotify app, start playing anything, tap the speaker icon and choose `Music Assistant Pairing`. The setup then continues by itself and you can switch back to your usual speaker straight away.
+
+> [!IMPORTANT]
+> Pair from a Spotify app signed in to the **same account** you connected in the first step, so your music library and the audio come from the same place. Music Assistant checks this and will ask you to pair again if the accounts do not match.
+
+> [!NOTE]
+> Not seeing `Music Assistant Pairing`? Make sure the device running the Spotify app is on the same network as the Music Assistant server.
 
 ### Optional: add a personal Client ID
 
@@ -89,9 +126,20 @@ Music Assistant shares one allowance from Spotify with everybody else using it, 
 
 Refer to the [Library Import Control](/music-providers/#library-import-control) settings.
 
+Two extra settings appear when Spotify Soloist is the playback engine:
+
+- **Streaming quality** — the highest quality Spotify is asked to stream, defaulting to `Lossless`. This is a ceiling rather than a promise: Spotify still picks something lower on a slow connection, when a song has no file at that quality, or when your plan does not include it. Podcasts and audiobooks are always Ogg Vorbis. Takes effect the next time playback starts.
+- **Enable Spotify's volume normalization** — on by default. Spotify evens out the loudness between songs using values computed for its whole catalogue, and Music Assistant then leaves the level alone instead of correcting it twice, which also makes songs start noticeably quicker. Turn it off to have Music Assistant do it instead, the same way it does for every other music source. Either way it only applies while volume normalization is enabled for the player.
+
+Crossfade is not set here — enable it for the player as usual and, with Soloist, Spotify's own crossfade is used between songs.
+
 ## Known Issues / Notes
 
 - Premium is required, including Duo and Family. Free accounts will not work
+- Accounts created around December 2024 and later cannot play through librespot. Choose Spotify Soloist for those accounts
+- With Spotify Soloist, only one thing can play at a time. Starting Spotify on a second player asks you to stop the first one
+- While Spotify Soloist is playing, Music Assistant shows up as a device in your Spotify app. Pausing or skipping there interferes with playback, so use Music Assistant's own controls
+- With Spotify Soloist, starting a queue and seeking take a few seconds because Spotify sends the audio at playback speed. Later songs in the queue are not affected
 - When you first save the source, Music Assistant checks whether your account has audiobooks. If it does, audiobook options appear the next time you open the settings
 - Spotify does not give Music Assistant any recommendations, so the Discover view will have nothing from Spotify in it
 - Spotify does not tell Music Assistant what genre anything is

--- a/src/content/docs/music-providers/spotify.md
+++ b/src/content/docs/music-providers/spotify.md
@@ -19,24 +19,29 @@ Spotify audio can be played through two different engines. You choose one while 
 
 **Spotify Soloist (official)** — Spotify's own playback engine for devices without a screen. It works with **every** Premium account, including accounts created since December 2024, and can deliver lossless audio. Setting it up needs a personal API key from the Spotify developer website and a one-off pairing with your Spotify app; the setup guides you through both.
 
+> [!IMPORTANT]
+> Spotify only publishes Soloist for Linux, so it is unavailable on a Windows or macOS server. Music Assistant will tell you so and ask you to choose librespot instead. This does not affect the Home Assistant add-on or the Docker container.
+
 > [!NOTE]
 > Music Assistant may not distribute Soloist as part of its own installation, so it is downloaded from Spotify's servers on your behalf (after your consent in the setup) and updated automatically. Spotify's terms do not clearly allow using Soloist this way — using it through Music Assistant is at your own risk.
 
-**librespot (community)** — a community-built, reverse-engineered engine. No API key, pairing or download is needed and it starts playing quicker, but it is intended for Premium accounts created **before December 2024** and may stop working whenever Spotify changes things on their end.
+**librespot (community)** — a community-built, reverse-engineered engine, and the default. Nothing is downloaded and there is no API key or developer account involved, and it starts playing quicker. It does still need a one-time playback approval from Spotify during setup. It is intended for Premium accounts created **before December 2024** and may stop working whenever Spotify changes things on their end.
 
 ### Which one should I pick?
 
 |  | Spotify Soloist | librespot |
 |:--|:--|:--|
 | Accounts created since December 2024 | Works | Usually will not play |
+| Runs on | Linux only | Any system |
 | Best audio quality | Lossless, up to 24-bit/44.1 kHz | Ogg Vorbis 320kbps |
-| Extra setup | API key + pairing with the Spotify app | None |
+| Setup | Terms, an API key and pairing | A one-time playback approval |
 | Starting a queue, and seeking | A few seconds | Quick |
-| Songs after the first one | Follow on without a break | Follow on without a break |
 | Crossfade between songs | Spotify's own crossfade | Music Assistant's crossfade |
-| Playing on two players at once | One at a time | Supported |
+| Playing on two players at once | One at a time, per Spotify account | Supported |
 
-Soloist trades a little responsiveness for quality and for working with newer accounts: Spotify sends the audio at playback speed, so the **first** song of a queue takes a few seconds to start, and so does seeking within a song. Everything after that first song is prepared while the current one plays, so the rest of the queue follows on without a break.
+Soloist trades a little responsiveness for quality and for working with newer accounts: Spotify sends the audio at playback speed, so the **first** song of a queue takes a few seconds to start, and so does seeking within a song. Consecutive songs are prepared while the current one plays, so they follow on without a break.
+
+That preparation only works from one song to the next. A podcast episode or an audiobook chapter is always played on its own, so each one takes those few seconds to start, and so does the same song twice in a row.
 
 If your account was created before December 2024 and you are happy with 320kbps, librespot remains the quicker, simpler option. It is preselected for a new setup, and for existing setups that were added before this choice existed.
 
@@ -53,7 +58,7 @@ If your account was created before December 2024 and you are happy with 320kbps,
 | Artist Top Tracks Support                       |            Yes                     |
 | Similar Artists Support                         |            No                      |
 | Similar Tracks Support                          |            Yes                      |
-| Maximum Stream Quality | Soloist: lossless, up to 24-bit/44.1 kHz. librespot: OGG Vorbis 320kbps |
+| Maximum Stream Quality | Lossless, up to 24-bit/44.1 kHz (Soloist) |
 | Login Method | OAuth |
 
 ### Other
@@ -72,6 +77,12 @@ If your account was created before December 2024 and you are happy with 320kbps,
 1. Add the Spotify source via `SETTINGS >> MUSIC SOURCES >> ADD A MUSIC SOURCE`.
 2. Follow the on screen instructions which should take you through the initial flow shown here
 <a href="/assets/screenshots/spotify-phase1.png"><img src="/assets/screenshots/spotify-phase1.png" alt="Preview image" style="width: 800px;"  loading="lazy" /></a>
+
+3. Choose how Spotify audio should be played. `librespot (community)` continues with the one-time playback approval below; `Spotify Soloist (official)` continues with [its own steps](#setting-up-spotify-soloist) instead.
+
+### librespot: the one-time playback approval
+
+Playing audio needs a separate approval from Spotify, on top of the sign-in you just completed. You can give it from the Spotify app or from a web browser.
 
 <details>
 <summary>I clicked - Use the Spotify App</summary>
@@ -95,13 +106,11 @@ If your account was created before December 2024 and you are happy with 320kbps,
 </div>
 </details>
 
-3. Choose how Spotify audio should be played. Pick `librespot (community)` to finish here, or `Spotify Soloist (official)` to continue with the extra steps below.
-
 Spotify will now work, but consider the optional step further below or click `Finish` and then `Done`.
 
 ### Setting up Spotify Soloist
 
-Choosing Soloist adds three steps to the setup:
+Choosing Soloist replaces the playback approval above with three steps of its own:
 
 1. **Read and accept the terms.** Soloist is downloaded from Spotify's servers and run on your behalf, and Spotify's terms do not clearly allow this. You have to agree before the setup continues.
 2. **Create your API key.** Open the <a href="https://developer.spotify.com/dashboard/soloist" target="_blank" rel="noopener noreferrer">Soloist API key page</a>, sign in, accept Spotify's terms if asked, choose `Generate API Key` and paste the key into Music Assistant. Creating the key needs a Premium account. Music Assistant stores it encrypted and only shares it with the Soloist app — your Spotify password is never asked for.
@@ -117,7 +126,7 @@ Choosing Soloist adds three steps to the setup:
 
 Music Assistant shares one allowance from Spotify with everybody else using it, and Spotify limits how fast that allowance can be used. Registering your own free Client ID gives you an allowance of your own, which may make everything quicker but it does have some potential problems detailed in the known issues section.
 
-1. Complete the basic setup above, then check `Use my own Spotify developer key` and click finish.
+1. Complete the basic setup above, then check `Use my own Spotify developer key (advanced, optional)` and click finish.
 2. A new dialog will open where you must add your own Client ID. 
 3. Create an app on Spotify's <a href="https://developer.spotify.com/documentation/web-api/concepts/apps" target="_blank" rel="noopener noreferrer">developer dashboard</a>. When filling in the app details, the only field that matters is the `Redirect URL`. Set it exactly to `https://music-assistant.io/callback`.
 4. Enter the Client ID from your new app in the dialog you saw after completing step 2, then click `Finish` and then `Done`.
@@ -136,10 +145,11 @@ Crossfade is not set here — enable it for the player as usual and, with Solois
 ## Known Issues / Notes
 
 - Premium is required, including Duo and Family. Free accounts will not work
-- Accounts created around December 2024 and later cannot play through librespot. Choose Spotify Soloist for those accounts
-- With Spotify Soloist, only one thing can play at a time. Starting Spotify on a second player asks you to stop the first one
+- Accounts created around December 2024 and later generally cannot play through librespot, and some older accounts are affected too. If playback fails and you see `Key Error` messages in the log, that is the symptom — choose Spotify Soloist instead
+- Spotify Soloist is available for Linux servers only
+- Each Spotify Soloist account plays one thing at a time. Starting Spotify on a second player asks you to stop the first one; a second Spotify account added as its own source has a session of its own
 - While Spotify Soloist is playing, Music Assistant shows up as a device in your Spotify app. Pausing or skipping there interferes with playback, so use Music Assistant's own controls
-- With Spotify Soloist, starting a queue and seeking take a few seconds because Spotify sends the audio at playback speed. Later songs in the queue are not affected
+- With Spotify Soloist, starting a queue and seeking take a few seconds because Spotify sends the audio at playback speed. Consecutive songs are not affected, but a podcast episode, an audiobook chapter or a repeated song each start fresh
 - When you first save the source, Music Assistant checks whether your account has audiobooks. If it does, audiobook options appear the next time you open the settings
 - Spotify does not give Music Assistant any recommendations, so the Discover view will have nothing from Spotify in it
 - Spotify does not tell Music Assistant what genre anything is

--- a/src/data/music-summary.ts
+++ b/src/data/music-summary.ts
@@ -132,4 +132,8 @@ export const QUALITY_TIER_OVERRIDES: Record<string, QualityTier> = {
   "music-providers/kion-music": "hi-res",
   "music-providers/yandex-music": "hi-res",
   "music-providers/zvuk": "hi-res",
+  // Soloist can serve lossless, and Music Assistant reports 24 bits because the
+  // engine hands the decoded audio over as 32-bit PCM. Spotify sells no hi-res
+  // tier though, so the comparison says CD rather than reading that figure as one.
+  "music-providers/spotify": "cd",
 };

--- a/src/data/music-summary.ts
+++ b/src/data/music-summary.ts
@@ -132,8 +132,10 @@ export const QUALITY_TIER_OVERRIDES: Record<string, QualityTier> = {
   "music-providers/kion-music": "hi-res",
   "music-providers/yandex-music": "hi-res",
   "music-providers/zvuk": "hi-res",
-  // Soloist can serve lossless, and Music Assistant reports 24 bits because the
-  // engine hands the decoded audio over as 32-bit PCM. Spotify sells no hi-res
-  // tier though, so the comparison says CD rather than reading that figure as one.
+  // Soloist can serve lossless, and the page says 24 bits because that is the
+  // ceiling Music Assistant reports for the tier (Soloist never says what it
+  // actually fetched). Spotify sells no hi-res tier, so this pins the chip to CD
+  // rather than letting that 24 be read as one - an editorial call, not a
+  // tie-break: the wording on its own would derive hi-res.
   "music-providers/spotify": "cd",
 };


### PR DESCRIPTION
## What does this change?

Revises the Spotify music source page now that Spotify audio can be played through Spotify's own engine as well as librespot. Server PR: https://github.com/music-assistant/server/pull/5918

- New **Playback engines** section: what Soloist and librespot are, and a short table for picking between them
- Soloist works with accounts created since December 2024 and can serve lossless audio, at the cost of a few seconds to start a queue or seek
- Documents the Soloist setup steps (terms, API key, pairing) and the two settings that come with it — streaming quality and Spotify's volume normalization
- Notes that with Soloist only one thing plays at a time, and that Music Assistant appears in your Spotify app while it does
- Drops two claims Soloist makes untrue: that newer accounts cannot work at all, and that lossless is not coming
- Premium is still required throughout, unlike the Spotify Connect plugin where people connecting afterwards may be on Free

The `Maximum Stream Quality` row feeds the chip on `I Want To Listen To`. Left it saying what Music Assistant reports (lossless, up to 24-bit/44.1 kHz) and pinned the chip to CD in `QUALITY_TIER_OVERRIDES`, since Spotify sells no hi-res tier and the wording would otherwise read that 24 as one.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers
