### PR TITLE
Point settings links at the settings that actually exist

### DIFF
--- a/src/content/docs/audio-analysis/smart-fades.md
+++ b/src/content/docs/audio-analysis/smart-fades.md
@@ -18,9 +18,9 @@ When Smart Fades is enabled on a player, the transition between tracks is:
 
 The result is closer to what a DJ would do manually than to a stock crossfade.
 
-## Enabling Smart Fades on a player
+## Choosing the crossfade mode
 
-Smart Fades is configured **per player** under that player's settings:
+Crossfade is a queue setting. Set it for all players in the [Player Queues settings](/settings/core/#player-queues), or for one player only in [that queue's own settings](/usage/#the-queue):
 
 | Mode | Behaviour |
 | --- | --- |
@@ -28,7 +28,7 @@ Smart Fades is configured **per player** under that player's settings:
 | **Standard Crossfade** | A simple time-based crossfade of a configurable duration. Used as a fallback when Smart Fades cannot run. |
 | **Smart Crossfade** | Uses the beat, key and energy data produced by this provider to build a beat-matched, EQ-aware transition. |
 
-The duration used for Standard Crossfade (and as a fallback for Smart Crossfade) is set via "Fallback crossfade duration" in the same settings group.
+The duration used for Standard Crossfade (and as a fallback for Smart Crossfade) is set via "Fallback crossfade duration" in the same place.
 
 Some players don't natively support gapless or crossfaded playback. For those, Music Assistant automatically switches into flow mode (a continuous re-encoded stream) so the crossfade can still happen.
 

--- a/src/content/docs/faq/tech-info.md
+++ b/src/content/docs/faq/tech-info.md
@@ -31,7 +31,7 @@ All further processing in MA is done at PCM raw audio level, such as the DSP Set
 
 The final part in the chain is that MA needs to send the audio to the player. By default MA encodes the raw PCM into FLAC because it is lossless while still providing a descent amount of compression. For players that can not handle FLAC very well, or simply to save bandwidth, MA provides an option (per player) to encode to MP3 instead.
 
-The [Streamserver Settings](/settings/core/#streamserver-advanced-settings) contains a number of options which determine how Volume Normalization will perform. Additionally, the [Individual Player Settings](/settings/individual-player/#queue-playback) provides access to options to enable and disable this feature as well as adjusting the [target level](/settings/individual-player/#queue-playback).
+The [Streams Queue Playback settings](/settings/core/#queue-playback) contain a number of options which determine how Volume Normalization will perform. Enabling and disabling the feature, and adjusting the target level, is done in the [Player Queues settings](/settings/core/#player-queues), and both can be overridden on an [individual queue basis](/usage/#the-queue).
 
 ## Stream Selection
 

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -74,7 +74,7 @@ Several client types can connect to Music Assistant via Sendspin:
 
 The player built into the Music Assistant web interface is itself a Sendspin player. On your own network it connects straight to the server, which sounds best. From anywhere else it connects over the internet instead, which still works but at a lower quality.
 
-The sync delay can be adjusted under **Settings → User Interface → Sendspin sync delay**. Music Assistant picks a value to suit your device, but it may need adjusting.
+Like any other Sendspin player, the web player has a **Static playback delay (ms)** setting in its [Output Protocols settings](/settings/individual-player/#output-protocols). Music Assistant picks a value to suit your device, but it may need adjusting if the web player is heard out of step with your other speakers.
 
 Audio quality in the web player depends on where you are listening from:
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -24,7 +24,7 @@ Full details of the DSP capabilities and the filters that are available can be f
 
 ## Player Options
 
-Some players (e.g. [MusicCast](../player-support/musiccast/) have [unique control features](../player-support/#player-options) which are fully described in the documentation for the relevant player provider 
+Some players (e.g. [MusicCast](/player-support/musiccast/) have [unique control features](/player-support/#player-options) which are fully described in the documentation for the relevant player provider 
 
 ## Generic Settings
 


### PR DESCRIPTION
## What does this change?

Four internal links were broken and two sections described settings that have since moved in the UI, so readers were being sent to the wrong place or to nothing at all.

**Broken links (4)**

- `faq/tech-info.md` linked `/settings/individual-player/#queue-playback` twice. That section is now **Queue Settings**, so the anchor no longer resolves. The same sentence also named *Streamserver Advanced Settings* for the volume normalization options, which actually live under **Streams → Queue Playback**. Rewritten to point at all three places these settings really are.
- `settings/individual-player.md` linked `../player-support/musiccast/` and `../player-support/#player-options`. The page is served at `/settings/individual-player/`, so `../` lands in `/settings/` and both 404. Changed to root-relative, matching the other 24 links to that section on the same page and the convention in `CONTRIBUTING.md`.

**Stale descriptions (2)**

- `audio-analysis/smart-fades.md` said crossfade is configured *per player*. It is a queue setting — global under Player Queues, or per queue. Heading and lead sentence updated.
- `player-support/sendspin.md` sent readers to *Settings → User Interface → Sendspin sync delay* for the web player. That setting is **Static playback delay (ms)** on the player itself, which the same page already documents further up — so the page contradicted itself.

## Checklist

- [x] Correct branch: `beta`
- [x] No new pages, so no sidebar entry needed

## Verification

Built the site and resolved every internal link and anchor against the generated heading slugs: **0 broken internal links across 174 pages**. The two relative-link 404s were only provable by building, since Astro emits relative hrefs verbatim.

Standalone — does not depend on any other open PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U42bRfm14UaFLyHtTjHt1o)_