### PR TITLE
Link the settings pages back to the pages that explain them

### DIFF
--- a/src/content/docs/settings/core.md
+++ b/src/content/docs/settings/core.md
@@ -151,7 +151,7 @@ A destructive operation that completely rebuilds the genre database from default
 
 ## Audio Analysis
 
-Administrators can access the **Audio Analysis** page from the settings menu. This page allows examination of the progress of the installed audio analysis providers — [Loudness Analysis](/audio-analysis/loudness-analysis/), [Smart Fades](/audio-analysis/smart-fades/), [Sonic Analysis](/audio-analysis/sonic-analysis/) and [AcoustID Lookup](/audio-analysis/acoustid/). The stale number is the number of tracks that need to be re-analysed due to a version change. There is also a section which shows failures and the reason for the failure. Each line can be individually deleted to unblock the file and allow it to be rescanned.
+Administrators can access the **Audio Analysis** page from the settings menu. This page allows examination of the progress of the installed audio analysis providers, namely [Loudness Analysis](/audio-analysis/loudness-analysis/), [Smart Fades](/audio-analysis/smart-fades/), [Sonic Analysis](/audio-analysis/sonic-analysis/) and [AcoustID Lookup](/audio-analysis/acoustid/). The stale number is the number of tracks that need to be re-analysed due to a version change. There is also a section which shows failures and the reason for the failure. Each line can be individually deleted to unblock the file and allow it to be rescanned.
 
 ![image](/assets/screenshots/audio-analysis-view.png)
 

--- a/src/content/docs/settings/core.md
+++ b/src/content/docs/settings/core.md
@@ -31,12 +31,12 @@ The core server settings are set with typical defaults that should work for most
 
 ## Music
 
