### PR TITLE
Home Assistant calls them Apps, not add-ons

### DIFF
--- a/src/content/docs/community-extensions.md
+++ b/src/content/docs/community-extensions.md
@@ -59,7 +59,7 @@ Music Assistant Player Card is a custom card which provides a full media player,
 *********************************
 ## <a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>
 
-Turn any Bluetooth speaker into a Music Assistant player using the Sendspin protocol. Supports multiple simultaneous devices, multiroom sync groups, and comes with a real-time web dashboard. Deploys as an HA addon, Docker Compose, Proxmox LXC, or OpenWrt LXC.
+Turn any Bluetooth speaker into a Music Assistant player using the Sendspin protocol. Supports multiple simultaneous devices, multiroom sync groups, and comes with a real-time web dashboard. Deploys as a Home Assistant App, Docker Compose, Proxmox LXC, or OpenWrt LXC.
 
 <img src="https://raw.githubusercontent.com/trudenboy/sendspin-bt-bridge/main/docs-site/public/screenshots/screenshot-dashboard-full.png" alt="Sendspin BT Bridge dashboard" style="width: 600px;"  loading="lazy" />
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -7,11 +7,11 @@ import { LinkButton } from '@astrojs/starlight/components';
 
 # Music Assistant
 
-![Music Assistant Add-on For Home Assistant](/assets/banner.png)
+![Music Assistant App For Home Assistant](/assets/banner.png)
 
 Music Assistant is a free, open source music library manager. It brings your streaming services and your own files together into one library, and plays them on almost any speaker in the house.
 
-It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a Home Assistant add-on — and you control it from any browser, or from Home Assistant with automations and voice.
+It runs on an always-on machine — a Raspberry Pi, a NAS, a spare PC, or as a Home Assistant App — and you control it from any browser, or from Home Assistant with automations and voice.
 
 ![Music sources flowing into Music Assistant and out to a wide range of players](/assets/MA_banner.png)
 

--- a/src/content/docs/integration/index.md
+++ b/src/content/docs/integration/index.md
@@ -10,7 +10,7 @@ The Music Assistant integration for Home Assistant provides a connection from MA
 
 - The integration is an official part of Home Assistant, there is no need to install custom components
 
-- The integration can connect to the MA server which is running either as an HA addon or as a docker container on the same or another host system
+- The integration can connect to the MA server which is running either as a Home Assistant App or as a docker container on the same or another host system
 
 See also the <a href="https://www.home-assistant.io/integrations/music_assistant/" target="_blank" rel="noopener noreferrer">documentation from Home Assistant about the Music Assistant integration</a>
 

--- a/src/content/docs/music-providers/mamma-mi-radio.md
+++ b/src/content/docs/music-providers/mamma-mi-radio.md
@@ -6,14 +6,14 @@ title: "Mamma Mi Radio"
 
 Music Assistant has support for <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">Mamma Mi Radio</a>, a self-hosted radio station whose hosts notice what is happening in your home and work it into the show. Contributed and maintained by <a href="https://github.com/florianhorner" target="_blank" rel="noopener noreferrer">Florian Horner</a>.
 
-Two Italian hosts. One very opinionated smart home. The addon runs on your own hardware and puts out a continuous station: music, host talk, news flashes, and gloriously fake ads. The hosts are Italian characters who broadcast mostly in English, slipping into Italian for greetings, asides, and the occasional dramatic moment.
+Two Italian hosts. One very opinionated smart home. The App runs on your own hardware and puts out a continuous station: music, host talk, news flashes, and gloriously fake ads. The hosts are Italian characters who broadcast mostly in English, slipping into Italian for greetings, asides, and the occasional dramatic moment.
 
 Turn on home context and the house joins the broadcast. Between songs a host might work the coffee machine into the banter, or ground the otherwise-fictional weather report in your actual forecast. You built the sensors; somebody finally comments on them.
 
-Out of the box the hosts speak with stock copy and fallback voices. Add your own AI provider key in the addon and they become fully generative.
+Out of the box the hosts speak with stock copy and fallback voices. Add your own AI provider key in the App and they become fully generative.
 
 > [!NOTE]
