### PR TITLE
Trim the repeated protocol settings from eight player pages

### DIFF
--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -40,7 +40,6 @@ Music Assistant chooses how to stream to each device automatically, so under nor
 - <b>Audio buffer depth.</b> How much audio the speaker keeps queued ahead of playback. Increase this if the speaker stays silent or drops out while Music Assistant shows it playing — at the cost of slower skipping and pausing. Automatic picks a value suited to the device.
 - <b>Ignore volume reports sent by the device itself.</b> Some devices report their own volume level unreliably, which can cause unexpected volume changes. Enable this to ignore those reports.
 - <b>Enable encryption.</b> Only shown for devices streaming with AirPlay 1 (RAOP). Some third party players require this to be turned off.
-- <b>Output channel mode.</b> Play only the left or right channel, for example to create a stereo pair from 2 players, or downmix to mono.
 
 ### AirPlay Provider Settings
 

--- a/src/content/docs/player-support/alexa.md
+++ b/src/content/docs/player-support/alexa.md
@@ -84,13 +84,9 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>API Basic Auth Password.</b> The password you put in `app_password.txt`
 - <b>Alexa Language.</b> Locale used for Alexa (e.g. en-US)
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Alexa players have the following settings:
+Alexa players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those behaves differently here:
 
-- <b>Output channel mode.</b> The default is `Stereo` but other options are `Left channel only`, `Right channel only` or `Mono (both channels)`
-- <b>Sample rates supported by this player.</b> This setting is automatically set upon player discovery but the sample rates and bit depths supported by the player can be manually set. Content with unsupported sample rates will be resampled
-- <b>Output codec to use for streaming audio to the player.</b> The default is `FLAC` but other options are `MP3`, `AAC` or `WAV`
-- <b>HTTP profile used for send audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues
-- <b>Try to inject metadata into stream (ICY).</b> Enabling this option attempts to provide metadata to the player which can be used to show track info, even when flow mode is enabled. Not all players support this correctly, therefore, if there are issues with playback try disabling this setting
+- <b>Sample rates supported by this player.</b> Unlike most players, this is set automatically when the player is discovered. You can still adjust it by hand if you need to
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/alexa.md
+++ b/src/content/docs/player-support/alexa.md
@@ -84,9 +84,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>API Basic Auth Password.</b> The password you put in `app_password.txt`
 - <b>Alexa Language.</b> Locale used for Alexa (e.g. en-US)
 
-Alexa players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those behaves differently here:
-
-- <b>Sample rates supported by this player.</b> Unlike most players, this is set automatically when the player is discovered. You can still adjust it by hand if you need to
+Alexa players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/amplipi.md
+++ b/src/content/docs/player-support/amplipi.md
@@ -28,7 +28,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Host.</b> The hostname or IP address of the AmpliPi controller (e.g. `amplipi.local` or `192.168.1.50`). A full URL may also be provided. This is asked when you add the provider and is required, as AmpliPi controllers are not auto-discovered
 
-Each zone on the controller becomes its own player, using the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
+Each zone on the controller becomes its own player. AmpliPi zones use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 
 AmpliPi zones always play the queue as one continuous stream, so there is no flow mode setting to change.
 

--- a/src/content/docs/player-support/amplipi.md
+++ b/src/content/docs/player-support/amplipi.md
@@ -28,13 +28,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Host.</b> The hostname or IP address of the AmpliPi controller (e.g. `amplipi.local` or `192.168.1.50`). A full URL may also be provided. This is asked when you add the provider and is required, as AmpliPi controllers are not auto-discovered
 
-Each zone on the controller becomes its own player. In addition to the [Individual Player Settings](/settings/individual-player/) the AmpliPi players have the following settings:
-
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if playback of those sources is unreliable
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits. Higher rates and 24 bit options are offered if your setup handles them. Content with unsupported sample rates will be resampled
+Each zone on the controller becomes its own player, using the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 
 AmpliPi zones always play the queue as one continuous stream, so there is no flow mode setting to change.
 

--- a/src/content/docs/player-support/heos.md
+++ b/src/content/docs/player-support/heos.md
@@ -2,7 +2,6 @@
 title: HEOS
 ---
 