-- <b>Advanced - Reset Library Database.</b> Selecting this button will erase the MA database. This is a destructive irreversible action! This should only be used if database corruption is confirmed. All library items including playlists stored in the database will be lost and will need to be recreated. A rescan of the music sources will rebuild the database with the information contained on those providers. Do not use this routinely. For problems with individual items use the REMOVE FROM LIBRARY menu option
+- <b>Advanced - Reset Library Database.</b> Selecting this button will erase the [MA library](/usage/#the-library) database. This is a destructive irreversible action! This should only be used if database corruption is confirmed. All library items including playlists stored in the database will be lost and will need to be recreated. A rescan of the music sources will rebuild the database with the information contained on those providers. Do not use this routinely. For problems with individual items use the REMOVE FROM LIBRARY menu option
 
 ## Players
 
 - <b>Volume step size.</b> Defaults to zero which enables an adapative mode where the step size is smaller at the ends of the range. When set, this determines how much the volume change when an up or down command is received (e.g. mouse wheel click, slider tap, HA action)
-- <b>Announcement text to speech engine.</b> Which engine is used to generate announcements sent from within Music Assistant
+- <b>Announcement text to speech engine.</b> Which engine is used to generate [announcements](/integration/announcements/) sent from within Music Assistant. The engines on offer come from your plugins, such as the [Home Assistant Plugin](/ha-plugin/#ai-and-text-to-speech-engines)
 
 ## Player Queues
 
@@ -118,7 +118,7 @@ This opens a view where the 150 line tail of the Music Assistant log can be seen
 
 ## Background Tasks
 
-This opens a view where the completed and upcoming background tasks can be seen. Any failures will be clearly indicated and log snippets can be inspected. Detailed information is obtained by clicking on a task. There is a ⋮ menu on the right which allows for:
+This opens a view where the completed and upcoming background tasks can be seen. This is where the sync interval for the [automatically generated playlists](/usage/#playlists) is set. Any failures will be clearly indicated and log snippets can be inspected. Detailed information is obtained by clicking on a task. There is a ⋮ menu on the right which allows for:
 - Viewing the task details
 - Editing the task schedule. Frequency can be Hourly, Daily or Weekly. A precise time can be specified for the task for Daily and Weekly frequencies
 - Running of the task now
@@ -130,7 +130,7 @@ Administrators can see all tasks on the server whereas Users can only see tasks 
 
 ## Genre Management
 
-Administrators can access the **Genre Management** page from the settings menu. This page provides tools for maintaining the genre database.
+Administrators can access the **Genre Management** page from the settings menu. This page provides tools for maintaining the genre database. The [Genres](/genres/#managing-genres) page describes these tools and the rest of the genre system in full.
 
 ![image](/assets/screenshots/genres/genre-management-overview.png)
 
@@ -151,7 +151,7 @@ A destructive operation that completely rebuilds the genre database from default
 
 ## Audio Analysis
 
-Administrators can access the **Audio Analysis** page from the settings menu. This page allows examination of the progress of the installed audio analysis providers. The stale number is the number of tracks that need to be re-analysed due to a version change. There is also a section which shows failures and the reason for the failure. Each line can be individually deleted to unblock the file and allow it to be rescanned.
+Administrators can access the **Audio Analysis** page from the settings menu. This page allows examination of the progress of the installed audio analysis providers — [Loudness Analysis](/audio-analysis/loudness-analysis/), [Smart Fades](/audio-analysis/smart-fades/), [Sonic Analysis](/audio-analysis/sonic-analysis/) and [AcoustID Lookup](/audio-analysis/acoustid/). The stale number is the number of tracks that need to be re-analysed due to a version change. There is also a section which shows failures and the reason for the failure. Each line can be individually deleted to unblock the file and allow it to be rescanned.
 
 ![image](/assets/screenshots/audio-analysis-view.png)
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -37,7 +37,7 @@ Some players (e.g. [MusicCast](/player-support/musiccast/) have [unique control 
 
 - <b>Preferred Output Protocol.</b> Choose from the list of available protocols
 
-Each available protocol then has its own configuration section. Protocols can be disabled except for the native protocol of the device.
+Each available protocol then has its own configuration section. Protocols can be disabled except for the native protocol of the device. The [Audio Pipeline](/audiopipeline/) view shows which protocol a player is actually using and what the audio quality is at each stage.
 
 ### Settings shared by most protocols
 
@@ -162,7 +162,7 @@ Universal Groups default to `Profile 1 - chunked` for the HTTP Profile, rather t
 
 ## Announcements Configuration
 
-There are a number of configurable options for controlling the volume of announcements sent to the MA players. These are well described by the help available by selecting this icon ![image](/assets/icons/question-mark.png) beside each field. The `Maximum` and `Minimum Volume` level boxes do not apply when the `Absolute volume` option is selected.
+There are a number of configurable options for controlling the volume of [announcements](/integration/announcements/) sent to the MA players. These are well described by the help available by selecting this icon ![image](/assets/icons/question-mark.png) beside each field. The `Maximum` and `Minimum Volume` level boxes do not apply when the `Absolute volume` option is selected.
 
 ![image](/assets/screenshots/announcements-settings.png)
 

--- a/src/content/docs/settings/profile.md
+++ b/src/content/docs/settings/profile.md
@@ -12,4 +12,4 @@ A list of active sessions that have been logged in with this user are shown and 
 
 ## Long-lived access tokens
 
-Tokens can be created here which can be used with external applications or to allow frontend access from [devices that have not been logged in](/faq/how-to/#access-the-ma-views-directly-via-url).
+Tokens can be created here which can be used with the [API](/api/), with external applications, or to allow frontend access from [devices that have not been logged in](/faq/how-to/#access-the-ma-views-directly-via-url).

--- a/src/content/docs/settings/remote-access.md
+++ b/src/content/docs/settings/remote-access.md
@@ -15,6 +15,6 @@ For most users this is all that is needed.
 
 ## Technical Details
 
-Remote access usually works without a Nabu Casa subscription. If any of the terms below are unfamiliar, [Networking Basics](/faq/networking/) explains them. The exception is complex network environments, for example double NAT, mobile carriers, or corporate networks blocking standard <a href="https://medium.com/@jamesbordane57/what-is-a-stun-server-df3563dbf14a" target="_blank" rel="noopener noreferrer">STUN servers</a>. This is where TURN servers (which Nabu Casa provides) are useful as they relay the traffic.
+Remote access usually works without a Nabu Casa subscription. The exception is complex network environments, for example double NAT, mobile carriers, or corporate networks blocking standard <a href="https://medium.com/@jamesbordane57/what-is-a-stun-server-df3563dbf14a" target="_blank" rel="noopener noreferrer">STUN servers</a>. This is where TURN servers (which Nabu Casa provides) are useful as they relay the traffic.
 
-Further information is shown in the MA UI.
+Further information is shown in the MA UI. For the network terms used elsewhere in this documentation, see [Networking Basics](/faq/networking/).

--- a/src/content/docs/settings/remote-access.md
+++ b/src/content/docs/settings/remote-access.md
@@ -4,7 +4,7 @@ title: "Remote Access"
 
 # Remote Access Settings <img src="/assets/icons/remote-access-icon.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-Remote Access allows you to securely connect to your Music Assistant server from anywhere in the world.
+Remote Access allows you to securely connect to your Music Assistant server from anywhere in the world. It is also what lets the [built-in web player](/player-support/sendspin/#the-web-player) reach your server from outside your own network.
 
 ## Configuration
 
@@ -15,6 +15,6 @@ For most users this is all that is needed.
 
 ## Technical Details
 
-Remote access usually works without a Nabu Casa subscription. The exception is complex network environments, for example double NAT, mobile carriers, or corporate networks blocking standard <a href="https://medium.com/@jamesbordane57/what-is-a-stun-server-df3563dbf14a" target="_blank" rel="noopener noreferrer">STUN servers</a>. This is where TURN servers (which Nabu Casa provides) are useful as they relay the traffic.
+Remote access usually works without a Nabu Casa subscription. If any of the terms below are unfamiliar, [Networking Basics](/faq/networking/) explains them. The exception is complex network environments, for example double NAT, mobile carriers, or corporate networks blocking standard <a href="https://medium.com/@jamesbordane57/what-is-a-stun-server-df3563dbf14a" target="_blank" rel="noopener noreferrer">STUN servers</a>. This is where TURN servers (which Nabu Casa provides) are useful as they relay the traffic.
 
 Further information is shown in the MA UI.

--- a/src/content/docs/settings/user-interface.md
+++ b/src/content/docs/settings/user-interface.md
@@ -16,7 +16,7 @@ Customise the user interface from this page. Preferences are stored per user and
 
 - <b>Enable browser media controls</b> Allow control of playback using the browser's built in media controls (e.g. keyboard media keys)
 - <b>Force mobile layout.</b> The mobile layout has the menu at the bottom and has icons for HOME, and SEARCH and the remainder of the items are accessed via a single library icon
-- <b>Prefer waveform progress bar</b> Show a waveform-style progress bar in the now playing view when audio analysis data is available for the playing track
+- <b>Prefer waveform progress bar</b> Show a waveform-style progress bar in the now playing view when audio analysis data is available for the playing track. The data comes from the [Sonic Analysis](/audio-analysis/sonic-analysis/) provider, so the bar only appears on tracks it has analysed
 - <b>Mobile sidebar side.</b> Which side the navigation menu opens from. Default is left
 
 ## Volume Control

--- a/src/content/docs/settings/user-management.md
+++ b/src/content/docs/settings/user-management.md
@@ -29,4 +29,4 @@ Each user can be restricted to a set of specific players. Additionally, restrict
 ### Audiobook and podcast progress sync in a multi-user environment
 
 <a name="filter-progress-multi-user"></a>
-Some podcast and/or audiobook sources allow syncing the progress of media items. By assigning such a source to only a certain user via the music source filter function, the progress is then only synced with this individual user, instead of all users. By setting up these music sources multiple times individual user syncing can be achieved by correctly assigning the source via the filter function.
+Some podcast and/or audiobook sources, such as [Audiobookshelf](/music-providers/audiobookshelf/), [Audible](/music-providers/audible/) and [Storytel](/music-providers/storytel/), allow syncing the progress of media items. By assigning such a source to only a certain user via the music source filter function, the progress is then only synced with this individual user, instead of all users. By setting up these music sources multiple times individual user syncing can be achieved by correctly assigning the source via the filter function.


### PR DESCRIPTION
## What does this change?

> **Stacked on #970** — it adds a link inside the Output Protocols section that PR introduces. Merge #970 first and this retargets cleanly. Touches different files from #971 and #972.

The settings pages are deliberately terse, and the explanation of what a setting is *for* lives on the feature page. Almost none of that was linked, so a reader who arrived at a setting had nowhere to go.

| Setting | Now links to |
|---|---|
| Genre Management — six lines here, a full page elsewhere | Genres → Managing Genres |
| Audio analysis view | the four providers it reports on |
| Announcement text to speech engine | Announcements, and the HA Plugin that supplies the engines |
| Reset Library Database | what the library actually is |
| Background tasks view | where the generated-playlist refresh interval is set |
| Prefer waveform progress bar | Sonic Analysis — which explains why the bar is missing on most tracks |
| Announcements Configuration, Output Protocols | Announcements, Audio Pipeline |
| Profile → long-lived tokens | the API page |
| Remote Access | the web-player case, and Networking Basics |
| User Management → progress sync | the three sources that support it |

`metadata-provider-settings.md` already did this well and was the model.

## Review fix

The **Networking Basics** pointer on `remote-access.md` was inserted mid-paragraph, splitting *"Remote access usually works without a subscription"* from *"The exception is…"* so the second sentence reached back across an interruption.

It also promised something untrue: it said that page explains the terms below, but `faq/networking.md` does not mention **NAT**, **STUN** or **TURN** anywhere — its glossary covers mDNS, multicast, SSDP, IGMP snooping, subnet and VLAN. The link now sits at the end of the section and describes what that page actually offers.

## Checklist

- [x] Correct branch (stacked, see above)
- [x] No new pages, so no sidebar entry needed

## Verification

Full build, then every internal link and anchor resolved: **0 broken internal links**.