-> Self-hosted and cloud-assisted. There is no Mamma Mi Radio account and no middleman service, but writing the hosts' lines and synthesizing their voices call out to the providers you configure, so the station needs network access. Home context is optional and read-only, and only the filtered context goes to the provider you chose: the addon shows you that context before anything uses it, you can mute any entity, and you can turn home context off entirely.
+> Self-hosted and cloud-assisted. There is no Mamma Mi Radio account and no middleman service, but writing the hosts' lines and synthesizing their voices call out to the providers you configure, so the station needs network access. Home context is optional and read-only, and only the filtered context goes to the provider you chose: the App shows you that context before anything uses it, you can mute any entity, and you can turn home context off entirely.
 
 ## Features
 
@@ -40,17 +40,17 @@ This source reads the station's live programme state, so Music Assistant can sho
 
 ## Requirements
 
-- A running <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">Mamma Mi Radio</a> addon, **version 2.13 or newer**, reachable from the Music Assistant host.
+- A running <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">Mamma Mi Radio</a> App, **version 2.13 or newer**, reachable from the Music Assistant host.
 - A working music source configured in Mamma Mi Radio.
 - No AI key is required. Without one, the hosts use stock copy and fallback voices.
 
 ## Configuration
 
-- **Mamma Mi Radio URL:** the base URL of your addon (default: `http://localhost:8000`).
+- **Mamma Mi Radio URL:** the base URL of your App (default: `http://localhost:8000`).
 
-Which URL is right depends on where Music Assistant runs relative to the addon:
+Which URL is right depends on where Music Assistant runs relative to the App:
 
-- **Music Assistant addon and Mamma Mi Radio addon on the same Home Assistant host:** the default `http://localhost:8000` works, because the Mamma Mi Radio addon uses host networking and is reachable on the host's own interface
+- **Music Assistant App and Mamma Mi Radio App on the same Home Assistant host:** the default `http://localhost:8000` works, because the Mamma Mi Radio App uses host networking and is reachable on the host's own interface
 - **Music Assistant on a different machine:** use the Home Assistant host's IP or DNS name, e.g. `http://192.168.1.10:8000`
 - **Behind a reverse proxy:** a path prefix is supported, e.g. `https://myhost.example/mammamiradio` (query strings and credentials in the URL are ignored)
 
@@ -61,9 +61,9 @@ Which URL is right depends on where Music Assistant runs relative to the addon:
 
 ## Known Issues / Notes
 
-- The addon appears as a single station. There is no per-track search or browsing into the programme, and tracks heard on air are not added to the Music Assistant library individually
+- The App appears as a single station. There is no per-track search or browsing into the programme, and tracks heard on air are not added to the Music Assistant library individually
 - As with all radio in Music Assistant, tracks cannot be skipped or seeked
 - Metadata refreshes about every 12 seconds, so the now-playing card can trail the audio slightly
 - Only one instance of this source can be configured
-- Music sources, hosts, language mix, and home-context permissions are all configured in the addon, not here; see the <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">addon documentation</a>
+- Music sources, hosts, language mix, and home-context permissions are all configured in the App, not here; see the <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">addon documentation</a>
 - Mamma Mi Radio itself has no account or subscription. Fully generative hosts require an API key from an AI provider you choose, billed by that provider

--- a/src/content/docs/music-providers/mamma-mi-radio.md
+++ b/src/content/docs/music-providers/mamma-mi-radio.md
@@ -65,5 +65,5 @@ Which URL is right depends on where Music Assistant runs relative to the App:
 - As with all radio in Music Assistant, tracks cannot be skipped or seeked
 - Metadata refreshes about every 12 seconds, so the now-playing card can trail the audio slightly
 - Only one instance of this source can be configured
-- Music sources, hosts, language mix, and home-context permissions are all configured in the App, not here; see the <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">addon documentation</a>
+- Music sources, hosts, language mix, and home-context permissions are all configured in the App, not here; see the <a href="https://github.com/florianhorner/mammamiradio" target="_blank" rel="noopener noreferrer">App documentation</a>
 - Mamma Mi Radio itself has no account or subscription. Fully generative hosts require an API key from an AI provider you choose, billed by that provider

