### PR TITLE
Replace the phrase "in step" throughout

### DIFF
--- a/src/content/docs/faq/networking.md
+++ b/src/content/docs/faq/networking.md
@@ -34,7 +34,7 @@ If discovery still fails after all of this, see the [Troubleshooting](/faq/troub
 
 A player that is found, starts playing, and then crackles, skips or stops is a different problem from one that is never found. Discovery is working. Something is interrupting the audio once it is flowing.
 
-**Why it works in the manufacturer's own app but not here.** Apps like Apple Music and Spotify send the speaker a large amount of audio ahead of time, tens of seconds of it, and the speaker plays out of that store. If the network loses some along the way there is plenty of time to send it again and you never hear a thing. Music Assistant sends audio as it is being played, with about two seconds in hand. That is what lets it keep several speakers in step and start a track the moment you press play, but it also means a network fault that was always there, and always hidden, is now something you can hear.
+**Why it works in the manufacturer's own app but not here.** Apps like Apple Music and Spotify send the speaker a large amount of audio ahead of time, tens of seconds of it, and the speaker plays out of that store. If the network loses some along the way there is plenty of time to send it again and you never hear a thing. Music Assistant sends audio as it is being played, with about two seconds in hand. That is what lets it keep several speakers in sync and start a track the moment you press play, but it also means a network fault that was always there, and always hidden, is now something you can hear.
 
 So "it works fine in every other app" does not rule out the network. Nothing about the network changed. What changed is how much slack the sender has to cover it up.
 

--- a/src/content/docs/music-providers/deezer.md
+++ b/src/content/docs/music-providers/deezer.md
@@ -8,7 +8,7 @@ Music Assistant has support for <a href="https://www.deezer.com/" target="_blank
 
 Deezer is a French subscription streaming service with a catalogue of around 100 million tracks, plus podcasts and audiobooks. It is available in most countries and streams lossless on its higher tiers.
 
-Connecting your account puts your Deezer favourites and playlists alongside the rest of your music in Music Assistant, with the whole catalogue there to search. Podcasts and audiobooks come across as well, and your place in them is kept in step with Deezer's own apps.
+Connecting your account puts your Deezer favourites and playlists alongside the rest of your music in Music Assistant, with the whole catalogue there to search. Podcasts and audiobooks come across as well, and your place in them is kept in sync with Deezer's own apps.
 
 > [!NOTE]
 > Deezer's terms of service mean only HiFi, Premium and Family accounts can be used here. Free accounts will not work.

--- a/src/content/docs/music-providers/gpodder.md
+++ b/src/content/docs/music-providers/gpodder.md
@@ -9,7 +9,7 @@ Music Assistant has support for <a href="https://gpodder.github.io" target="_bla
 
 gPodder is a synchronisation service for podcast apps rather than a place to discover podcasts. It keeps a
 shared record of the podcasts you subscribe to and how far through each episode you are, so that several apps
-can stay in step with one another.
+can stay in sync with one another.
 
 This provider connects Music Assistant to that shared record. Your existing subscriptions turn up as podcasts
 you can play, and your listening progress is written back as you go, so an episode started elsewhere can be
@@ -51,7 +51,7 @@ To setup this functionality you need:
 - <b>Device ID.</b>
 
 > [!NOTE]
-> The Device ID can be anything you like, as long as it is plain letters and numbers. What matters is that every app you want to keep in step uses exactly the same one.
+> The Device ID can be anything you like, as long as it is plain letters and numbers. What matters is that every app you want kept in sync uses exactly the same one.
 
 > [!NOTE]
 > `gpodder.net` is deliberately _not_ supported. This source checks in with the server often, and the service hosted there is known to be either slow or completely unresponsive, which would hold Music Assistant up. Run one of the alternatives yourself instead.

--- a/src/content/docs/player-support/msx-bridge.md
+++ b/src/content/docs/player-support/msx-bridge.md
@@ -62,7 +62,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 - <b>Show notification before closing player.</b> Shows a confirmation dialog on the TV when playback is stopped from Music Assistant. Off by default
 - <b>Enable player grouping (experimental).</b> Allows several MSX TVs to be grouped so they play the same track together. Off by default. Disable it again if you run into problems with multi TV setups
 - <b>Sendspin bridge (experimental).</b> On by default. Registers each TV as a Sendspin client so it can join sample synchronised playback groups with any other Music Assistant player. The TV opens the web kiosk in Sendspin mode when a synchronised stream starts. It needs a TV browser capable of running the Sendspin web client, and falls back to the regular HTTP player if the TV cannot connect
-- <b>Stream Delivery Mode.</b> How the audio reaches the TVs. MA Streamserver (the default) points each TV straight at the Music Assistant stream server, which uses the least CPU and applies the per player codec and audio processing, falling back to Independent if the address cannot be worked out. Independent gives each TV its own separate stream, which uses more CPU and does not keep them in step. Shared Buffer prepares the audio once and feeds it to every group member, which is easier on your server and keeps grouped TVs better in step. Note that MA Streamserver mode has each grouped TV fetch its own stream, so they are not kept in step
+- <b>Stream Delivery Mode.</b> How the audio reaches the TVs. MA Streamserver (the default) points each TV straight at the Music Assistant stream server, which uses the least CPU and applies the per player codec and audio processing, falling back to Independent if the address cannot be worked out. Independent gives each TV its own separate stream, which uses more CPU and does not keep them synchronised. Shared Buffer prepares the audio once and feeds it to every group member, which is easier on your server and keeps grouped TVs better synchronised. Note that MA Streamserver mode has each grouped TV fetch its own stream, so they are not synchronised
 
 MSX players use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols). Two of those are worth knowing about on a TV:
 