-
 # HEOS <img src="/assets/icons/heos-icon.svg" alt="Preview image" style="width: 70px; float: right;" loading="lazy" />
 
 Music Assistant has support for Denon & Marantz devices with [HEOS](https://www.denon.com/en-us/denon-heos.html). Contributed and maintained by [Tommatheussen](https://github.com/Tommatheussen).
@@ -28,12 +27,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Main controller hostname or IP address.</b> This is the HEOS device that will be act as the main controller, it is not mandatory. This setting can be used to force MA to use a specific device as the controller
 - <b>Command timeout value.</b> How long Music Assistant waits for a HEOS device to answer a command, in seconds. The default is 25 and it can be set between 10 and 60. Increase it if you see command timeout messages in the log
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the HEOS players have the following settings:
-
-- <b>Output codec to use for streaming audio to the player.</b> The default is `FLAC` but other options are `MP3`, `AAC` or `WAV`
-- <b>Output channel mode.</b> The default is `Stereo` but other options are `Left channel only`, `Right channel only` or `Mono (both channels)`
-- <b>HTTP profile used for send audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
+HEOS players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 
 HEOS players always play the queue as one continuous stream, so there is no flow mode setting to change. There is also no sample rates setting because HEOS players report their own capability. First generation HEOS hardware is limited to 48kHz / 16 bits, while HS2 and newer models handle up to 192kHz / 24 bits.
 

--- a/src/content/docs/player-support/roku.md
+++ b/src/content/docs/player-support/roku.md
@@ -33,7 +33,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 Roku players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on a Roku:
 
-- <b>Sample rates supported by this player.</b> The ticked defaults match Roku's stated support. Higher rates may still work depending on the device, so they are worth a try
+- <b>Sample rates supported by this player.</b> The rates selected by default match Roku's stated support. Higher rates may still work depending on the device, so they are worth adding to see
 - <b>Output codec to use for streaming audio to the player.</b> Some codecs load faster than others depending on the Roku device, so try another if playback is slow to start
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/roku.md
+++ b/src/content/docs/player-support/roku.md
@@ -33,7 +33,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 Roku players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on a Roku:
 
-- <b>Sample rates supported by this player.</b> The rates selected by default match Roku's stated support. Higher rates may still work depending on the device, so they are worth adding to see
+- <b>Sample rates supported by this player.</b> The rates selected by default match Roku's stated support. Higher rates may still work depending on the device
 - <b>Output codec to use for streaming audio to the player.</b> Some codecs load faster than others depending on the Roku device, so try another if playback is slow to start
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/roku.md
+++ b/src/content/docs/player-support/roku.md
@@ -31,16 +31,12 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Manual IP addresses for discovery.</b> Add Roku devices by IP address when automatic discovery does not find them on your network
 - <b>App ID of Media Assistant.</b> Defaults to the Roku Channel Store version of Media Assistant, ID 782875. Set it to dev if you sideloaded the app onto your Roku
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Roku players have the following settings:
+Roku players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those are worth knowing about on a Roku:
 
-- <b>Enable queue flow mode.</b> Off by default. Enabling this option will send all tracks as a continuous audio stream. This allows for support of gapless or crossfading. This can also help if your Roku is having difficulty transitioning between tracks. This does have the side effect of losing some displayed metadata
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Sample rates supported by this player.</b> This setting defaults to Roku's stated support of 44.1kHz / 16 bits and 48kHz / 16 bits, but the sample rates and bit depths can be manually set. Unsupported sample rates may work depending on the Roku device
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV. Some codecs may load faster than others depending on the Roku device
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the Roku cannot play continuous WAV streams
-- <b>Try to inject metadata into stream (ICY).</b> Only applies while flow mode is enabled, so it is greyed out with the default settings. It attempts to provide metadata to the player so it can show track info during a flow stream
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Sample rates supported by this player.</b> Defaults to Roku's stated support of 44.1 kHz / 16 bit and 48 kHz / 16 bit. Higher rates may work anyway depending on the device, so they are worth trying
+- <b>Output codec to use for streaming audio to the player.</b> Some codecs load faster than others depending on the Roku device, so it is worth trying another if playback is slow to start
+
+If your Roku struggles to move from one track to the next, turning on <b>Enable queue flow mode</b> often helps.
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/roku.md
+++ b/src/content/docs/player-support/roku.md
@@ -31,12 +31,10 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Manual IP addresses for discovery.</b> Add Roku devices by IP address when automatic discovery does not find them on your network
 - <b>App ID of Media Assistant.</b> Defaults to the Roku Channel Store version of Media Assistant, ID 782875. Set it to dev if you sideloaded the app onto your Roku
 
-Roku players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those are worth knowing about on a Roku:
+Roku players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on a Roku:
 
-- <b>Sample rates supported by this player.</b> Defaults to Roku's stated support of 44.1 kHz / 16 bit and 48 kHz / 16 bit. Higher rates may work anyway depending on the device, so they are worth trying
-- <b>Output codec to use for streaming audio to the player.</b> Some codecs load faster than others depending on the Roku device, so it is worth trying another if playback is slow to start
-
-If your Roku struggles to move from one track to the next, turning on <b>Enable queue flow mode</b> often helps.
+- <b>Sample rates supported by this player.</b> The ticked defaults match Roku's stated support. Higher rates may still work depending on the device, so they are worth a try
+- <b>Output codec to use for streaming audio to the player.</b> Some codecs load faster than others depending on the Roku device, so try another if playback is slow to start
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/samsung-wam.md
+++ b/src/content/docs/player-support/samsung-wam.md
@@ -30,11 +30,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Manual IP addresses for discovery.</b> Specify one or more IP addresses to add speakers that aren't discovered automatically. Only needed in non-standard network setups, for example, if your speakers are on a different subnet from the MA server.
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Samsung WAM players have the following settings:
-
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC, or WAV
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only, or Mono (both channels)
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the speaker cannot play continuous WAV streams
+Samsung WAM players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 
 WAM speakers always play the queue as one continuous stream, because they cannot queue the next track themselves. The stream starts at the first track's sample rate and only resamples later tracks upward, and there is no setting to change that. There is also no sample rates setting, as WAM speakers report their own support of 44.1kHz through to 192kHz at 16 or 24 bits.
 

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -48,7 +48,6 @@ In addition to the [Individual Player Settings](/settings/individual-player/) th
 - <b>Automatically play line-in on.</b> Only shown for devices with a line-in that can report when a signal is present. Chooses where that line-in plays automatically, either This device, another player, or Off
 - <b>Static playback delay (ms).</b> Only shown for devices that support it. Shifts this player's audio to keep it in step with the others, from 0 up to 5000 ms. Increase it if audio on this player is heard too late, for example to make up for delay added by an amplifier, active speakers or the device's own operating system
 - <b>Preferred audio format.</b> The audio format used for playback on this player. Automatic (let client decide) is the default, and the other options are read from the device itself
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -35,9 +35,9 @@ Individual Sendspin players will appear automatically when clients connect
 
 In addition to the [Player Provider Settings](/settings/player-provider/) when setting up this provider the following settings are available:
 
-<b>Manual IP addresses for discovery.</b> Sendspin players are normally found on their own. If yours is not, add its IP address or network name here, for example 192.168.1.50 or speaker.local. Music Assistant will then connect to it directly, and keep trying if the device is switched off when MA starts
-<b>Allow legacy clients.</b> On by default. Accepts older Sendspin devices that do not follow the current specification, including devices that connect without encryption, whose traffic can be read by anyone on your local network. Turn it off to accept only up to date devices. This option is temporary and will be removed in a future release
-<b>Minimum PIN length.</b> The fewest digits a device may use for dynamic PIN pairing. The default is 4 and it can be set as high as 12
+- <b>Manual IP addresses for discovery.</b> Sendspin players are normally found on their own. If yours is not, add its IP address or network name here, for example 192.168.1.50 or speaker.local. Music Assistant will then connect to it directly, and keep trying if the device is switched off when MA starts
+- <b>Allow legacy clients.</b> On by default. Accepts older Sendspin devices that do not follow the current specification, including devices that connect without encryption, whose traffic can be read by anyone on your local network. Turn it off to accept only up to date devices. This option is temporary and will be removed in a future release
+- <b>Minimum PIN length.</b> The fewest digits a device may use for dynamic PIN pairing. The default is 4 and it can be set as high as 12
 
 In addition to the [Individual Player Settings](/settings/individual-player/) the Sendspin players have the following settings:
 

--- a/src/content/docs/player-support/snapcast.md
+++ b/src/content/docs/player-support/snapcast.md
@@ -51,9 +51,7 @@ One setting applies whichever server you use:
 
 ### Player
 
-In addition to the [Individual Player Settings](/settings/individual-player/), Snapcast players also have a unique setting as follows:
-
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
+Snapcast players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 
 ## Known Issues / Notes
 


### PR DESCRIPTION
## What does this change?

> **Stacked on #970** — it links the anchor that PR adds, so the base is `claude/docs-protocol-settings` rather than `beta`. Merge #970 first and this retargets cleanly.

Eight player pages restated settings that mean the same thing on every player, in wordings that had drifted apart from one another. With the shared explanation now on the player settings page, they point at it instead.

Pages: `airplay` · `alexa` · `amplipi` · `heos` · `roku` · `samsung-wam` · `sendspin` · `snapcast`

## How I decided what was safe to remove

Bullets were removed **only** where the server code confirms the provider uses the stock config entry — checked against `music-assistant/server` @ `d790439`. None of these eight overrides any entry removed here.

Kept, because it is genuinely specific to the device:

- **roku** — the ticked sample rates match Roku's stated support but higher ones may still work; some codecs load faster than others
- **amplipi**, **heos**, **samsung-wam** — the existing notes about always streaming the queue continuously, and the HEOS generation sample-rate limits
- **airplay**, **sendspin**, **snapcast** — their own unique settings are untouched; only the one shared bullet went

## Fixed after review

- **alexa** — the sample-rate bullet claimed the value is "set automatically when the player is discovered". The code does not support that: Alexa has no sample-rate override at all. Removed rather than repeated.
- **roku** — a new line repeated flow-mode advice already present in Known Issues on the same short page. Dropped.
- **sendspin** — three provider settings had no list markers, so CommonMark rendered them as one run-on paragraph. Fixed while editing that list.
- One pointer sentence is now used on every page, instead of the several variants the first pass produced, and the brittle "two of those differ" counts are gone.

## Checklist

- [x] Correct branch (stacked, see above)
- [x] No new pages, so no sidebar entry needed

## Verification

Full build passes; every internal link and anchor resolves (**0 broken**).