### PR TITLE
Describe the multi-select settings as they actually appear

### DIFF
--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -114,9 +114,11 @@ Change it if the player cannot play FLAC, or to cut down network traffic on a we
 
 #### Sample rates supported by this player
 
-The sample rates and bit depths Music Assistant will send to this player as they are. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are ticked by default.
+The sample rates and bit depths Music Assistant will send to this player as they are. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are selected by default.
 
-Rates are offered up to 384 kHz / 24 bit, though most providers narrow that list to what the device plausibly handles. On most players the ticked boxes are a safe starting point rather than something detected from the device, and the higher ones are offered for you to try. If your player genuinely supports them, tick them and you will get better quality; if playback breaks or the player falls silent, untick them again. Manufacturers vary, so test rather than assume. Some providers do detect the device's capabilities and set this for you, and those pages say so.
+You choose the rates from a drop down list of checkboxes, and the ones you pick are then shown as chips in the field, so you can see the whole selection at a glance.
+
+Rates go up to 384 kHz / 24 bit, though most providers narrow that list to what the device plausibly handles. On most players the selection is a safe starting point rather than something detected from the device, and the higher rates are there for you to try. If your player genuinely supports them, add them and you will get better quality. If playback breaks or the player falls silent, remove them again. Manufacturers vary, so test rather than assume. Some providers do detect the device's capabilities and set this for you, and those pages say so.
 
 #### Output Channel Mode
 

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -153,9 +153,9 @@ Change it only to fix a problem. If the player behaves in any of those ways, wor
 
 ## Group Player Settings
 
-For group players the following settings will be seen:
+For group players the following settings will be seen. **Group members** and **Allowed members** are both chosen from a drop down list of checkboxes, with the players you pick then shown as chips in the field.
 
-- <b>Group members.</b> For Group player types the members of the group are configured in this field
+- <b>Group members.</b> The players that belong to this group
 - <b>Enable dynamic members</b> toggle. This setting is available for [Sync and Universal Groups](/faq/groups/). When enabled, it is then possible to add and remove members from these group types
 - <b>Allowed members</b>. Limit which players can join this group. Leave empty to allow any sync-compatible player. This can be used to reduce the list of players that show up for joining in case you have a lot of players. Only shown when the advanced toggle is on
 - <b>Allow crossfades between tracks of different sample rates</b>. Enable this option to allow crossfades between tracks that have different sample rates (e.g. 44.1kHz to 48kHz). Disable this option if you experience audio glitches during transitions between tracks. Only shown when the advanced toggle is on

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -114,7 +114,7 @@ Change it if the player cannot play FLAC, or to cut down network traffic on a we
 
 #### Sample rates supported by this player
 
-The sample rates and bit depths Music Assistant will send to this player as they are. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are selected by default.
+The sample rates and bit depths this player can be sent without resampling. Anything higher is resampled down to fit. `44.1 kHz / 16 bit` and `48 kHz / 16 bit` are selected by default.
 
 You choose the rates from a drop down list of checkboxes, and the ones you pick are then shown as chips in the field, so you can see the whole selection at a glance.
 


### PR DESCRIPTION
## What does this change?

Three settings on this page let you pick several values at once, and none of them said how. The **Sample rates** section, added in #970, went further and described the control as boxes you tick and untick, which is only half of what a reader sees.

All three work the same way: you choose from a **drop down list of checkboxes**, and what you pick is then shown as **chips in the field**. Someone hunting for tick boxes on the settings page will not immediately find them.

| Setting | Now says |
|---|---|
| **Sample rates supported by this player** | "You choose the rates from a drop down list of checkboxes, and the ones you pick are then shown as chips in the field, so you can see the whole selection at a glance." |
| **Group members** and **Allowed members** | "…are both chosen from a drop down list of checkboxes, with the players you pick then shown as chips in the field." |

The surrounding prose now uses **select**, **add** and **remove** rather than tick and untick, which stays true however the control is rendered.

Also trims the **Group members** description, which read "the members of the group are configured in this field" without saying what the field does. The sentence above now covers that, so the bullet just says what the setting is.

## Checklist

- [x] Correct branch: `beta`
- [x] No new pages, so no sidebar entry needed

## Verification

Full build passes.

Sibling PRs carry the same wording to the pages that describe their own defaults: #971 (roku), #972 (bluesound, bose-soundtouch, dlna, google-cast, wiim) and #974 (troubleshooting).

> Touches `settings/individual-player.md`, as does #975. Different sections of the file, so they should merge cleanly in either order.