@@ -80,7 +80,7 @@ You can check on all of this at `http://<ma-ip>:8099/`.
 ## Known Issues / Notes
 
 - **Audio format**: MP3 works on every TV, which is why it is the default. AAC sounds slightly better for the same file size. FLAC is lossless, but with it Music Assistant cannot tell the TV up front how much audio is coming, and some TVs will not play without that
-- **Player grouping**: This is experimental. `Shared Buffer` keeps the TVs better in step, but every TV in the group has to be set to the same audio format
+- **Player grouping**: This is experimental. `Shared Buffer` keeps the TVs better synchronised, but every TV in the group has to be set to the same audio format
 - **Network**: The TV and Music Assistant have to be on the same network. There is no way to reach a TV from outside your home
 - **Idle timeout**: If a TV is switched off or the MSX app is closed, it disappears from the player list after the idle timeout, 30 minutes by default. It comes back as soon as the TV connects again
 - Crossfade is not supported, because the TV does its own playing and cannot fade one track into the next

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -4,7 +4,7 @@ title: "Sendspin"
 
 # Sendspin-audio Provider  <img src="/assets/icons/sendspin-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-<a href="https://www.sendspin-audio.com/" target="_blank" rel="noopener noreferrer">Sendspin</a> is Music Assistant's own way of sending audio to a player. It keeps several devices playing in step with each other, closely enough that the same track can play in more than one room without any echo between them.
+<a href="https://www.sendspin-audio.com/" target="_blank" rel="noopener noreferrer">Sendspin</a> is Music Assistant's own way of sending audio to a player. It keeps several devices playing in sync with each other, closely enough that the same track can play in more than one room without any echo between them.
 
 It is built into Music Assistant and switched on from the start, so there is nothing to install. The web player you use in your browser is a Sendspin player, and Sendspin speakers and apps appear on their own once they are on your network.
 
@@ -19,7 +19,7 @@ To bring audio from a compatible Sendspin line-in, microphone, or other input in
     
 ## Features
 
-- **Synchronised multi-room audio**: every connected device stays in step
+- **Synchronised multi-room audio**: every connected device plays at the same moment
 - **Automatic discovery**: Sendspin devices on your network are found on their own
 - **Per-player audio settings**: each device gets its own equaliser and volume
 - **Control from the device**: play, pause and skip can be driven from the player as well as from Music Assistant