--- a/src/content/docs/music-providers/netease-cloud-music-zh.md
+++ b/src/content/docs/music-providers/netease-cloud-music-zh.md
@@ -46,7 +46,7 @@ Music Assistant 已支持 <a href="https://music.163.com/" target="_blank" rel="
 
 该提供商需要可访问的 NeteaseCloudMusicApi 兼容 HTTP 服务（默认：`http://127.0.0.1:3000`）。
 
-Home Assistant 用户可参考配套 add-on PR：  
+Home Assistant 用户可参考配套 App PR：  
 <a href="https://github.com/music-assistant/home-assistant-addon/pull/16" target="_blank" rel="noopener noreferrer">home-assistant-addon#16</a>
 
 ### 扫码登录流程（网易云 App）

--- a/src/content/docs/music-providers/netease-cloud-music.md
+++ b/src/content/docs/music-providers/netease-cloud-music.md
@@ -45,7 +45,7 @@ This source signs Music Assistant in to your NetEase account, so the music and p
 
 NetEase provides no proper way in for other apps, so this source talks to NetEase through a separate piece of software called NeteaseCloudMusicApi, which you run yourself. Music Assistant expects to find it at `http://127.0.0.1:3000` unless you tell it otherwise.
 
-If you run Music Assistant under Home Assistant, there is a companion add-on in progress:  
+If you run Music Assistant under Home Assistant, there is a companion App in progress:  
 <a href="https://github.com/music-assistant/home-assistant-addon/pull/16" target="_blank" rel="noopener noreferrer">home-assistant-addon#16</a>
 
 ### QR Login Flow (NetEase App)

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -66,7 +66,7 @@ Several client types can connect to Music Assistant via Sendspin:
 | **Web Browser** | The built-in Music Assistant web player uses Sendspin for local playback |
 | **[Google Cast (Sendspin mode)](/player-support/google-cast/)** | Experimental Sendspin mode for Chromecast devices |
 | **<a href="https://esphome.github.io/home-assistant-voice-pe/" target="_blank" rel="noopener noreferrer">Home Assistant Voice PE</a>** | Built into recent Voice PE firmware. Update the device with the official installer, choosing a pre-release build if the current stable one does not show up as a player |
-| **<a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>** | Bridges Bluetooth speakers as MA players — multi-device, multiroom sync, web dashboard. Deploys as HA addon, Docker, or LXC |
+| **<a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>** | Bridges Bluetooth speakers as MA players — multi-device, multiroom sync, web dashboard. Deploys as a Home Assistant App, Docker, or LXC |
 | **<a href="https://www.sendspin-audio.com/code/" target="_blank" rel="noopener noreferrer"> Various Sendspin Clients</a>** | Clients are becoming available for various platforms |
 
 ## The Web Player

--- a/src/content/docs/settings/core.md
+++ b/src/content/docs/settings/core.md
@@ -4,7 +4,7 @@ title: "System Settings"
 
 # MA System Settings <img src="/assets/icons/settings-core-icon.png" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-The core server settings are set with typical defaults that should work for most users. However, there are settings available for each of the core controllers and these are outlined below. All controllers have a setting for the log level in the advanced section. There may be slight differences in the settings between the HA add-on and docker versions of the servers.
+The core server settings are set with typical defaults that should work for most users. However, there are settings available for each of the core controllers and these are outlined below. All controllers have a setting for the log level in the advanced section. There may be slight differences in the settings between the Home Assistant App and docker versions of the servers.
 
 ![image](/assets/screenshots/settings-core.png)
 


### PR DESCRIPTION
Home Assistant renamed add-ons to Apps, so the docs should match what the reader sees on screen.

18 replacements across 8 files, in Home Assistant contexts only:

- `index.mdx` - the banner alt text, and "or as a Home Assistant add-on"
- `integration/index.md`
- `settings/core.md`
- `player-support/sendspin.md`
- `community-extensions.md`
- `music-providers/netease-cloud-music.md` and its Chinese translation
- `music-providers/mamma-mi-radio.md` - nine mentions, since the provider is itself an App

Left alone anywhere the string is part of a repository name or URL, such as `home-assistant-addon`, `local-audio-addon`, `ha-addon-squeezelite`, `HomeAssistant-Addons` and `supervisor_addon`. Those are identifiers rather than product names, and changing them would break the links.

Site builds clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U42bRfm14UaFLyHtTjHt1o)_