### PR TITLE
Explain the protocol settings once, on the player settings page

### DIFF
--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -43,19 +43,22 @@ Each available protocol then has its own configuration section. Protocols can be
 
 The settings below appear under most protocols and mean the same thing wherever you see them. **Most people never need to change any of them** — the defaults are chosen to work on the widest range of hardware, and the usual reason to come here is that something is not playing properly.
 
-Three things are true of all of them:
+Two things are true of all of them:
 
 - They are only visible when the `Show advanced settings` toggle is on
 - Changing one reloads the player, so anything currently playing stops briefly
-- Not every player shows every setting, and that is normal. A provider can set its own default or hide a setting where it does not apply, and some depend on what the player can do: a player that always streams the queue in one go has no flow mode setting to change, and a player that reports its own capabilities has no sample rate setting. Where a player differs from the defaults below, it is noted on that provider's own page
+
+Not every player shows every setting, and that is normal. A provider can set its own default, or hide a setting where it does not apply. Some depend on what the player can do: a player that always streams the queue in one go has no flow mode setting, and a player that reports its own capabilities has no sample rate setting. Where a player differs from the defaults below, its own page says so.
+
+AirPlay, Sendspin and Snapcast do not stream over HTTP, so those players show only **Output Channel Mode** from this list.
 
 #### Enable queue flow mode
 
-Sends the whole queue to the player as one continuous stream, instead of one track at a time. Off by default.
+Sends the whole queue to the player as one continuous stream, instead of one track at a time. Off by default on most players, though several providers turn it on because their devices work better that way; those pages say so.
 
-Turn it on if the player leaves a gap between tracks, stumbles on the change from one track to the next, or cannot do gapless playback at all. It is also switched on automatically when crossfade is in use, because stitching tracks together requires one continuous stream.
+Turn it on if the player leaves a gap between tracks, stumbles on the change from one track to the next, or cannot do gapless playback at all. Music Assistant also switches it on by itself when crossfade is in use *and* the player cannot do gapless playback on its own, since stitching those tracks together needs one continuous stream.
 