@@ -46,7 +46,7 @@ Sendspin does not stream over HTTP, so of the [settings shared by most protocols
 - <b>Require pairing.</b> Shown for a device you allowed to connect without pairing. Stops it connecting that way
 - <b>Manage device settings.</b> Opens the device's own pairing settings, where unpaired access, static PIN pairing and dynamic PIN pairing can each be turned on or off. While this section is open the device refuses connections from other servers, so close it again with <b>Close device management</b> when you are finished
 - <b>Automatically play line-in on.</b> Only shown for devices with a line-in that can report when a signal is present. Chooses where that line-in plays automatically, either This device, another player, or Off
-- <b>Static playback delay (ms).</b> Only shown for devices that support it. Shifts this player's audio to keep it in step with the others, from 0 up to 5000 ms. Increase it if audio on this player is heard too late, for example to make up for delay added by an amplifier, active speakers or the device's own operating system
+- <b>Static playback delay (ms).</b> Only shown for devices that support it. Shifts this player's audio to keep it in sync with the others, from 0 up to 5000 ms. Increase it if audio on this player is heard too late, for example to make up for delay added by an amplifier, active speakers or the device's own operating system
 - <b>Preferred audio format.</b> The audio format used for playback on this player. Automatic (let client decide) is the default, and the other options are read from the device itself
 
 ## Known Issues / Notes

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -19,7 +19,7 @@ To bring audio from a compatible Sendspin line-in, microphone, or other input in
     
 ## Features
 
-- **Synchronised multi-room audio**: every connected device plays at the same moment
+- **Synchronised multi-room audio**: every connected device stays in step
 - **Automatic discovery**: Sendspin devices on your network are found on their own
 - **Per-player audio settings**: each device gets its own equaliser and volume
 - **Control from the device**: play, pause and skip can be driven from the player as well as from Music Assistant

--- a/src/content/docs/player-support/squeezelite.md
+++ b/src/content/docs/player-support/squeezelite.md
@@ -34,7 +34,7 @@ In addition to the [Player Provider Settings](/settings/player-provider/) when s
 In addition to the [Individual Player Settings](/settings/individual-player/) and the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols), the Squeezelite provider has these settings of its own:
 
 - <b>Presets.</b> Real Squeezebox hardware or jive(lite) based emulators support presets. This section lets you assign a Playlist or Radio Station from your library to each of the ten presets
-- <b>Audio synchronization delay correction.</b> Shifts this player's audio by up to ±500 ms to keep it in step with the others. Refer to the Player Summary Table to identify which types support sync correction
+- <b>Audio synchronization delay correction.</b> Shifts this player's audio by up to ±500 ms to keep it in sync with the others. Refer to the Player Summary Table to identify which types support sync correction
 - <b>Enable display support.</b> Some Squeezelite hardware has a display and this setting enables support for it
 - <b>Visualization type.</b> The visualisation shown on the display during playback. It only becomes available once display support is enabled
 - <b>[Prefer low-latency WAV for live sources](/settings/individual-player/#prefer-low-latency-wav-for-live-sources).</b> On by default for Squeezelite. Turn it off if the player cannot play continuous WAV streams


### PR DESCRIPTION
Ten occurrences across six pages, all of them saying that players, apps or playback positions are synchronised. They now say "in sync" or "synchronised".

- `faq/networking.md` keeping several speakers in sync
- `music-providers/deezer.md` playback position kept in sync with Deezer's apps
- `music-providers/gpodder.md` two, apps sharing a subscription record
- `player-support/msx-bridge.md` four, across the Stream Delivery Mode options and the grouping note
- `player-support/sendspin.md` two
- `player-support/squeezelite.md` the sync delay correction setting

Two are left as they were. The Sendspin feature bullet keeps its original wording, since the alternatives were worse than the phrase. And `music-providers/spotify.md` says "shown in step 3", which is a numbered instruction rather than the phrase.

Site builds clean.