### PR TITLE
Reduce the provider pages to what differs from the shared settings

### DIFF
--- a/src/content/docs/player-support/airplay.md
+++ b/src/content/docs/player-support/airplay.md
@@ -23,6 +23,8 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 ## Protocol Settings
 
+AirPlay does not stream over HTTP, so of the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols) these players show only **Output Channel Mode**. The settings below are specific to AirPlay.
+
 Some devices (Apple TVs, HomePods and other AirPlay 2 speakers) must be paired before Music Assistant can use them. These show a Setup button in the player settings — press it and follow the steps, entering the PIN shown on the device's screen. Devices protected with a password ask for the password instead.
 
 Apple TVs offer two extra pairing steps after the main one. Both are optional and can be added later by running Setup again:

--- a/src/content/docs/player-support/bluesound.md
+++ b/src/content/docs/player-support/bluesound.md
@@ -23,8 +23,8 @@ Refer to the [Player Provider Settings](/settings/player-provider/) when setting
 
 Bluesound players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on BluOS:
 
-- <b>Sample rates supported by this player.</b> Everything up to 192 kHz / 24 bit is selected by default, rather than only 44.1 kHz / 16 bit and 48 kHz / 16 bit. Remove the higher ones if your player cannot manage them
-- <b>Try to inject metadata into stream (ICY).</b> Defaults to Profile 2 - full info, rather than being off as it is elsewhere
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> Everything up to 192 kHz / 24 bit is selected by default, rather than only 44.1 kHz / 16 bit and 48 kHz / 16 bit. Remove the higher ones if your player cannot manage them
+- <b>[Try to inject metadata into stream (ICY)](/settings/individual-player/#try-to-inject-metadata-into-stream-icy).</b> Defaults to Profile 2 - full info, rather than being off as it is elsewhere
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bluesound.md
+++ b/src/content/docs/player-support/bluesound.md
@@ -21,12 +21,10 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 Refer to the [Player Provider Settings](/settings/player-provider/) when setting up this provider as it has no unique settings at the provider level.
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Bluesound players have the following settings:
+Bluesound players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those differ here:
 
-- <b>Sample rates supported by this player.</b> This setting is automatically set upon player discovery but the sample rates and bit depths supported by the player can be manually set. Content with unsupported sample rates will be resampled
-- <b>Output codec to use for streaming audio to the player.</b> The default is `FLAC` but other options are `MP3`, `AAC` or `WAV`
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
-- <b>Output channel mode.</b> The default is `Stereo` but other options are `Left channel only`, `Right channel only` or `Mono (both channels)`
+- <b>Sample rates supported by this player.</b> Set automatically when the player is discovered, with options offered up to 192 kHz / 24 bit
+- <b>Try to inject metadata into stream (ICY).</b> Defaults to Profile 2 - full info on BluOS players, rather than being off as it is elsewhere
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bluesound.md
+++ b/src/content/docs/player-support/bluesound.md
@@ -21,10 +21,10 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 Refer to the [Player Provider Settings](/settings/player-provider/) when setting up this provider as it has no unique settings at the provider level.
 
-Bluesound players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those differ here:
+Bluesound players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on BluOS:
 
-- <b>Sample rates supported by this player.</b> Set automatically when the player is discovered, with options offered up to 192 kHz / 24 bit
-- <b>Try to inject metadata into stream (ICY).</b> Defaults to Profile 2 - full info on BluOS players, rather than being off as it is elsewhere
+- <b>Sample rates supported by this player.</b> Everything up to 192 kHz / 24 bit is offered and ticked by default, rather than just the two safe rates. Untick the higher ones if your player cannot manage them
+- <b>Try to inject metadata into stream (ICY).</b> Defaults to Profile 2 - full info, rather than being off as it is elsewhere
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bluesound.md
+++ b/src/content/docs/player-support/bluesound.md
@@ -23,7 +23,7 @@ Refer to the [Player Provider Settings](/settings/player-provider/) when setting
 
 Bluesound players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on BluOS:
 
-- <b>Sample rates supported by this player.</b> Everything up to 192 kHz / 24 bit is selected by default, rather than just the two safe rates. Remove the higher ones if your player cannot manage them
+- <b>Sample rates supported by this player.</b> Everything up to 192 kHz / 24 bit is selected by default, rather than only 44.1 kHz / 16 bit and 48 kHz / 16 bit. Remove the higher ones if your player cannot manage them
 - <b>Try to inject metadata into stream (ICY).</b> Defaults to Profile 2 - full info, rather than being off as it is elsewhere
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/bluesound.md
+++ b/src/content/docs/player-support/bluesound.md
@@ -23,7 +23,7 @@ Refer to the [Player Provider Settings](/settings/player-provider/) when setting
 
 Bluesound players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on BluOS:
 
-- <b>Sample rates supported by this player.</b> Everything up to 192 kHz / 24 bit is offered and ticked by default, rather than just the two safe rates. Untick the higher ones if your player cannot manage them
+- <b>Sample rates supported by this player.</b> Everything up to 192 kHz / 24 bit is selected by default, rather than just the two safe rates. Remove the higher ones if your player cannot manage them
 - <b>Try to inject metadata into stream (ICY).</b> Defaults to Profile 2 - full info, rather than being off as it is elsewhere
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/bose-soundtouch.md
+++ b/src/content/docs/player-support/bose-soundtouch.md
@@ -41,8 +41,8 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the SoundTouch players have the following settings:
 
 - <b>Overwrite preset 1-6.</b> Press one of these buttons to hand that physical preset button on this speaker over to Music Assistant. Do this once per speaker for each button you want to use. The button's label tells you when the speaker already has something stored on that preset. What the button plays is set in the provider settings above
-- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 on SoundTouch speakers, which gives by far the most reliable playback. The other codecs are available but are more likely to cause problems here
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit
+- <b>[Output codec to use for streaming audio to the player](/settings/individual-player/#output-codec-to-use-for-streaming-audio-to-the-player).</b> Defaults to MP3 on SoundTouch speakers, which gives by far the most reliable playback. The other codecs are available but are more likely to cause problems here
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> Rates go up to 192 kHz / 24 bit
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bose-soundtouch.md
+++ b/src/content/docs/player-support/bose-soundtouch.md
@@ -42,7 +42,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 
 - <b>Overwrite preset 1-6.</b> Press one of these buttons to hand that physical preset button on this speaker over to Music Assistant. Do this once per speaker for each button you want to use. The button's label tells you when the speaker already has something stored on that preset. What the button plays is set in the provider settings above
 - <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 on SoundTouch speakers, which gives by far the most reliable playback. The other codecs are available but are more likely to cause problems here
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit. The usual two stay selected by default
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bose-soundtouch.md
+++ b/src/content/docs/player-support/bose-soundtouch.md
@@ -2,7 +2,6 @@
 title: Bose SoundTouch
 ---
 
-
 # Bose SoundTouch <img src="/assets/icons/bose-soundtouch-icon.png" alt="Preview image" style="width: 70px; float: right;" loading="lazy" />
 
 Music Assistant has support for [Bose SoundTouch](https://www.bose.com/) speakers. Following Bose's end of life of the SoundTouch platform, this provider keeps the speakers usable within Music Assistant by exposing native control and mapping their physical preset buttons to Music Assistant content. Contributed and maintained by [Odn0](https://github.com/Odn0).
@@ -39,12 +38,11 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Bose SoundTouch app key.</b> Optional. A Bose SoundTouch developer app key enables sending announcements to the speaker as an overlay that ducks the current music and resumes it afterwards. Leave this empty to disable native announcements (they then play through the linked playback protocol instead)
 - <b>Presets 1-6.</b> Each of the six physical preset buttons can be mapped to a Music Assistant media item. The mapping is shared by every SoundTouch speaker of this provider, so preset 4 plays the same thing on all of them. To set one up, use the <b>Search engine preset</b> section: choose a <b>Media type</b>, enter your keywords and press <b>Search</b>, pick a <b>Result</b>, choose which button it belongs to under <b>Select for preset</b>, then press <b>Assign result to preset</b>. The chosen item appears under <b>Presets</b> as <b>Preset 1-6 to play</b>, where a Music Assistant URI (provider://media_type/identifier) can also be entered manually instead of using the search flow
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the SoundTouch players have the following settings:
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the SoundTouch players have the following settings:
 
 - <b>Overwrite preset 1-6.</b> Press one of these buttons to hand that physical preset button on this speaker over to Music Assistant. Do this once per speaker for each button you want to use. The button's label tells you when the speaker already has something stored on that preset. What the button plays is set in the provider settings above
-- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 for SoundTouch speakers, which gives by far the most reliable playback. FLAC, AAC and WAV are also available but are more likely to cause problems on these speakers
-- <b>Enable queue flow mode.</b> Sends all queue tracks as one continuous audio stream. Use this if the speaker has trouble transitioning between tracks
-- <b>Sample rates supported by this player.</b> This setting is automatically set upon player discovery but the sample rates and bit depths can be manually set. SoundTouch speakers support up to 192kHz / 24 bits. Content with unsupported sample rates will be resampled
+- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 on SoundTouch speakers, which gives by far the most reliable playback. The other codecs are available but are more likely to cause problems here
+- <b>Sample rates supported by this player.</b> Set automatically when the speaker is discovered. SoundTouch speakers support up to 192 kHz / 24 bit
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bose-soundtouch.md
+++ b/src/content/docs/player-support/bose-soundtouch.md
@@ -42,7 +42,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 
 - <b>Overwrite preset 1-6.</b> Press one of these buttons to hand that physical preset button on this speaker over to Music Assistant. Do this once per speaker for each button you want to use. The button's label tells you when the speaker already has something stored on that preset. What the button plays is set in the provider settings above
 - <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 on SoundTouch speakers, which gives by far the most reliable playback. The other codecs are available but are more likely to cause problems here
-- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. The usual two rates stay ticked by default
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit. The usual two stay selected by default
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/bose-soundtouch.md
+++ b/src/content/docs/player-support/bose-soundtouch.md
@@ -42,7 +42,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 
 - <b>Overwrite preset 1-6.</b> Press one of these buttons to hand that physical preset button on this speaker over to Music Assistant. Do this once per speaker for each button you want to use. The button's label tells you when the speaker already has something stored on that preset. What the button plays is set in the provider settings above
 - <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 on SoundTouch speakers, which gives by far the most reliable playback. The other codecs are available but are more likely to cause problems here
-- <b>Sample rates supported by this player.</b> Set automatically when the speaker is discovered. SoundTouch speakers support up to 192 kHz / 24 bit
+- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. The usual two rates stay ticked by default
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/dlna.md
+++ b/src/content/docs/player-support/dlna.md
@@ -27,8 +27,8 @@ For information about the settings seen in the MA UI refer to the [Player Provid
 
 - <b>Enable queue flow mode.</b> On by default for DLNA, because most DLNA players cannot queue up the next track themselves
 - <b>Replace Pause with Stop.</b> Some older uPnP players are unable to pause streamed music and ignore the command. Enable this if that occurs and a stop command will be issued for both pause and stop
-- <b>Sample rates supported by this player.</b> Set automatically when the player is discovered, with options offered up to 192 kHz / 24 bit
-- <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only shown for players that can queue the next track themselves, and only while flow mode is switched off
+- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. The usual two rates stay ticked by default
+- <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only shown for players that support gapless playback, and only while flow mode is switched off
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/dlna.md
+++ b/src/content/docs/player-support/dlna.md
@@ -27,7 +27,7 @@ For information about the settings seen in the MA UI refer to the [Player Provid
 
 - <b>Enable queue flow mode.</b> On by default for DLNA, because most DLNA players cannot queue up the next track themselves
 - <b>Replace Pause with Stop.</b> Some older uPnP players are unable to pause streamed music and ignore the command. Enable this if that occurs and a stop command will be issued for both pause and stop
-- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. The usual two rates stay ticked by default
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit. The usual two stay selected by default
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only shown for players that support gapless playback, and only while flow mode is switched off
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/dlna.md
+++ b/src/content/docs/player-support/dlna.md
@@ -23,17 +23,11 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 ## Settings
 
-For information about the settings seen in the MA UI refer to the [Player Provider Settings](/settings/player-provider/) and [Individual Player Settings](/settings/individual-player/) pages. Specific settings available for this player in the Output Protocol(s) section are:
+For information about the settings seen in the MA UI refer to the [Player Provider Settings](/settings/player-provider/) and [Individual Player Settings](/settings/individual-player/) pages, including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Settings that differ or are specific to DLNA are:
 
-- <b>Enable queue flow mode.</b> Sends all tracks as one continuous audio stream. This is switched on by default for DLNA because most DLNA players cannot queue up the next track themselves. May have the side effect of losing metadata to the player
-- <b>Flow Mode sample rate.</b> A flow mode stream uses a single sample rate from start to finish, and this decides which one. Smart (the default) starts at the first track's rate and only restarts the stream when a later track is higher. Other options are Bit-perfect, a fixed 48 kHz or 96 kHz, or Highest supported by player
+- <b>Enable queue flow mode.</b> On by default for DLNA, because most DLNA players cannot queue up the next track themselves
 - <b>Replace Pause with Stop.</b> Some older uPnP players are unable to pause streamed music and ignore the command. Enable this if that occurs and a stop command will be issued for both pause and stop
-- <b>Sample rates supported by this player.</b> This setting is automatically set upon player discovery but the sample rates and bit depths supported by the player can be manually set. DLNA players are offered up to 192kHz / 24 bits. Content with unsupported sample rates will be resampled
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Try to inject metadata into stream (ICY).</b> Off by default. Enabling this attempts to provide metadata to the player which can be used to show track info, even when flow mode is enabled. Profile 1 - basic info sends title and artist only, Profile 2 - full info adds the album name and cover art. Not all players support this correctly, therefore, if there are issues with playback try a lower profile or disable it
+- <b>Sample rates supported by this player.</b> Set automatically when the player is discovered, with options offered up to 192 kHz / 24 bit
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only shown for players that can queue the next track themselves, and only while flow mode is switched off
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/dlna.md
+++ b/src/content/docs/player-support/dlna.md
@@ -27,7 +27,7 @@ For information about the settings seen in the MA UI refer to the [Player Provid
 
 - <b>Enable queue flow mode.</b> On by default for DLNA, because most DLNA players cannot queue up the next track themselves
 - <b>Replace Pause with Stop.</b> Some older uPnP players are unable to pause streamed music and ignore the command. Enable this if that occurs and a stop command will be issued for both pause and stop
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit. The usual two stay selected by default
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only shown for players that support gapless playback, and only while flow mode is switched off
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/dlna.md
+++ b/src/content/docs/player-support/dlna.md
@@ -25,9 +25,9 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 For information about the settings seen in the MA UI refer to the [Player Provider Settings](/settings/player-provider/) and [Individual Player Settings](/settings/individual-player/) pages, including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Settings that differ or are specific to DLNA are:
 
-- <b>Enable queue flow mode.</b> On by default for DLNA, because most DLNA players cannot queue up the next track themselves
+- <b>[Enable queue flow mode](/settings/individual-player/#enable-queue-flow-mode).</b> On by default for DLNA, because most DLNA players cannot queue up the next track themselves
 - <b>Replace Pause with Stop.</b> Some older uPnP players are unable to pause streamed music and ignore the command. Enable this if that occurs and a stop command will be issued for both pause and stop
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> Rates go up to 192 kHz / 24 bit
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only shown for players that support gapless playback, and only while flow mode is switched off
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/fully-kiosk.md
+++ b/src/content/docs/player-support/fully-kiosk.md
@@ -30,7 +30,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Use HTTPS when connecting to the Fully Kiosk API.</b> This is off by default
 - <b>Verify HTTPS certificates (recommended).</b> This is on by default. Turning it off trusts any certificate without validation
 - <b>TLS certificate fingerprint.</b> Optional SHA-256 hex fingerprint. When provided it must match the device certificate and overrides the Verify HTTPS certificates setting
-- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 here rather than FLAC, because many tablets struggle with lossless. Stay on MP3 unless you have a reason to change
+- <b>[Output codec to use for streaming audio to the player](/settings/individual-player/#output-codec-to-use-for-streaming-audio-to-the-player).</b> Defaults to MP3 here rather than FLAC, because many tablets struggle with lossless. Stay on MP3 unless you have a reason to change
   
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/fully-kiosk.md
+++ b/src/content/docs/player-support/fully-kiosk.md
@@ -31,12 +31,11 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Verify HTTPS certificates (recommended).</b> This is on by default. Turning it off trusts any certificate without validation
 - <b>TLS certificate fingerprint.</b> Optional SHA-256 hex fingerprint. When provided it must match the device certificate and overrides the Verify HTTPS certificates setting
 - <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 here rather than FLAC, because many tablets struggle with lossless. Stay on MP3 unless you have a reason to change
-- <b>Sample rates supported by this player.</b> The default pair suits most tablets. Add higher rates only if the device genuinely handles them
   
 ## Known Issues / Notes
 
 - A <a href="https://www.fully-kiosk.com/#pricing" target="_blank" rel="noopener noreferrer">paid license</a> for Fully Kiosk is required
 - These players are never found automatically, so each tablet has to be added by hand with its IP address and Fully Kiosk password
 - Once added the device name can be changed, if required, in the specific player configuration
-- Crossfade is supported if [flow mode](/faq/tech-info/#track-queueing) is enabled in the individual player settings. Enabling flow mode may also solve playback issues however it might come with the side effect of disabling actual physical buttons and/or display of metadata on the device itself
+- Fully Kiosk players always stream the queue as one continuous [flow mode](/faq/tech-info/#track-queueing) stream, so there is no setting to turn it on or off. Crossfade works as a result, but the device may not show track metadata and its physical buttons may not respond
 - This player can be grouped via a [Universal Group](/faq/groups/#universal-groups) but perfect sync is not possible.

--- a/src/content/docs/player-support/fully-kiosk.md
+++ b/src/content/docs/player-support/fully-kiosk.md
@@ -24,17 +24,14 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Fully Kiosk devices.</b> The devices to connect to, entered one per line as host or host:port. The port defaults to 2323 when it is left off. Each device becomes its own player. After saving, open each player's settings page to set its password and any HTTPS options
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Fully Kiosk players have the following settings:
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Fully Kiosk players have the following settings:
 
 - <b>Password.</b> The password set for the Fully Kiosk REST API on that device. A player stays unavailable until it has one, so press <b>Setup</b> on the player and enter it
 - <b>Use HTTPS when connecting to the Fully Kiosk API.</b> This is off by default
 - <b>Verify HTTPS certificates (recommended).</b> This is on by default. Turning it off trusts any certificate without validation
 - <b>TLS certificate fingerprint.</b> Optional SHA-256 hex fingerprint. When provided it must match the device certificate and overrides the Verify HTTPS certificates setting
-- <b>Output codec to use for streaming audio to the player.</b> The default is MP3 but other options are FLAC, AAC or WAV. Many tablets struggle with lossless, so stay on MP3 unless you have a reason to change
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits, which suits most tablets. Add higher rates only if the device genuinely handles them. Content with unsupported sample rates will be resampled
+- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 here rather than FLAC, because many tablets struggle with lossless. Stay on MP3 unless you have a reason to change
+- <b>Sample rates supported by this player.</b> The default pair suits most tablets. Add higher rates only if the device genuinely handles them
   
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/google-cast.md
+++ b/src/content/docs/player-support/google-cast.md
@@ -31,7 +31,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 
 - <b>HTTP Profile used for sending audio.</b> Defaults to `Profile 3 - forced content length` on Cast devices. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
 - <b>Use Music Assistant Cast App.</b> On by default and enables the use of a special MA Cast Receiver app to play media on cast devices. It has been optimised to provide better metadata and for future expansion. If issues are experienced with playback then try disabling this option.
-- <b>Sample rates supported by this player.</b> Cast officially supports FLAC up to 96 kHz / 24 bit, which works on most of Google's own hardware. Other brands vary and some handle it badly, so test rather than assume
+- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only the usual two rates are ticked by default, because higher rates are unreliable on some devices despite being officially supported. Try them rather than assume
 - <b>Prefer low-latency WAV for live sources.</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
 - <b>Enable queue flow mode.</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
 

--- a/src/content/docs/player-support/google-cast.md
+++ b/src/content/docs/player-support/google-cast.md
@@ -29,11 +29,11 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Google Cast provider has the following:
 
-- <b>HTTP Profile used for sending audio.</b> Defaults to `Profile 3 - forced content length` on Cast devices. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
+- <b>[HTTP Profile used for sending audio](/settings/individual-player/#http-profile-used-for-sending-audio).</b> Defaults to `Profile 3 - forced content length` on Cast devices. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
 - <b>Use Music Assistant Cast App.</b> On by default and enables the use of a special MA Cast Receiver app to play media on cast devices. It has been optimised to provide better metadata and for future expansion. If issues are experienced with playback then try disabling this option.
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only 44.1 kHz / 16 bit and 48 kHz / 16 bit are selected by default, because the higher ones are unreliable on some devices despite being officially supported. Add them and test rather than assume
-- <b>Prefer low-latency WAV for live sources.</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
-- <b>Enable queue flow mode.</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> Rates go up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only 44.1 kHz / 16 bit and 48 kHz / 16 bit are selected by default, because the higher ones are unreliable on some devices despite being officially supported. Add them and test rather than assume
+- <b>[Prefer low-latency WAV for live sources](/settings/individual-player/#prefer-low-latency-wav-for-live-sources).</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
+- <b>[Enable queue flow mode](/settings/individual-player/#enable-queue-flow-mode).</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/google-cast.md
+++ b/src/content/docs/player-support/google-cast.md
@@ -31,7 +31,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 
 - <b>HTTP Profile used for sending audio.</b> Defaults to `Profile 3 - forced content length` on Cast devices. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
 - <b>Use Music Assistant Cast App.</b> On by default and enables the use of a special MA Cast Receiver app to play media on cast devices. It has been optimised to provide better metadata and for future expansion. If issues are experienced with playback then try disabling this option.
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only the usual two are selected by default, because the higher ones are unreliable on some devices despite being officially supported. Add them and test rather than assume
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only 44.1 kHz / 16 bit and 48 kHz / 16 bit are selected by default, because the higher ones are unreliable on some devices despite being officially supported. Add them and test rather than assume
 - <b>Prefer low-latency WAV for live sources.</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
 - <b>Enable queue flow mode.</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
 

--- a/src/content/docs/player-support/google-cast.md
+++ b/src/content/docs/player-support/google-cast.md
@@ -27,17 +27,13 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Manual IP addresses for discovery.</b> Normally Music Assistant will automatically discover all players on the network, using multicast discovery on the (L2) local network, such as mDNS or UPNP (see [Networking Basics](/faq/networking/) for what these terms mean). In the case of special network setups or when issues are encountered with one or more players not being discovered, IP addresses can be manually added. Note that this setting is not recommended for normal use and should only be used by those with advanced networking knowledge. Also, if players are not on the same subnet as the Music Assistant server, issues may be experienced with streaming. In that case, ensure the players can reach the server on the network and double check the base URL configuration of the [Stream server in the settings](/settings/core/#streams)
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Google Cast provider also has some unique settings as follows:
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Google Cast provider has the following:
 
-- <b>Output codec to use for streaming audio to the player.</b> The default is `FLAC` but other options are `MP3`, `AAC` or `WAV`.
-- <b>HTTP Profile used for sending audio.</b> An advanced setting that changes how the audio is sent to the player. Cast devices use `Profile 3 - forced content length` by default. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
+- <b>HTTP Profile used for sending audio.</b> Defaults to `Profile 3 - forced content length` on Cast devices. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
 - <b>Use Music Assistant Cast App.</b> On by default and enables the use of a special MA Cast Receiver app to play media on cast devices. It has been optimised to provide better metadata and for future expansion. If issues are experienced with playback then try disabling this option.
-- <b>Sample rates supported by this player.</b> Defaults to 44.1 kHz and 48 kHz at 16 bit. This is a deliberately safe setting rather than something detected from your device, and higher rates are offered for you to try. Cast officially supports FLAC up to 96 kHz 24 bit, which works on most of Google's own hardware, but other brands vary and some handle it badly, so test rather than assume. Content above what is selected here is resampled
-- <b>Output channel mode.</b> The default is `Stereo` but other options are `Left channel only`, `Right channel only` or `Mono (both channels)`
-- <b>Prefer low-latency WAV for live sources.</b> On by default for Cast devices. Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the device cannot play continuous WAV streams
-- <b>Try to inject metadata into stream (ICY).</b> Enabling this option attempts to provide metadata to the player which can be used to show track info, even when flow mode is enabled. Not all players support this correctly, therefore, if there are issues with playback try disabling this setting.
-- <b>Enable queue flow mode.</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time. It may have the side effect of losing metadata to the player
-- <b>Flow Mode sample rate.</b> A flow mode stream uses a single sample rate from start to finish, and this decides which one. Smart (the default) starts at the first track's rate and only restarts the stream when a later track is higher. Other options are Bit-perfect, a fixed 48 kHz or 96 kHz, or Highest supported by player
+- <b>Sample rates supported by this player.</b> Cast officially supports FLAC up to 96 kHz / 24 bit, which works on most of Google's own hardware. Other brands vary and some handle it badly, so test rather than assume
+- <b>Prefer low-latency WAV for live sources.</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
+- <b>Enable queue flow mode.</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/google-cast.md
+++ b/src/content/docs/player-support/google-cast.md
@@ -31,7 +31,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 
 - <b>HTTP Profile used for sending audio.</b> Defaults to `Profile 3 - forced content length` on Cast devices. If playback stops part way through a track, see [playback stops part way through a track](#playback-stops-part-way-through-a-track) below
 - <b>Use Music Assistant Cast App.</b> On by default and enables the use of a special MA Cast Receiver app to play media on cast devices. It has been optimised to provide better metadata and for future expansion. If issues are experienced with playback then try disabling this option.
-- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only the usual two rates are ticked by default, because higher rates are unreliable on some devices despite being officially supported. Try them rather than assume
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit for a single player, and up to 96 kHz for a Cast group. Only the usual two are selected by default, because the higher ones are unreliable on some devices despite being officially supported. Add them and test rather than assume
 - <b>Prefer low-latency WAV for live sources.</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
 - <b>Enable queue flow mode.</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
 

--- a/src/content/docs/player-support/home-assistant.md
+++ b/src/content/docs/player-support/home-assistant.md
@@ -31,13 +31,9 @@ Before the Player Provider can be added the [Plugin](/ha-plugin/) must be instal
 
 ## Settings
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the following audio and streaming related settings are available for Home Assistant Media Players:
+Home Assistant Media Players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those differs here:
 
-- <b>Output codec to use for streaming audio to the player.</b> Selects the audio codec for the stream sent to the player. Options are FLAC (lossless, compressed), MP3 (lossy), AAC (lossy), or WAV (lossless, uncompressed). The default for HA media players is MP3 as it has the broadest compatibility across HA player integrations
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits, which suits the widest range of HA players. Higher rates and 24 bit options are offered if the device handles them. Content with unsupported sample rates will be resampled
+- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 here rather than FLAC, as it has the broadest compatibility across Home Assistant player integrations
 
 Flow mode streams audio as a continuous flow rather than individual tracks, which avoids gaps between tracks. For HA media players flow mode is always used and there is no setting to turn it off, because the wide variation in HA player capabilities makes it the most reliable playback method.
 

--- a/src/content/docs/player-support/home-assistant.md
+++ b/src/content/docs/player-support/home-assistant.md
@@ -39,7 +39,7 @@ Flow mode streams audio as a continuous flow rather than individual tracks, whic
 
 ### ESPHome Media Players
 
-Newer ESPHome based players such as the Voice PE are configured from the capabilities they report, so several of the settings above are set for you and do not appear. The output codec and the HTTP profile are fixed to what the device asks for, metadata injection is switched off, and the sample rates come from the device rather than the list above. Output channel mode and the low latency WAV setting are still available.
+Newer ESPHome based players such as the Voice PE are configured from the capabilities they report, so several of the settings above are set for you and do not appear. The output codec is fixed to what the device asks for, the HTTP profile is fixed to Profile 2, metadata injection is switched off, and the sample rates come from the device rather than the list above. Output channel mode and the low latency WAV setting are still available.
 
 ### MA Natively Supported Media Players
 

--- a/src/content/docs/player-support/home-assistant.md
+++ b/src/content/docs/player-support/home-assistant.md
@@ -33,7 +33,7 @@ Before the Player Provider can be added the [Plugin](/ha-plugin/) must be instal
 
 Home Assistant Media Players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those differs here:
 
-- <b>Output codec to use for streaming audio to the player.</b> Defaults to MP3 here rather than FLAC, as it has the broadest compatibility across Home Assistant player integrations
+- <b>[Output codec to use for streaming audio to the player](/settings/individual-player/#output-codec-to-use-for-streaming-audio-to-the-player).</b> Defaults to MP3 here rather than FLAC, as it has the broadest compatibility across Home Assistant player integrations
 
 Flow mode streams audio as a continuous flow rather than individual tracks, which avoids gaps between tracks. For HA media players flow mode is always used and there is no setting to turn it off, because the wide variation in HA player capabilities makes it the most reliable playback method.
 

--- a/src/content/docs/player-support/msx-bridge.md
+++ b/src/content/docs/player-support/msx-bridge.md
@@ -79,7 +79,7 @@ You can check on all of this at `http://<ma-ip>:8099/`.
 
 ## Known Issues / Notes
 
-- **Audio format**: MP3 works on every TV, which is why it is the default. AAC sounds slightly better for the same file size. FLAC is lossless, but Music Assistant cannot tell the TV in advance how long the audio will be, and some TVs do not cope with that
+- **Audio format**: MP3 works on every TV, which is why it is the default. AAC sounds slightly better for the same file size. FLAC is lossless, but with it Music Assistant cannot tell the TV up front how much audio is coming, and some TVs will not play without that
 - **Player grouping**: This is experimental. `Shared Buffer` keeps the TVs better in step, but every TV in the group has to be set to the same audio format
 - **Network**: The TV and Music Assistant have to be on the same network. There is no way to reach a TV from outside your home
 - **Idle timeout**: If a TV is switched off or the MSX app is closed, it disappears from the player list after the idle timeout, 30 minutes by default. It comes back as soon as the TV connects again

--- a/src/content/docs/player-support/msx-bridge.md
+++ b/src/content/docs/player-support/msx-bridge.md
@@ -64,16 +64,10 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Sendspin bridge (experimental).</b> On by default. Registers each TV as a Sendspin client so it can join sample synchronised playback groups with any other Music Assistant player. The TV opens the web kiosk in Sendspin mode when a synchronised stream starts. It needs a TV browser capable of running the Sendspin web client, and falls back to the regular HTTP player if the TV cannot connect
 - <b>Stream Delivery Mode.</b> How the audio reaches the TVs. MA Streamserver (the default) points each TV straight at the Music Assistant stream server, which uses the least CPU and applies the per player codec and audio processing, falling back to Independent if the address cannot be worked out. Independent gives each TV its own separate stream, which uses more CPU and does not keep them in step. Shared Buffer prepares the audio once and feeds it to every group member, which is easier on your server and keeps grouped TVs better in step. Note that MA Streamserver mode has each grouped TV fetch its own stream, so they are not kept in step
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the MSX players have the following settings:
+MSX players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those are worth knowing about on a TV:
 
-- <b>Output codec to use for streaming audio to the player.</b> Set per TV. The default is MP3 but other options are FLAC, AAC or WAV
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the TV cannot play continuous WAV streams
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits. Higher rates and 24 bit options are offered if the TV handles them. Content with unsupported sample rates will be resampled
-- <b>Enable queue flow mode.</b> Off by default for MSX players. Sends all tracks as one continuous audio stream, which stops the TV from reporting track progress correctly, so leave it off unless you have a reason to change it
-- <b>Try to inject metadata into stream (ICY).</b> Only applies while flow mode is enabled, so it is greyed out with the default settings. It attempts to provide metadata to the player so it can show track info during a flow stream
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Output codec to use for streaming audio to the player.</b> Set per TV, and defaults to MP3 here rather than FLAC
+- <b>Enable queue flow mode.</b> Turning this on stops the TV reporting track progress correctly, so leave it off unless you have a reason to change it
 
 ## How It Works
 

--- a/src/content/docs/player-support/msx-bridge.md
+++ b/src/content/docs/player-support/msx-bridge.md
@@ -66,8 +66,8 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 MSX players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those are worth knowing about on a TV:
 
-- <b>Output codec to use for streaming audio to the player.</b> Set per TV, and defaults to MP3 here rather than FLAC
-- <b>Enable queue flow mode.</b> Turning this on stops the TV reporting track progress correctly, so leave it off unless you have a reason to change it
+- <b>[Output codec to use for streaming audio to the player](/settings/individual-player/#output-codec-to-use-for-streaming-audio-to-the-player).</b> Set per TV, and defaults to MP3 here rather than FLAC
+- <b>[Enable queue flow mode](/settings/individual-player/#enable-queue-flow-mode).</b> Turning this on stops the TV reporting track progress correctly, so leave it off unless you have a reason to change it
 
 ## How It Works
 

--- a/src/content/docs/player-support/music-player-daemon.md
+++ b/src/content/docs/player-support/music-player-daemon.md
@@ -34,11 +34,10 @@ For full configuration options refer to the <a href="https://mpd.readthedocs.io/
 
 ## Settings
 
-MPD players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Three of those differ here:
+MPD players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on MPD:
 
 - <b>Output codec to use for streaming audio to the player.</b> MP3 is the default here, with AAC and WAV also available. FLAC is not offered for MPD
 - <b>Prefer low-latency WAV for live sources.</b> On by default for MPD. Turn it off if the server cannot play continuous WAV streams
-- <b>Sample rates supported by this player.</b> MPD does not report what it can handle, so set these by hand to match your output hardware
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/music-player-daemon.md
+++ b/src/content/docs/player-support/music-player-daemon.md
@@ -34,16 +34,11 @@ For full configuration options refer to the <a href="https://mpd.readthedocs.io/
 
 ## Settings
 
-In addition to the [Individual Player Settings](/settings/individual-player/), the MPD provider has the following unique settings:
+MPD players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Three of those differ here:
 
-- <b>Output codec to use for streaming audio to the player.</b> The audio format MA streams to MPD. MP3 is the default, with AAC and WAV (uncompressed) also available. FLAC is not offered for MPD
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Prefer low-latency WAV for live sources.</b> On by default for MPD. Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the server cannot play continuous WAV streams
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits. MPD does not report what it can handle, so higher rates and 24 bit options are offered for you to set manually based on your output hardware. Content with unsupported sample rates will be resampled
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Enable queue flow mode.</b> Off by default. Sends all tracks as one continuous audio stream. Use it if MPD has trouble transitioning between tracks, at the cost of losing per track metadata
-- <b>Try to inject metadata into stream (ICY).</b> Only applies while flow mode is enabled, so it is greyed out with the default settings. It attempts to provide metadata to the player so it can show track info during a flow stream
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Output codec to use for streaming audio to the player.</b> MP3 is the default here, with AAC and WAV also available. FLAC is not offered for MPD
+- <b>Prefer low-latency WAV for live sources.</b> On by default for MPD. Turn it off if the server cannot play continuous WAV streams
+- <b>Sample rates supported by this player.</b> MPD does not report what it can handle, so set these by hand to match your output hardware
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/music-player-daemon.md
+++ b/src/content/docs/player-support/music-player-daemon.md
@@ -36,8 +36,8 @@ For full configuration options refer to the <a href="https://mpd.readthedocs.io/
 
 MPD players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on MPD:
 
-- <b>Output codec to use for streaming audio to the player.</b> MP3 is the default here, with AAC and WAV also available. FLAC is not offered for MPD
-- <b>Prefer low-latency WAV for live sources.</b> On by default for MPD. Turn it off if the server cannot play continuous WAV streams
+- <b>[Output codec to use for streaming audio to the player](/settings/individual-player/#output-codec-to-use-for-streaming-audio-to-the-player).</b> MP3 is the default here, with AAC and WAV also available. FLAC is not offered for MPD
+- <b>[Prefer low-latency WAV for live sources](/settings/individual-player/#prefer-low-latency-wav-for-live-sources).</b> On by default for MPD. Turn it off if the server cannot play continuous WAV streams
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/musiccast.md
+++ b/src/content/docs/player-support/musiccast.md
@@ -31,7 +31,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Switch to this non-net source when leaving a group.</b> Players have to switch inputs when leaving a group. This option defines which input is selected. It must be an input that does not need a network connection, and it is recommended to select a source that is unused so that unexpected sound output does not occur upon input switching. This setting is only available on multi-zone players
 - <b>Turn off the zone when it leaves a group.</b> Toggle defines the power behaviour when the player leaves a group. This setting is only available on multi-zone players
 - <b>Auto-advance queue when the device stops at end of track.</b> On by default. Yamaha receivers occasionally drop the queued next track and stop playing, and this lets Music Assistant notice that and move the queue on. The side effect is that stopping playback yourself in the last few seconds of a track also advances to the next item, so turn it off if you would rather the device's own stop always be respected
-- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. Set these to match what your device handles
+- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit. Set these to match what your device handles
 
 ## Player Options
 

--- a/src/content/docs/player-support/musiccast.md
+++ b/src/content/docs/player-support/musiccast.md
@@ -31,7 +31,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Switch to this non-net source when leaving a group.</b> Players have to switch inputs when leaving a group. This option defines which input is selected. It must be an input that does not need a network connection, and it is recommended to select a source that is unused so that unexpected sound output does not occur upon input switching. This setting is only available on multi-zone players
 - <b>Turn off the zone when it leaves a group.</b> Toggle defines the power behaviour when the player leaves a group. This setting is only available on multi-zone players
 - <b>Auto-advance queue when the device stops at end of track.</b> On by default. Yamaha receivers occasionally drop the queued next track and stop playing, and this lets Music Assistant notice that and move the queue on. The side effect is that stopping playback yourself in the last few seconds of a track also advances to the next item, so turn it off if you would rather the device's own stop always be respected
-- <b>Sample rates supported by this player.</b> Rates go up to 192 kHz / 24 bit. Set these to match what your device handles
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> Rates go up to 192 kHz / 24 bit. Set these to match what your device handles
 
 ## Player Options
 

--- a/src/content/docs/player-support/musiccast.md
+++ b/src/content/docs/player-support/musiccast.md
@@ -25,19 +25,14 @@ If a device does not appear, work through the [discovery checklist](/faq/network
 
 ## Settings
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the MusicCast provider also some unique settings in the `Output Protocol(s)` section for the player:
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the MusicCast provider has some unique settings in the `Output Protocol(s)` section for the player:
 
 - <b>Disable zone handling completely.</b> This disables the automatic source change if playback is switched to another source. It is recommended to first try using the provider with this toggle disabled. However, should issues be encountered during playback then toggle this on, which makes the other two zone settings below inactive. This setting is only available on multi-zone players
 - <b>Switch to this non-net source when leaving a group.</b> Players have to switch inputs when leaving a group. This option defines which input is selected. It must be an input that does not need a network connection, and it is recommended to select a source that is unused so that unexpected sound output does not occur upon input switching. This setting is only available on multi-zone players
 - <b>Turn off the zone when it leaves a group.</b> Toggle defines the power behaviour when the player leaves a group. This setting is only available on multi-zone players
 - <b>Auto-advance queue when the device stops at end of track.</b> On by default. Yamaha receivers occasionally drop the queued next track and stop playing, and this lets Music Assistant notice that and move the queue on. The side effect is that stopping playback yourself in the last few seconds of a track also advances to the next item, so turn it off if you would rather the device's own stop always be respected
 - <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits, with options offered up to 192kHz / 24 bits. Set these to match what your device handles. Content with unsupported sample rates will be resampled
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
-- <b>Enable queue flow mode.</b> Off by default. Sends all tracks as one continuous audio stream. Use for players that do not natively support gapless or crossfading, or that have difficulty transitioning between tracks. May have the side effect of losing metadata to the player
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. Set these to match what your device handles
 
 ## Player Options
 

--- a/src/content/docs/player-support/musiccast.md
+++ b/src/content/docs/player-support/musiccast.md
@@ -31,7 +31,6 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Switch to this non-net source when leaving a group.</b> Players have to switch inputs when leaving a group. This option defines which input is selected. It must be an input that does not need a network connection, and it is recommended to select a source that is unused so that unexpected sound output does not occur upon input switching. This setting is only available on multi-zone players
 - <b>Turn off the zone when it leaves a group.</b> Toggle defines the power behaviour when the player leaves a group. This setting is only available on multi-zone players
 - <b>Auto-advance queue when the device stops at end of track.</b> On by default. Yamaha receivers occasionally drop the queued next track and stop playing, and this lets Music Assistant notice that and move the queue on. The side effect is that stopping playback yourself in the last few seconds of a track also advances to the next item, so turn it off if you would rather the device's own stop always be respected
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
 - <b>Sample rates supported by this player.</b> Options are offered up to 192 kHz / 24 bit. Set these to match what your device handles
 
 ## Player Options

--- a/src/content/docs/player-support/roku.md
+++ b/src/content/docs/player-support/roku.md
@@ -33,8 +33,8 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 Roku players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). These differ on a Roku:
 
-- <b>Sample rates supported by this player.</b> The rates selected by default match Roku's stated support. Higher rates may still work depending on the device
-- <b>Output codec to use for streaming audio to the player.</b> Some codecs load faster than others depending on the Roku device, so try another if playback is slow to start
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> The rates selected by default match Roku's stated support. Higher rates may still work depending on the device
+- <b>[Output codec to use for streaming audio to the player](/settings/individual-player/#output-codec-to-use-for-streaming-audio-to-the-player).</b> Some codecs load faster than others depending on the Roku device, so try another if playback is slow to start
 
 ## Known Issues / Notes
 

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -39,7 +39,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Allow legacy clients.</b> On by default. Accepts older Sendspin devices that do not follow the current specification, including devices that connect without encryption, whose traffic can be read by anyone on your local network. Turn it off to accept only up to date devices. This option is temporary and will be removed in a future release
 - <b>Minimum PIN length.</b> The fewest digits a device may use for dynamic PIN pairing. The default is 4 and it can be set as high as 12
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Sendspin players have the following settings:
+Sendspin does not stream over HTTP, so of the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols) these players show only **Output Channel Mode**. In addition to the standard [Individual Player Settings](/settings/individual-player/), Sendspin players have the following:
 
 - <b>Pairing.</b> Each device shows its security state at the top of its settings, either paired, connected without pairing, or connected without encryption. Press <b>Setup</b> on the player to pair it by entering the PIN or pairing token the device gives you, or to allow it to play without pairing. Bridged players and the built in web player have nothing to pair
 - <b>Unpair.</b> Removes the pairing with this device. Both sides forget the stored credential and the device reconnects as unpaired

--- a/src/content/docs/player-support/sonos.md
+++ b/src/content/docs/player-support/sonos.md
@@ -40,15 +40,10 @@ The Sonos S1 provider has two further settings:
 - <b>Enable network scan for discovery.</b> Off by default. Scans the network for players instead of waiting for them to announce themselves. Try it if some of your S1 players are not found automatically, though it should not normally be needed
 - <b>Household ID.</b> The ID of your Sonos S1 system. It is detected automatically when left empty, so only fill it in if you have a reason to
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Sonos players have the following settings:
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Sonos players have the following settings:
 
 - <b>HTTP Profile used for sending audio.</b> This is considered to be an advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Prefer low-latency WAV for live sources.</b> On by default for Sonos and Sonos S1. Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the speaker cannot play continuous WAV streams
-- <b>Enable queue flow mode.</b> Off by default. Enabling this option will send all tracks as one continuous audio stream. Use for players that do not natively support gapless or crossfading, or that have difficulty transitioning between tracks. May have the side effect of losing metadata to the player
-- <b>Try to inject metadata into stream (ICY).</b> Only applies while flow mode is enabled. It attempts to provide metadata to the player so it can show track info during a flow stream. Not all players support this correctly, therefore, if there are issues with playback try disabling it
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Prefer low-latency WAV for live sources.</b> On by default for Sonos and Sonos S1. Turn it off if the speaker cannot play continuous WAV streams
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. It applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 There is no sample rates setting for Sonos players, as each speaker's capability is known already. Current Sonos models take 44.1kHz and 48kHz at 16 or 24 bits, while older models are limited to 16 bits. Sonos S1 players are 44.1kHz and 48kHz at 16 bits.

--- a/src/content/docs/player-support/sonos.md
+++ b/src/content/docs/player-support/sonos.md
@@ -42,7 +42,7 @@ The Sonos S1 provider has two further settings:
 
 In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Sonos players have the following settings:
 
-- <b>Prefer low-latency WAV for live sources.</b> On by default for Sonos and Sonos S1. Turn it off if the speaker cannot play continuous WAV streams
+- <b>[Prefer low-latency WAV for live sources](/settings/individual-player/#prefer-low-latency-wav-for-live-sources).</b> On by default for Sonos and Sonos S1. Turn it off if the speaker cannot play continuous WAV streams
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. It applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 There is no sample rates setting for Sonos players, as each speaker's capability is known already. Current Sonos models take 44.1kHz and 48kHz at 16 or 24 bits, while older models are limited to 16 bits. Sonos S1 players are 44.1kHz and 48kHz at 16 bits.

--- a/src/content/docs/player-support/sonos.md
+++ b/src/content/docs/player-support/sonos.md
@@ -42,7 +42,6 @@ The Sonos S1 provider has two further settings:
 
 In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Sonos players have the following settings:
 
-- <b>HTTP Profile used for sending audio.</b> This is considered to be an advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
 - <b>Prefer low-latency WAV for live sources.</b> On by default for Sonos and Sonos S1. Turn it off if the speaker cannot play continuous WAV streams
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. It applies while flow mode is off, so it is greyed out once flow mode is enabled
 

--- a/src/content/docs/player-support/squeezelite.md
+++ b/src/content/docs/player-support/squeezelite.md
@@ -31,18 +31,13 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>JSON-RPC CLI/API Port.</b> Some slimproto players use the LMS style JSON-RPC API to fetch album art and other metadata. It runs on port 9000 by default. Set it to 0 to switch it off
 - <b>Enable Discovery server.</b> On by default. Broadcasts discovery packets so slimproto clients find and connect to this server on their own. Turn it off if you run more than one slimproto server on your network, or you do not want clients connecting automatically
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Squeezelite provider also has a unique setting in the Advanced section and a unique Presets section
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Squeezelite provider has a unique setting in the Advanced section and a unique Presets section
 
 - <b>Presets.</b> Real Squeezebox hardware or jive(lite) based emulators support presets. This section lets you assign a Playlist or Radio Station from your library to each of the ten presets
 - <b>Audio synchronization delay correction.</b> Shifts this player's audio by up to ±500 ms to keep it in step with the others. Refer to the Player Summary Table to identify which types support sync correction
 - <b>Enable display support.</b> Some Squeezelite hardware has a display and this setting enables support for it
 - <b>Visualization type.</b> The visualisation shown on the display during playback. It only becomes available once display support is enabled
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Prefer low-latency WAV for live sources.</b> On by default for Squeezelite. Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the player cannot play continuous WAV streams
-- <b>Enable queue flow mode.</b> Off by default. Enabling this option will send all tracks as one continuous audio stream. Use for players that do not natively support gapless or crossfading, or that have difficulty transitioning between tracks. May have the side effect of losing metadata to the player
-- <b>Try to inject metadata into stream (ICY).</b> Only applies while flow mode is enabled. It attempts to provide metadata to the player so it can show track info during a flow stream. Not all players support this correctly, therefore, if there are issues with playback try disabling it
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Prefer low-latency WAV for live sources.</b> On by default for Squeezelite. Turn it off if the player cannot play continuous WAV streams
 - <b>Allow crossfades between tracks of different sample rates.</b> Only enable this if the player supports it. It applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 There is no sample rates setting for Squeezelite players, as each one reports the highest rate it can take and Music Assistant works from that. There is also no HTTP profile setting, as it is fixed at Profile 2 for slimproto.

--- a/src/content/docs/player-support/squeezelite.md
+++ b/src/content/docs/player-support/squeezelite.md
@@ -31,7 +31,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>JSON-RPC CLI/API Port.</b> Some slimproto players use the LMS style JSON-RPC API to fetch album art and other metadata. It runs on port 9000 by default. Set it to 0 to switch it off
 - <b>Enable Discovery server.</b> On by default. Broadcasts discovery packets so slimproto clients find and connect to this server on their own. Turn it off if you run more than one slimproto server on your network, or you do not want clients connecting automatically
 
-In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Squeezelite provider has a unique setting in the Advanced section and a unique Presets section
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Squeezelite provider has these settings of its own:
 
 - <b>Presets.</b> Real Squeezebox hardware or jive(lite) based emulators support presets. This section lets you assign a Playlist or Radio Station from your library to each of the ten presets
 - <b>Audio synchronization delay correction.</b> Shifts this player's audio by up to ±500 ms to keep it in step with the others. Refer to the Player Summary Table to identify which types support sync correction

--- a/src/content/docs/player-support/squeezelite.md
+++ b/src/content/docs/player-support/squeezelite.md
@@ -37,7 +37,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Audio synchronization delay correction.</b> Shifts this player's audio by up to ±500 ms to keep it in step with the others. Refer to the Player Summary Table to identify which types support sync correction
 - <b>Enable display support.</b> Some Squeezelite hardware has a display and this setting enables support for it
 - <b>Visualization type.</b> The visualisation shown on the display during playback. It only becomes available once display support is enabled
-- <b>Prefer low-latency WAV for live sources.</b> On by default for Squeezelite. Turn it off if the player cannot play continuous WAV streams
+- <b>[Prefer low-latency WAV for live sources](/settings/individual-player/#prefer-low-latency-wav-for-live-sources).</b> On by default for Squeezelite. Turn it off if the player cannot play continuous WAV streams
 - <b>Allow crossfades between tracks of different sample rates.</b> Only enable this if the player supports it. It applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 There is no sample rates setting for Squeezelite players, as each one reports the highest rate it can take and Music Assistant works from that. There is also no HTTP profile setting, as it is fixed at Profile 2 for slimproto.

--- a/src/content/docs/player-support/wiim.md
+++ b/src/content/docs/player-support/wiim.md
@@ -34,16 +34,9 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Manual IP addresses for discovery.</b> Not recommended for normal use. Refer to the description in the MA UI
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the WiiM players have the following settings:
+WiiM players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those differs here:
 
-- <b>HTTP Profile used for sending audio.</b> This is considered to be an advanced setting and should only be adjusted if needed. For example, try the different options if the player stops halfway through a stream or for other playback related issues. The default is Profile 2 - no content length
-- <b>Sample rates supported by this player.</b> Everything up to 192kHz / 24 bits is offered and selected by default. Please note some older (Generation 1) devices only support up to 48kHz / 16 bits, so untick the higher rates on those. Content with unsupported sample rates will be resampled
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the speaker cannot play continuous WAV streams
-- <b>Try to inject metadata into stream (ICY).</b> Off by default and only applies while flow mode is enabled. It attempts to provide metadata to the player so it can show track info during a flow stream. Not all players support this correctly, therefore, if there are issues with playback try a lower profile or disable it
-- <b>Enable queue flow mode.</b> Off by default. Enabling this option will send all tracks as one continuous audio stream. Use for players that do not natively support gapless or crossfading, or that have difficulty transitioning between tracks. May have the side effect of losing metadata to the player
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>Sample rates supported by this player.</b> Unusually, everything up to 192 kHz / 24 bit is offered and selected by default. Older Generation 1 devices only support up to 48 kHz / 16 bit, so untick the higher rates on those
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 Generic LinkPlay speakers such as Edifier are handled differently to WiiM and Audio Pro devices. Music Assistant controls them but hands the audio to another output protocol, so their audio settings appear under that protocol's own section rather than the list above.

--- a/src/content/docs/player-support/wiim.md
+++ b/src/content/docs/player-support/wiim.md
@@ -36,7 +36,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 WiiM players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those differs here:
 
-- <b>Sample rates supported by this player.</b> Unusually, everything up to 192 kHz / 24 bit is offered and selected by default. Older Generation 1 devices only support up to 48 kHz / 16 bit, so untick the higher rates on those
+- <b>Sample rates supported by this player.</b> Unusually, everything up to 192 kHz / 24 bit is selected by default. Older Generation 1 devices only support up to 48 kHz / 16 bit, so remove the higher rates on those
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 Generic LinkPlay speakers such as Edifier are handled differently to WiiM and Audio Pro devices. Music Assistant controls them but hands the audio to another output protocol, so their audio settings appear under that protocol's own section rather than the list above.

--- a/src/content/docs/player-support/wiim.md
+++ b/src/content/docs/player-support/wiim.md
@@ -36,7 +36,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 WiiM players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). One of those differs here:
 
-- <b>Sample rates supported by this player.</b> Unusually, everything up to 192 kHz / 24 bit is selected by default. Older Generation 1 devices only support up to 48 kHz / 16 bit, so remove the higher rates on those
+- <b>[Sample rates supported by this player](/settings/individual-player/#sample-rates-supported-by-this-player).</b> Unusually, everything up to 192 kHz / 24 bit is selected by default. Older Generation 1 devices only support up to 48 kHz / 16 bit, so remove the higher rates on those
 - <b>Allow crossfades between tracks of different sample rates.</b> Should be disabled if audio glitches occur during track transitions. Only applies while flow mode is off, so it is greyed out once flow mode is enabled
 
 Generic LinkPlay speakers such as Edifier are handled differently to WiiM and Audio Pro devices. Music Assistant controls them but hands the audio to another output protocol, so their audio settings appear under that protocol's own section rather than the list above.

--- a/src/content/docs/player-support/yandex-station.md
+++ b/src/content/docs/player-support/yandex-station.md
@@ -57,7 +57,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>Experimental: Intercept native Station playback.</b> Off by default. When the Station starts playing Yandex Music on its own, usually from an Alice voice command but also from a touch on the Station itself, this silences the Station and plays the same track on the target player chosen below. The Station keeps its own queue running quietly in the background so Music Assistant can follow each next track. It needs the provider level switch above turned on
 - <b>Intercept target player.</b> The Music Assistant player that receives intercepted playback. Every registered player except this Station is listed, including ones that are currently offline so you can pick a target before it is switched on. Pause, volume and seek are mirrored where the target supports them and are quietly skipped where it does not
 - <b>Experimental: Voice control integration.</b> Off by default. Resumes the Music Assistant queue automatically after voice commands such as "Алиса, стоп" or "Алиса, дальше". Experimental, so it may behave unexpectedly
-- <b>HTTP Profile used for sending audio.</b> Defaults to Profile 3 - forced content length here, because Yandex Stations need a content length and cannot handle chunked streams
+- <b>[HTTP Profile used for sending audio](/settings/individual-player/#http-profile-used-for-sending-audio).</b> Defaults to Profile 3 - forced content length here, because Yandex Stations need a content length and cannot handle chunked streams
 
 ### Voice control integration (experimental)
 

--- a/src/content/docs/player-support/yandex-station.md
+++ b/src/content/docs/player-support/yandex-station.md
@@ -52,19 +52,12 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 
 - <b>Experimental: Enable intercept feature.</b> Off by default. The master switch for the intercept feature described below. While it is off, the per-player intercept settings have no effect. The yandex_music music provider must also be configured, as that is what resolves the tracks
 
-In addition to the [Individual Player Settings](/settings/individual-player/) the Yandex Station players have the following settings:
+In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Yandex Station players have the following settings:
 
 - <b>Experimental: Intercept native Station playback.</b> Off by default. When the Station starts playing Yandex Music on its own, usually from an Alice voice command but also from a touch on the Station itself, this silences the Station and plays the same track on the target player chosen below. The Station keeps its own queue running quietly in the background so Music Assistant can follow each next track. It needs the provider level switch above turned on
 - <b>Intercept target player.</b> The Music Assistant player that receives intercepted playback. Every registered player except this Station is listed, including ones that are currently offline so you can pick a target before it is switched on. Pause, volume and seek are mirrored where the target supports them and are quietly skipped where it does not
 - <b>Experimental: Voice control integration.</b> Off by default. Resumes the Music Assistant queue automatically after voice commands such as "Алиса, стоп" or "Алиса, дальше". Experimental, so it may behave unexpectedly
-- <b>Output codec to use for streaming audio to the player.</b> The default is FLAC but other options are MP3, AAC or WAV
-- <b>Output channel mode.</b> The default is Stereo (both channels) but other options are Left channel only, Right channel only or Mono (both channels)
-- <b>HTTP Profile used for sending audio.</b> This is considered to be a very advanced setting and should only be adjusted if needed. The default is Profile 3 - forced content length, because Yandex Stations need a content length and cannot handle chunked streams
-- <b>Prefer low-latency WAV for live sources.</b> Sends live sources such as Spotify Connect and AirPlay Receiver as uncompressed audio to reduce the delay before you hear them. Disable this if the Station cannot play continuous WAV streams
-- <b>Sample rates supported by this player.</b> Defaults to 44.1kHz / 16 bits and 48kHz / 16 bits. Higher rates and 24 bit options are offered if the Station handles them. Content with unsupported sample rates will be resampled
-- <b>Enable queue flow mode.</b> Off by default. Sends all tracks as one continuous audio stream. Use it if the Station has difficulty transitioning between tracks, at the cost of losing per track metadata
-- <b>Try to inject metadata into stream (ICY).</b> Only applies while flow mode is enabled, so it is greyed out with the default settings
-- <b>Flow Mode sample rate.</b> Only applies while flow mode is enabled. A flow mode stream uses a single sample rate from start to finish, and this decides which one
+- <b>HTTP Profile used for sending audio.</b> Defaults to Profile 3 - forced content length here, because Yandex Stations need a content length and cannot handle chunked streams
 
 ### Voice control integration (experimental)
 


### PR DESCRIPTION
## What does this change?

> **Stacked on #970**, same as #971 — it links the anchor that PR adds. Merge #970 first and this retargets cleanly. Touches different files from #971, so the two do not conflict.

Thirteen player pages restated the protocol settings in full, even where the provider uses the stock behaviour. With the shared explanation on the player settings page, each page now carries only its own differences.

## Kept as deltas — each confirmed against the server at `d790439`

| Page | Difference kept |
|---|---|
| bluesound | **every** rate to 192 kHz / 24 bit ticked by default; ICY defaults to Profile 2 |
| bose-soundtouch | output codec defaults to MP3; options to 192 kHz / 24 bit |
| dlna | flow mode on by default; options to 192 kHz / 24 bit |
| fully-kiosk | output codec defaults to MP3 |
| google-cast | HTTP Profile 3; prefer WAV on; flow mode on; 192 kHz per player / 96 kHz per group |
| home-assistant | output codec defaults to MP3 |
| msx-bridge | output codec defaults to MP3; flow mode caveat for TVs |
| music-player-daemon | output codec offers no FLAC; prefer WAV on |
| musiccast | options to 192 kHz / 24 bit |
| sonos | prefer WAV on |
| squeezelite | prefer WAV on |
| wiim | all rates offered *and selected* by default, with the Generation 1 caveat |
| yandex-station | HTTP Profile 3, with the reason |

## Corrections a verification pass against the server found

A second pass over the source caught claims that were wrong or were not differences at all. All are fixed in this branch:

**Not actually deltas, so removed**
- **musiccast** and **sonos** HTTP Profile — both use `HTTP_PROFILE_DEFAULT_2`, which sets the same value as the global default. There was nothing to say.
- **mpd** and **fully-kiosk** sample rates — neither provider overrides the entry.

**Wrong, so corrected**
- **bluesound** ticks *every* rate up to 192 kHz / 24 bit by default, not just the usual two. WiiM has the identical override and its page already said so.
- **google-cast** offers up to 192 kHz / 24 bit for a single player and 96 kHz for a *group*, and the higher rates are unreliable on some devices despite being officially supported. The page had claimed 96 kHz was the ceiling and that it works on most Google hardware — the source comment says the opposite.
- **bluesound**, **bose** and **dlna** said sample rates are "set automatically when the player is discovered". Nothing is probed from the device; these are static per-provider option lists.
- **home-assistant** said the HTTP profile is fixed to what the device asks for. It is fixed to Profile 2 regardless.
- **fully-kiosk** told readers to enable flow mode. Those players always use flow mode and have no such setting.
- **dlna** said the crossfade setting depends on the player being able to queue the next track. It depends on gapless playback support.

**Also fixed here**
- `bluesound` was missing its ICY default entirely — the provider sets it to *Profile 2 - full info*, but the bullet had been dropped at some point.
- `home-assistant` documented an HTTP Profile setting that is **hidden** for those players, so no reader could act on it.

## A distinction worth recording

Providers that *force* a setting rather than defaulting it also **hide** it (`FORCED_n` sets `hidden: True`). Those are deliberately not documented, since the reader will never see them: bluesound and squeezelite HTTP profile, snapcast HTTP profile, and the ICY setting on home-assistant, musiccast and samsung-wam.

I had originally planned to document forced settings as "fixed at X" — reading the entry definitions showed that would have described controls nobody can see.

## Checklist

- [x] Correct branch (stacked, see above)
- [x] No new pages, so no sidebar entry needed

## Verification

Full build passes; every internal link and anchor resolves (**0 broken**). Claims re-checked against `music-assistant/server` @ `d790439`.