-The trade-off is that most players stop showing track information on their own display, because they only ever receive one long "track". The ICY setting below can put some of it back.
+The trade-off is that most players stop showing track information on their own display, because they only ever receive one long "track". The ICY setting below can put some of it back. [Track Queueing](/faq/tech-info/#track-queueing) explains how this differs from letting the player queue the next track itself.
 
 #### Flow Mode sample rate
 
@@ -76,18 +79,18 @@ Only applies when flow mode is on. A flow stream uses a single sample rate from 
 
 #### Try to inject metadata into stream (ICY)
 
-Only applies when flow mode is on. Slips the track title and artist into the audio stream itself so the player can display them — the same trick internet radio stations use. Disabled by default.
+Only applies when flow mode is on. Puts the track title and artist into the audio stream itself so the player can display them, in the same way internet radio stations do. Disabled by default.
 
-Turn it on if your player shows nothing useful while flow mode is running. Not every player handles it correctly, so if playback becomes unreliable after enabling it, step down to Profile 1 or turn it off again.
+Turn it on if your player shows nothing useful while flow mode is running. Start with Profile 1, and move to Profile 2 if you want album art as well. Not every player handles it correctly, so if playback becomes unreliable, step back down or turn it off again.
 
 <details>
 <summary>What each option does</summary>
 
 | Option | Behaviour |
 | --- | --- |
-| **Disabled** *(default)* | No metadata is injected; the player will not show track info during flow mode |
+| **Disabled - do not send ICY metadata** *(default)* | No metadata is injected; the player will not show track info during flow mode |
 | **Profile 1 - basic info** | Title and artist only. Lightweight and widely compatible |
-| **Profile 2 - full info** | Also sends the album name and cover art. Richer, but some players mishandle it — use Profile 1 if you see playback issues |
+| **Profile 2 - full info (including image)** | Also sends the album name and cover art. Richer, but some players mishandle it — use Profile 1 if you see playback issues |
 
 </details>
 
@@ -113,7 +116,7 @@ Change it if the player cannot play FLAC, or to cut down network traffic on a we
 
 The sample rates and bit depths Music Assistant will send to this player as they are. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are ticked by default.
 
-This is worth understanding before changing it: **the ticked boxes are a deliberately safe starting point, not something detected from your device.** The higher rates are offered for you to try. If your player genuinely supports them, tick them and you will get better quality; if playback breaks or the player falls silent, untick them again. Manufacturers vary, so test rather than assume.
+Rates are offered up to 384 kHz / 24 bit, though most providers narrow that list to what the device plausibly handles. On most players the ticked boxes are a safe starting point rather than something detected from the device, and the higher ones are offered for you to try. If your player genuinely supports them, tick them and you will get better quality; if playback breaks or the player falls silent, untick them again. Manufacturers vary, so test rather than assume. Some providers do detect the device's capabilities and set this for you — those pages say so.
 
 #### Output Channel Mode
 
@@ -123,7 +126,7 @@ The usual reason to change it is building a stereo pair from two players — set
 
 #### Prefer low-latency WAV for live sources
 
-Sends live sources such as [Spotify Connect](/plugins/spotify-connect/) and the [AirPlay Receiver](/plugins/airplay-receiver/) as uncompressed audio, so there is less delay before you hear them. Off by default on most players, on by default on a few where it works well.
+Sends live sources such as [Spotify Connect](/plugins/spotify-connect/) and the [AirPlay Receiver](/plugins/airplay-receiver/) as uncompressed audio, so there is less delay before you hear them. Off by default on most players; providers that turn it on say so on their own page.
 
 Turn it off if those sources are unreliable on your player; Music Assistant will fall back to the output codec set above.
 
@@ -131,7 +134,7 @@ Turn it off if those sources are unreliable on your player; Music Assistant will
 
 A low-level detail of how the audio is handed to the player. `Profile 2` by default, and correct for most players.
 
-This is a troubleshooting setting rather than a tuning one. Come here if the player stops part way through a track, refuses to start, or cannot seek — then try the other profiles.
+Change it only to fix a problem: if the player stops part way through a track, refuses to start, or cannot seek, try the other profiles.
 
 <details>
 <summary>What each option does</summary>
@@ -144,7 +147,7 @@ This is a troubleshooting setting rather than a tuning one. Come here if the pla
 
 </details>
 
-### Group player settings
+## Group Player Settings
 
 For group players the following settings will be seen:
 
@@ -152,6 +155,8 @@ For group players the following settings will be seen:
 - <b>Enable dynamic members</b> toggle. This setting is available for [Sync and Universal Groups](/faq/groups/). When enabled, it is then possible to add and remove members from these group types
 - <b>Allowed members</b>. Limit which players can join this group. Leave empty to allow any sync-compatible player. This can be used to reduce the list of players that show up for joining in case you have a lot of players. Only shown when the advanced toggle is on
 - <b>Allow crossfades between tracks of different sample rates</b>. Enable this option to allow crossfades between tracks that have different sample rates (e.g. 44.1kHz to 48kHz). Disable this option if you experience audio glitches during transitions between tracks. Only shown when the advanced toggle is on
+
+Universal Groups default to `Profile 1 - chunked` for the HTTP Profile, rather than Profile 2 as elsewhere.
 
 ## Announcements Configuration
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -48,7 +48,7 @@ Two things are true of all of them:
 - They are only visible when the `Show advanced settings` toggle is on
 - Changing one reloads the player, so anything currently playing stops briefly
 
-Not every player shows every setting, and that is normal. A provider can set its own default, or hide a setting where it does not apply. Some depend on what the player can do: a player that always streams the queue in one go has no flow mode setting, and a player that reports its own capabilities has no sample rate setting. Where a player differs from the defaults below, its own page says so.
+Not every player shows every setting, and that is normal. A provider can set its own default, or hide a setting where it does not apply. Some also depend on what the player can do, so a player that always streams the queue in one go has no flow mode setting, and a player that reports its own capabilities has no sample rate setting. Where a player differs from the defaults below, its own page says so.
 
 AirPlay, Sendspin and Snapcast do not stream over HTTP, so those players show only **Output Channel Mode** from this list.
 
@@ -134,7 +134,7 @@ Turn it off if those sources are unreliable on your player; Music Assistant will
 
 A low-level detail of how the audio is handed to the player. `Profile 2` by default, and correct for most players.
 
-Change it only to fix a problem: if the player stops part way through a track, refuses to start, or cannot seek, try the other profiles.
+Change it only to fix a problem. If the player stops part way through a track, refuses to start, or cannot seek, try the other profiles.
 
 <details>
 <summary>What each option does</summary>

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -47,7 +47,7 @@ Three things are true of all of them:
 
 - They are only visible when the `Show advanced settings` toggle is on
 - Changing one reloads the player, so anything currently playing stops briefly
-- Not every player shows every setting. A provider can set its own default, fix a setting so it cannot be changed, or hide it entirely where it does not apply. Where that happens it is noted on that provider's own page
+- Not every player shows every setting, and that is normal. A provider can set its own default or hide a setting where it does not apply, and some depend on what the player can do: a player that always streams the queue in one go has no flow mode setting to change, and a player that reports its own capabilities has no sample rate setting. Where a player differs from the defaults below, it is noted on that provider's own page
 
 #### Enable queue flow mode
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -37,7 +37,114 @@ Some players (e.g. [MusicCast](/player-support/musiccast/) have [unique control 
 
 - <b>Preferred Output Protocol.</b> Choose from the list of available protocols
 
-Each available protocol then has its own configuration section. Protocols can be disabled except for the native protocol of the device. Refer to the relevant Player provider for settings which are available for each.
+Each available protocol then has its own configuration section. Protocols can be disabled except for the native protocol of the device.
+
+### Settings shared by most protocols
+
+The settings below appear under most protocols and mean the same thing wherever you see them. **Most people never need to change any of them** — the defaults are chosen to work on the widest range of hardware, and the usual reason to come here is that something is not playing properly.
+
+Three things are true of all of them:
+
+- They are only visible when the `Show advanced settings` toggle is on
+- Changing one reloads the player, so anything currently playing stops briefly
+- Not every player shows every setting. A provider can set its own default, fix a setting so it cannot be changed, or hide it entirely where it does not apply. Where that happens it is noted on that provider's own page
+
+#### Enable queue flow mode
+
+Sends the whole queue to the player as one continuous stream, instead of one track at a time. Off by default.
+
+Turn it on if the player leaves a gap between tracks, stumbles on the change from one track to the next, or cannot do gapless playback at all. It is also switched on automatically when crossfade is in use, because stitching tracks together requires one continuous stream.
+
+The trade-off is that most players stop showing track information on their own display, because they only ever receive one long "track". The ICY setting below can put some of it back.
+
+#### Flow Mode sample rate
+
+Only applies when flow mode is on. A flow stream uses a single sample rate from start to finish, and this decides which one. `Smart` is the default and the right choice for almost everyone.
+
+<details>
+<summary>What each option does</summary>
+
+| Option | Behaviour |
+| --- | --- |
+| **Smart** *(default)* | Starts at the first track's rate, upsamples lower-rate tracks to match, and restarts the stream only when a track has a higher rate. The best balance of quality and seamless playback |
+| **Bit-perfect** | Never resamples. Playback restarts between tracks of differing sample rates, which disables gapless and crossfade across those transitions |
+| **48 kHz** | Resamples everything to a fixed 48 kHz, or the closest rate the player supports. A good compromise of quality and bandwidth |
+| **96 kHz** | Resamples everything to a fixed 96 kHz, or the closest rate the player supports |
+| **Highest supported by player** | Resamples everything to the highest rate the player supports. Best quality, but can waste a lot of bandwidth |
+
+</details>
+
+#### Try to inject metadata into stream (ICY)
+
+Only applies when flow mode is on. Slips the track title and artist into the audio stream itself so the player can display them — the same trick internet radio stations use. Disabled by default.
+
+Turn it on if your player shows nothing useful while flow mode is running. Not every player handles it correctly, so if playback becomes unreliable after enabling it, step down to Profile 1 or turn it off again.
+
+<details>
+<summary>What each option does</summary>
+
+| Option | Behaviour |
+| --- | --- |
+| **Disabled** *(default)* | No metadata is injected; the player will not show track info during flow mode |
+| **Profile 1 - basic info** | Title and artist only. Lightweight and widely compatible |
+| **Profile 2 - full info** | Also sends the album name and cover art. Richer, but some players mishandle it — use Profile 1 if you see playback issues |
+
+</details>
+
+#### Output codec to use for streaming audio to the player
+
+The format Music Assistant encodes the audio into before sending it. `FLAC` by default, which is lossless.
+
+Change it if the player cannot play FLAC, or to cut down network traffic on a weak Wi-Fi link — a lossy codec is a good first thing to try when playback stutters on wireless players.
+
+<details>
+<summary>What each option does</summary>
+
+| Option | Behaviour |
+| --- | --- |
+| **FLAC (lossless, compressed)** *(default)* | Full quality at a moderate bitrate. The best choice for most players |
+| **MP3 (lossy)** | Smaller bitrate at some quality cost. Use for players that cannot play FLAC, or to save bandwidth |
+| **AAC (lossy)** | Comparable to MP3; pick it for players that prefer AAC |
+| **WAV (uncompressed PCM)** | Highest bandwidth of the four. Only needed for players that cannot handle FLAC |
+
+</details>
+
+#### Sample rates supported by this player
+
+The sample rates and bit depths Music Assistant will send to this player as they are. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are ticked by default.
+
+This is worth understanding before changing it: **the ticked boxes are a deliberately safe starting point, not something detected from your device.** The higher rates are offered for you to try. If your player genuinely supports them, tick them and you will get better quality; if playback breaks or the player falls silent, untick them again. Manufacturers vary, so test rather than assume.
+
+#### Output Channel Mode
+
+Whether the player receives both channels, one channel, or a mono mix of the two. `Stereo` by default.
+
+The usual reason to change it is building a stereo pair from two players — set one to `Left channel only` and the other to `Right channel only`, then group them.
+
+#### Prefer low-latency WAV for live sources
+
+Sends live sources such as [Spotify Connect](/plugins/spotify-connect/) and the [AirPlay Receiver](/plugins/airplay-receiver/) as uncompressed audio, so there is less delay before you hear them. Off by default on most players, on by default on a few where it works well.
+
+Turn it off if those sources are unreliable on your player; Music Assistant will fall back to the output codec set above.
+
+#### HTTP Profile used for sending audio
+
+A low-level detail of how the audio is handed to the player. `Profile 2` by default, and correct for most players.
+
+This is a troubleshooting setting rather than a tuning one. Come here if the player stops part way through a track, refuses to start, or cannot seek — then try the other profiles.
+
+<details>
+<summary>What each option does</summary>
+
+| Option | Behaviour |
+| --- | --- |
+| **Profile 1 - chunked** | Sends audio using chunked transfer encoding, without a fixed length up front |
+| **Profile 2 - no content length** *(default)* | Streams without a Content-Length header. Works for most players |
+| **Profile 3 - forced content length** | Sends an estimated Content-Length header. Some players need this to start playback or to seek |
+
+</details>
+
+### Group player settings
 
 For group players the following settings will be seen:
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -134,16 +134,18 @@ Turn it off if those sources are unreliable on your player; Music Assistant will
 
 A low-level detail of how the audio is handed to the player. `Profile 2` by default, and correct for most players.
 
-Change it only to fix a problem. If the player stops part way through a track, refuses to start, or cannot seek, try the other profiles.
+The three differ in whether Music Assistant tells the player how much audio is coming before it starts sending any. Most players do not mind either way, but a few will not start, stop part way through, or refuse to skip within a track unless they are told in advance.
+
+Change it only to fix a problem. If the player behaves in any of those ways, work through the other profiles.
 
 <details>
 <summary>What each option does</summary>
 
 | Option | Behaviour |
 | --- | --- |
-| **Profile 1 - chunked** | Sends audio using chunked transfer encoding, without a fixed length up front |
-| **Profile 2 - no content length** *(default)* | Streams without a Content-Length header. Works for most players |
-| **Profile 3 - forced content length** | Sends an estimated Content-Length header. Some players need this to start playback or to seek |
+| **Profile 1 - chunked** | Sends the audio in pieces as it is produced, without saying how much is coming |
+| **Profile 2 - no content length** *(default)* | Sends the audio as one continuous stream, without saying how much is coming. Right for most players |
+| **Profile 3 - forced content length** | Tells the player up front roughly how much audio to expect, worked out from the length of the track. Try this one first if the player will not start, cuts off early, or will not let you skip within a track |
 
 </details>
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -41,7 +41,7 @@ Each available protocol then has its own configuration section. Protocols can be
 
 ### Settings shared by most protocols
 
-The settings below appear under most protocols and mean the same thing wherever you see them. **Most people never need to change any of them** — the defaults are chosen to work on the widest range of hardware, and the usual reason to come here is that something is not playing properly.
+The settings below appear under most protocols and mean the same thing wherever you see them. **Most people never need to change any of them.** The defaults are chosen to work on the widest range of hardware, and the usual reason to come here is that something is not playing properly.
 
 Two things are true of all of them:
 
@@ -90,7 +90,7 @@ Turn it on if your player shows nothing useful while flow mode is running. Start
 | --- | --- |
 | **Disabled - do not send ICY metadata** *(default)* | No metadata is injected; the player will not show track info during flow mode |
 | **Profile 1 - basic info** | Title and artist only. Lightweight and widely compatible |
-| **Profile 2 - full info (including image)** | Also sends the album name and cover art. Richer, but some players mishandle it — use Profile 1 if you see playback issues |
+| **Profile 2 - full info (including image)** | Also sends the album name and cover art. Richer, but some players mishandle it, so use Profile 1 if you see playback issues |
 
 </details>
 
@@ -98,7 +98,7 @@ Turn it on if your player shows nothing useful while flow mode is running. Start
 
 The format Music Assistant encodes the audio into before sending it. `FLAC` by default, which is lossless.
 
-Change it if the player cannot play FLAC, or to cut down network traffic on a weak Wi-Fi link — a lossy codec is a good first thing to try when playback stutters on wireless players.
+Change it if the player cannot play FLAC, or to cut down network traffic on a weak Wi-Fi link. A lossy codec is a good first thing to try when playback stutters on wireless players.
 
 <details>
 <summary>What each option does</summary>
@@ -116,13 +116,13 @@ Change it if the player cannot play FLAC, or to cut down network traffic on a we
 
 The sample rates and bit depths Music Assistant will send to this player as they are. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are ticked by default.
 
-Rates are offered up to 384 kHz / 24 bit, though most providers narrow that list to what the device plausibly handles. On most players the ticked boxes are a safe starting point rather than something detected from the device, and the higher ones are offered for you to try. If your player genuinely supports them, tick them and you will get better quality; if playback breaks or the player falls silent, untick them again. Manufacturers vary, so test rather than assume. Some providers do detect the device's capabilities and set this for you — those pages say so.
+Rates are offered up to 384 kHz / 24 bit, though most providers narrow that list to what the device plausibly handles. On most players the ticked boxes are a safe starting point rather than something detected from the device, and the higher ones are offered for you to try. If your player genuinely supports them, tick them and you will get better quality; if playback breaks or the player falls silent, untick them again. Manufacturers vary, so test rather than assume. Some providers do detect the device's capabilities and set this for you, and those pages say so.
 
 #### Output Channel Mode
 
 Whether the player receives both channels, one channel, or a mono mix of the two. `Stereo` by default.
 
-The usual reason to change it is building a stereo pair from two players — set one to `Left channel only` and the other to `Right channel only`, then group them.
+The usual reason to change it is building a stereo pair from two players. Set one to `Left channel only` and the other to `Right channel only`, then group them.
 
 #### Prefer low-latency WAV for live sources
 


### PR DESCRIPTION
## What does this change?

Eight settings appear under most output protocols and mean the same thing wherever they appear, but they were only ever explained on the individual provider pages — **113 copies across `player-support/`**, with the quality of the explanation varying by which speaker the reader happened to own. *Sample rates supported by this player* had **thirteen different wordings across fourteen pages**; someone reading `amplipi.md` got "the default is FLAC but other options are MP3, AAC or WAV" and nothing about why they would pick one.

This adds a **Settings shared by most protocols** section under *Output Protocols*, covering all eight:

queue flow mode · flow mode sample rate · ICY metadata · output codec · sample rates · output channel mode · low-latency WAV · HTTP profile

Each says what it does, what the default is, and **when you would change it**. Option-by-option detail sits in collapsed `<details>` sections so the page stays scannable for someone looking up one setting — the same pattern already used in `usage.md` and `local-files.md`.

## Facts stated here for the first time

- All eight are only visible with the `Show advanced settings` toggle on, and **changing one reloads the player**, so playback stops briefly.
- **Flow Mode sample rate** and **ICY metadata** both depend on flow mode being enabled, so both are greyed out until it is. This is general behaviour; one provider page had presented it as a device quirk.
- **AirPlay, Sendspin and Snapcast do not stream over HTTP**, so those players show only *Output Channel Mode* from this list.
- Rates are offered up to 384 kHz / 24 bit, and Universal Groups default to `Profile 1` for the HTTP profile.

## Where the content came from

Checked against `music-assistant/server` @ `d790439` — `constants.py` for defaults and behaviour, `translations/en.json` for what each option means — so the docs agree with the UI help rather than paraphrasing it a fourteenth way. **No source strings were changed.**

A verification pass over the finished text caught four claims that were wrong or too absolute, now corrected in the second commit:

- Crossfade only forces flow mode when the player **cannot do gapless playback itself**, not whenever crossfade is on.
- The ticked sample rates are a safe subset **on most players** — four providers do set them from the device, so the previous flat "not something detected from your device" was wrong.
- Flow mode is off by default **on most** players; several providers turn it on.
- Two ICY option labels now match the wording shown in the UI.

## Checklist

- [x] Correct branch: `beta`
- [x] No new pages, so no sidebar entry needed

## Verification

Full build; `<details>` blocks and their tables render correctly; every internal link and anchor resolves (**0 broken**).

Standalone. #971, #972 and #975 stack on this one; merge it first and they retarget cleanly.