### PR TITLE
Give the duplicate settings headings distinct anchors

### DIFF
--- a/src/content/docs/settings/core.md
+++ b/src/content/docs/settings/core.md
@@ -8,7 +8,7 @@ The core server settings are set with typical defaults that should work for most
 
 ![image](/assets/screenshots/settings-core.png)
 
-## Background Tasks
+## Background Tasks (configuration)
 
 - <b>Maximum number of concurrent background tasks.</b> Defaults to 2. This controls how many background tasks run simultaneously. Higher numbers mean higher demands on the system's resources and can slow the system down. Setting is only visible when the advanced toggle is on
 
@@ -99,7 +99,7 @@ How much to raise or lower the volume, in dB, whenever the fixed-gain path is us
 - The <b>Published IP address</b> and <b>TCP Port</b> are normally populated automatically and set to `auto`. This is the address Music Assistant advertises to stream clients (including [Sendspin](/player-support/sendspin/)) as the place to connect to for audio. It must be a literal IP address reachable by players on your local network, not a hostname, domain name, or URL. If there are issues with playback, confirm the IP address shown is reachable by the players on the local network. The port must be available.
 - <b>Bind to IP/interface.</b> Use in complex network setups to start the streamserver on a specific interface
 
-#### Audio Analysis
+#### Audio Analysis Options
 
 - <b>SmartFades Log Level.</b> Specific log level for the Smart Fades mixer and analyzer
 - <b>Background analysis concurrency.</b> Maximum number of tracks analysed concurrently during the nightly background scan. Default is 1 and should only be increased on more powerful systems


### PR DESCRIPTION
## What does this change?

`settings/core.md` used **Background Tasks** and **Audio Analysis** twice each, so the second of each pair silently became `#background-tasks-1` and `#audio-analysis-1`.

That was already causing a wrong landing. `music-providers/index.md` reads *"…is done in the [Background Tasks](/settings/core/#background-tasks) **view**"* — it says *view*, but the anchor resolved to the concurrency setting near the top of the page. The link checker passes it because the anchor exists.

The bare anchors now point at the sections a link-writer would expect:

| Line | Heading | Result |
|---|---|---|
| 11 | `Background Tasks` → `Background Tasks (configuration)` | `#background-tasks-configuration` |
| 102 | `Audio Analysis` → `Audio Analysis Options` | `#audio-analysis-options` |
| 119 | unchanged | now owns `#background-tasks` |
| 152 | unchanged | now owns `#audio-analysis` |

The existing link in `music-providers/index.md` starts resolving correctly **with no edit to that file**, and nothing links to either audio-analysis anchor yet, so that half is free.

### Two judgement calls worth flagging

- The UI genuinely lists *two* entries called "Background tasks", so `(configuration)` is a documentation-only disambiguator. An anchor has to be unique in a way a menu does not.
- Headings keep this page's existing Title Case rather than matching the UI's mixed casing (the UI has *Background tasks* and *Audio analysis* in sentence case beside *Player Queues* and *Genre Management* in Title Case). Matching the UI exactly is the right rule for **breadcrumbs**; for section headings, internal consistency reads better.

## Checklist

- [x] Correct branch: `beta`
- [x] No new pages, so no sidebar entry needed

## Verification

Full build, then every internal link and anchor resolved against generated heading slugs: **0 broken internal links**.

Standalone. Worth merging before the crosslinking PRs, which will link `#background-tasks` and `#audio-analysis` meaning the sections this PR gives them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U42bRfm14UaFLyHtTjHt1o)_