### PR TITLE
Bring the AI Radio page back in line with the plugin

### DIFF
--- a/src/content/docs/plugins/ai-radio.md
+++ b/src/content/docs/plugins/ai-radio.md
@@ -27,19 +27,11 @@ AI Radio is in alpha. The show and host editors, the bundled hosts and the gener
 - Turn on an AI DJ for any queue straight from the queue menu
 - Duplicate a show to make a variation without starting again
 
-## Requirements
+## Before you start
 
-- The **AI Radio** plugin, added from **Settings → Plugins → Add a plugin**
-- At least one playlist with playable tracks
-- An **AI engine** to write what the host says, and a **text-to-speech engine** to speak it. Both come from other plugins. See [AI and text-to-speech engines](/ha-plugin/#ai-and-text-to-speech-engines)
-- An enabled and available player to listen on
-
-> [!IMPORTANT]
-> Both engines have to exist **before** you add AI Radio. Setup will not let you continue without them, and will tell you to set up a plugin that provides the missing one first.
-
-:::note
-The host is written fresh every time, so the same show will not say the same thing twice.
-:::
+- An **AI engine** to write what the host says, and a **text-to-speech engine** to speak it. Both come from other plugins, so set these up first. AI Radio will not get past its own first step without them. See [AI and text-to-speech engines](/ha-plugin/#ai-and-text-to-speech-engines)
+- A player to listen on, enabled and available
+- A playlist with playable tracks, if you want to build a show. The AI DJ works on whatever is already in the queue
 
 ## Setting it up
 
@@ -86,6 +78,8 @@ Music Assistant prepares the first few tracks and host segments, queues them, an
 
 Only one show can be on air at a time. If another is already running, Music Assistant asks whether to stop it and switch.
 
+The host is written fresh every time, so the same show will not say the same thing twice.
+
 > [!NOTE]
 > Starting a show clears the target queue and turns off shuffle on it, so the segments stay with the tracks they were written for. Anything already queued is replaced.
 
@@ -98,6 +92,8 @@ Open the queue menu and choose **Enable AI Radio DJ**, then pick a host. Choose 
 The choice sticks to that queue and survives a Music Assistant restart, so the DJ carries on until you turn it off. Switching to a different host removes anything the previous host had lined up.
 
 A queue has one host at a time. If you start a show on the queue, the show takes it over and the menu shows **On air** with that show's host instead.
+
+The difference from a show is that a show has a beginning and an end, while a queue just keeps going. The DJ only ever fills the gaps between songs, so a host's **Once at start** and **Once at end** segments never play. If you want the opening greeting and the sign-off, run it as a show.
 
 ## Customizing a show
 
@@ -130,7 +126,7 @@ Select **Edit** on a host card, or **Add host** to build one from scratch. You c
 |---|---|
 | **Host name** | The name shown wherever you pick a host |
 | **Voice** | The text-to-speech voice this host speaks with. **Default** uses the engine chosen during setup |
-| **Language** | The language the host speaks. **Follow server language** uses your Music Assistant language |
+| **Language** | The language the host speaks. **Follow server language** uses the **Preferred language** from [**Settings → System → Metadata**](/settings/core/#metadata) |
 | **Host and Program Instructions** | The personality and writing style. This goes to the AI with every segment |
 
 ### Segments

--- a/src/content/docs/plugins/ai-radio.md
+++ b/src/content/docs/plugins/ai-radio.md
@@ -1,211 +1,238 @@
 ---
 title: AI Radio Plugin
-description: Turn a playlist into an AI-hosted radio show, either as a generated playlist or as a live dynamic queue.
+description: Turn a playlist into a radio show with an AI host, or let an AI DJ talk over the queue you are already playing.
 ---
 
 # AI Radio Plugin
 
-AI Radio turns one of your playlists into a radio-style show with spoken host segments between tracks. The host can introduce songs, bridge from one track to the next, add occasional weather or news breaks, and save the finished program as a playlist or play it live through a Music Assistant player.
+AI Radio puts a spoken host between your tracks. The host can open the show, introduce songs, link one track to the next, and add weather, news or artist facts along the way.
+
+There are two ways to use it:
+
+- A **show** turns one of your playlists into a radio programme and plays it on a player you choose
+- The **AI DJ** adds the same spoken breaks to a queue you are already listening to, without setting up a show at all
 
 :::note
-AI Radio is currently in beta. The show editor, prompt presets, generated output, and advanced station format may change between Music Assistant releases.
+AI Radio is in alpha. The show and host editors, the bundled hosts and the generated output may all change between Music Assistant releases.
 :::
 
 ## Features
 
-- Create reusable **shows** from Music Assistant playlists
-- Pick a bundled host style such as **Morning show**, **Minimal DJ**, **Music nerd**, or **Party host**
-- Choose how often the host speaks with the talkativeness setting
-- Generate spoken sections with an AI provider and synthesize them with a TTS provider
-- Play a show live through a Music Assistant player
-- Generate a completed show and save it as a Music Assistant playlist
-- Customize each segment's prompt, timing, web-search behavior, and character limit
-- Use placeholders such as `<prev_songinfo>`, `<next_songinfo>`, `<timestamp>`, and `<weather_hourly>`
-- Add optional weather updates through Open-Meteo when a weather location is configured
-- Duplicate existing shows to create variations without starting from scratch
+- Build reusable **shows** from your playlists
+- Start from a bundled host such as **Morning show**, **Minimal DJ**, **Music nerd** or **Party host**
+- Give a host its own voice, language and personality, and reuse it across shows
+- Decide when the host speaks, from every song to once an hour
+- Let the host look things up on the web for segments that need current information
+- Add weather to any segment through Open-Meteo
+- Turn on an AI DJ for any queue straight from the queue menu
+- Duplicate a show to make a variation without starting again
 
 ## Requirements
 
-- The **AI Radio** plugin must be enabled in **Settings → Plugins → Add a plugin**.
-- At least one playlist with playable tracks.
-- An **AI engine**, to write what the host says, and a **text-to-speech engine**, to speak it. Both come from other plugins. See [AI and text-to-speech engines](/ha-plugin/#ai-and-text-to-speech-engines).
-- For live playback, an enabled and available Music Assistant player.
+- The **AI Radio** plugin, added from **Settings → Plugins → Add a plugin**
+- At least one playlist with playable tracks
+- An **AI engine** to write what the host says, and a **text-to-speech engine** to speak it. Both come from other plugins. See [AI and text-to-speech engines](/ha-plugin/#ai-and-text-to-speech-engines)
+- An enabled and available player to listen on
 
 > [!IMPORTANT]
-> Both engines have to exist **before** you add AI Radio. Its setup will not let you continue without them, and will tell you to set up a plugin that provides the missing one first.
+> Both engines have to exist **before** you add AI Radio. Setup will not let you continue without them, and will tell you to set up a plugin that provides the missing one first.
 
 :::note
-AI Radio generates new speech each time a show is started. The exact wording can vary even when the same show and playlist are used.
+The host is written fresh every time, so the same show will not say the same thing twice.
 :::
 
-## Installation
-
-### Configure the Plugin
+## Setting it up
 
 1. Go to **Settings → Plugins → Add a plugin**.
 2. Add **AI Radio**.
-3. Setup opens at a step called **Choose the AI Radio engines**. Pick the AI engine that will write the host's lines and the text-to-speech engine that will voice them.
-4. Configure the optional plugin settings:
-
-| Setting | Description |
-|---|---|
-| **Timezone** | Used for timestamp placeholders and local date formatting. Defaults to the server timezone. |
-| **Weather city** | City used when a show segment contains weather placeholders. |
-| **Weather country** | Country used together with the city for weather lookup. |
-
-Weather is optional. Shows without weather segments do not need a weather location.
+3. Setup opens at **Set up AI Radio**. Choose the AI engine that writes the host's lines and the text-to-speech engine that voices them.
+4. If you want weather in your shows, fill in the weather city and country on the same screen. You can leave them empty and add them later.
+5. **AI Radio** then appears in the main navigation.
 
 ### Changing the AI or text-to-speech engine later
 
 :::caution[The engine pickers are not in AI Radio's settings]
-AI Radio stores its two engine choices with its setup rather than its settings. **Configure** shows only the timezone and weather options above.
+AI Radio stores its two engine choices with its setup rather than its settings, so **Configure** does not show them.
 
-To change either engine, choose **Reconfigure** from the AI Radio provider's menu. This reopens the **Choose the AI Radio engines** step with your current selections filled in, so you can change one and leave the other. Nothing else is affected and your shows are unchanged.
+To change either engine, choose **Reconfigure** from the AI Radio provider's menu. This reopens **Set up AI Radio** with your current choices filled in, so you can change one and leave the other. Your shows and hosts are not affected.
 :::
+
+## Shows and hosts
+
+AI Radio keeps these two things separate, and it is worth knowing which is which before you start.
+
+A **show** is the short part. It is a playlist, a host, and a name.
+
+A **host** is where the character lives. It holds the voice, the language, the personality, and the segments that decide what gets said and when. Because the host is separate, one host can front several shows, and changing the host changes all of them.
+
+The AI Radio page has a gallery for each, **Shows** and **Hosts**.
 
 ## Creating a show
 
-1. Open **AI Radio** from the Music Assistant sidebar.
+1. Open **AI Radio** from the navigation.
 2. Select **Create show**.
 3. Choose a **Source playlist**.
-4. Select a **Host style**.
-5. Choose a **Talkativeness** level.
-6. Give the show a name.
-7. Select **Create** or **Create & play**.
+4. Choose a **Host**.
+5. Give the show a **Show name**.
+6. Select **Create**, or **Create & play** to start it straight away.
 
-The create dialog is meant to get a useful show running quickly. You can fine-tune the show later with **Customize**.
+There is a shortcut if you are already looking at the playlist you want. Open its menu and choose **Play as AI Radio**, which opens the AI Radio page with that playlist already filled in.
 
 ## Playing a show
 
-Each show card has two main run options.
+Each show card has **Play**, which starts it on the show's player. While it runs the card shows **On air**, and **Stop** ends it.
 
-| Action | What it does |
-|---|---|
-| **Play** | Starts a live AI Radio run on the selected player. Music Assistant prepares the first batch of tracks and host segments, queues them, then continues preparing more while playback is running. |
-| **Generate and save as playlist** | Builds the complete show in the background and saves it as a Music Assistant playlist. Use this when you want a reusable generated episode instead of live generation. |
+Music Assistant prepares the first few tracks and host segments, queues them, and keeps preparing more while the show plays.
 
-Only one AI Radio run can be active at a time. If another show is already on air, Music Assistant asks whether to stop it and switch to the selected show.
+Only one show can be on air at a time. If another is already running, Music Assistant asks whether to stop it and switch.
+
+> [!NOTE]
+> Starting a show clears the target queue and turns off shuffle on it, so the segments stay with the tracks they were written for. Anything already queued is replaced.
+
+## The AI DJ on a queue
+
+The AI DJ is the quick way in. Instead of building a show, you point a host at a queue and it starts talking between the tracks already playing there.
+
+Open the queue menu and choose **Enable AI Radio DJ**, then pick a host. Choose **Off** in the same menu to stop it.
+
+The choice sticks to that queue and survives a Music Assistant restart, so the DJ carries on until you turn it off. Switching to a different host removes anything the previous host had lined up.
+
+A queue has one host at a time. If you start a show on the queue, the show takes it over and the menu shows **On air** with that show's host instead.
 
 ## Customizing a show
 
-Select **Customize** on a show card to edit its basics, segments, and advanced settings.
-
-### Basics
+Select **Customize** on a show card.
 
 | Field | Description |
 |---|---|
-| **Show name** | Display name for the show. |
-| **Source playlist** | Playlist used as the music source. |
-| **Default playback device** | Player used by the **Play** action. This can be left empty and selected later. |
+| **Show name** | The name on the card |
+| **Source playlist** | The playlist the music comes from |
+| **Host** | The host that fronts this show |
+
+<details>
+<summary>Advanced show settings</summary>
+
+| Setting | Default | Description |
+|---|---:|---|
+| **Default Playback Device (optional)** | Empty | The player **Play** uses. **Use current player** fills in the one you are listening on |
+| **Source Playtime Cap (minutes)** | 0 | The most source music the show will use, in minutes. Tracks are taken in the order the show plays them until the cap is reached. Leave it at 0 for no limit |
+| **Shuffle Playlist Tracks** | On | Plays the source playlist in random order. Turn it off to follow the playlist's own order |
+
+</details>
+
+## Customizing a host
+
+Select **Edit** on a host card, or **Add host** to build one from scratch. You can also start from **Blank host**.
+
+### Personality
+
+| Field | Description |
+|---|---|
+| **Host name** | The name shown wherever you pick a host |
+| **Voice** | The text-to-speech voice this host speaks with. **Default** uses the engine chosen during setup |
+| **Language** | The language the host speaks. **Follow server language** uses your Music Assistant language |
+| **Host and Program Instructions** | The personality and writing style. This goes to the AI with every segment |
 
 ### Segments
 
-A segment is one spoken part of the show. A segment has:
+A segment is one spoken part. **Add segment** offers ready-made ones for **Intro**, **Transition**, **Weather**, **News**, **Artist fact** and **Sign-off**, or a **Blank segment**.
 
 | Field | Description |
 |---|---|
-| **Segment name** | Name shown in the editor and in generated playlist entries. |
-| **Prompt** | Instructions sent to the AI for this spoken section. |
-| **Web Search Mode** | Whether the AI may use web search for this segment. |
-| **Character Limit** | Soft maximum length for the generated text before TTS. |
-| **Plays** | When and how often the segment should be inserted. |
+| **Segment name** | The name shown in the editor |
+| **Prompt** | What you want the AI to say in this segment |
+| **Web Search Mode** | Whether the host may look things up for this segment |
+| **Character Limit** | Roughly how long the spoken text may get |
+| **Plays** | When and how often the segment is used |
 
-The simple editor supports these timing choices:
+**Plays** offers **Once at start**, **Once at end**, **Every song**, **Every ~N songs**, **Every ~N min** and **Occasionally**, the last with a percentage.
 
-- **Once at start**
-- **Once at end**
-- **Every song**
-- **Every ~N songs**
-- **Every ~N min**
-- **Occasionally**, with a percentage
-
-If more than one between-song segment is due at the same point, AI Radio can draft those segments separately and merge them into one spoken host break. For example, a song transition and a weather segment can become one moderator line that knows both the next song and the weather.
+If two between-song segments fall at the same point, AI Radio writes them separately and merges them into a single break, so a song transition and the weather arrive as one piece of speech rather than two.
 
 ### Web search modes
 
-| Mode | Description |
+| Mode | What it does |
 |---|---|
-| **disabled** | The AI should rely on the prompt and track metadata only. |
-| **allow** | The AI may use web search if the AI provider supports it. |
-| **force** | The segment requires web search. This is useful for current-news style segments. |
+| **disabled (no web tool)** | The host uses the prompt and the track information only |
+| **allow (model may use web)** | The host may search if the AI engine supports it |
+| **force (web search required)** | The segment always searches. Use this for news |
 
-Use web search sparingly. It can improve current or factual segments, but it can also make generation slower and depends on the capabilities of the configured AI provider.
+Use it sparingly. Searching makes a segment slower to prepare, and what it can do depends on your AI engine.
 
-### Prompt placeholders
+### Placeholders
 
-AI Radio replaces placeholders in prompts before sending them to the AI.
+Anything below is filled in before the prompt goes to the AI. In the editor you can tap a placeholder to copy it.
 
 | Placeholder | Meaning |
 |---|---|
-| `<prev_songinfo>` | Artist/title information for the previous track, when available. |
-| `<next_songinfo>` | Artist/title information for the next track, when available. |
-| `<very_next_songinfo>` | Artist/title information for the track after the next track, when available. |
-| `<timestamp>` | Current local time based on the AI Radio timezone setting. |
-| `<weather_hourly>` | Current and near-future weather summary, when weather is configured. |
-| `<weather_daily>` | Daily weather summary, when weather is configured. |
+| `<prev_songinfo>` | The track just played |
+| `<next_songinfo>` | The track coming up |
+| `<very_next_songinfo>` | The track after that |
+| `<timestamp>` | The current local time |
+| `<weather_hourly>` | The weather now and over the next few hours |
+| `<weather_daily>` | The weather for the day |
 
-Example prompt:
+An example prompt:
 
 ```text
 The previous track was <prev_songinfo> and the next track is <next_songinfo>.
 Create a natural radio transition that connects both songs and keeps it concise.
 ```
 
-## Advanced settings
+<details>
+<summary>Advanced text-to-speech options</summary>
+
+A host can pass extra options straight to its text-to-speech engine as key and value pairs, for example a `voice` key with a value of `en_US-lessac-medium`.
+
+Only add keys your chosen engine understands. An unsupported key can make the engine reject the whole clip, so the host says nothing at all.
+
+</details>
+
+## Weather
+
+Weather comes from Open-Meteo. To use it, set the weather city and country in the plugin settings, then give a segment a prompt containing `<weather_hourly>` or `<weather_daily>`.
+
+A timing such as **Every ~60 min** or **Occasionally** keeps it from coming round too often.
+
+If the weather cannot be fetched, the host leaves the weather out and carries on rather than stopping the show. A segment that exists only to read the forecast is skipped instead.
+
+## Plugin settings
+
+Found under **Configure** on the AI Radio provider.
 
 | Setting | Default | Description |
-|---|---:|---|
-| **Host and Program Instructions** | Preset-specific | Overall host personality and writing style. This is sent with every generated segment. |
-| **Source Playtime Cap (minutes)** | 0 | Limits the total source music used for a run. Set to `0` for no limit. Tracks are sampled randomly until the cap is reached. |
-| **Dynamic Batch Size** | 3 | Number of source tracks prepared at a time in live mode. Larger batches reduce mid-show waiting but can increase startup time and token usage. |
-| **Clear Queue on Dynamic Start** | On | Clears the selected player's queue before live playback. Turn it off to append the show after the current queue instead. |
+|---|---|---|
+| **Weather City** | From setup | The city used to look up the forecast |
+| **Weather Country** | From setup | The country that goes with it |
 
-## Weather segments
+<details>
+<summary>Advanced plugin settings</summary>
 
-AI Radio uses Open-Meteo for weather placeholders. To use weather:
+These appear only when the `Show advanced settings` toggle is on.
 
-1. Configure **Weather city** and **Weather country** in the AI Radio plugin settings.
-2. Add or keep a segment whose prompt contains `<weather_hourly>` or `<weather_daily>`.
-3. Use a timing rule such as **Every ~60 min** or **Occasionally** so weather does not appear too often.
+| Setting | Default | Description |
+|---|---|---|
+| **Timezone** | The server's | The timezone used to work out the current time for `<timestamp>` |
+| **Weather Provider** | Open-Meteo | Where the forecast comes from. Set it to Disabled to stop looking one up |
+| **Weather Request Timeout** | 20 | How long to wait for the forecast, in seconds, before giving up |
+| **Spoken Clip Loudness Boost** | 3 | How many decibels above the music the spoken sections sit. Peaks are always limited so the audio cannot clip, so the last few decibels arrive mostly as compression rather than loudness. Set it to 0 to keep speech at the same level as the music |
 
-If weather lookup fails or the location is missing, AI Radio skips weather placeholder content rather than stopping the whole show.
-
-## Generated playlists
-
-When you select **Generate and save as playlist**, Music Assistant creates a new playlist containing:
-
-- The generated TTS host sections
-- The selected source tracks
-- Stable metadata for the AI Radio sections
-
-Generated playlists are useful for testing a show format, saving an episode, or playing the result later without waiting for live generation.
-
-## Live mode
-
-When you select **Play**, AI Radio runs in dynamic mode:
-
-1. It samples source tracks from the selected playlist.
-2. It plans the first batch of host segments.
-3. It generates AI text and TTS audio.
-4. It queues the generated host audio and music.
-5. While playback continues, it prepares later batches before the queue reaches them.
-
-If **Clear Queue on Dynamic Start** is enabled, the selected queue is replaced. If disabled, AI Radio appends the show after the current queue and waits for the correct playback position before adding later batches.
+</details>
 
 ## Tips
 
-- Start with **Minimal DJ** if you want fewer interruptions.
-- Use **Music nerd** with web search allowed for artist facts and context.
-- Use **Morning show** if you want weather and news-style breaks.
-- Keep segment prompts short and direct. The best prompts describe the exact role of the segment and mention that the text is for spoken delivery.
-- Use character limits to keep TTS sections from becoming too long.
-- Generate a playlist first when experimenting with new prompts. It is easier to review the complete result before using live playback.
+- Start with **Minimal DJ** if you want the music mostly left alone
+- **Music nerd** with web search allowed is the one for artist facts
+- **Morning show** is the busiest, with weather and news built in
+- Keep prompts short and specific. Say what the segment is for, and that it will be read aloud
+- Use the character limit to stop a segment turning into a monologue
+- Try a new host on a queue with the AI DJ first. It is quicker than building a show to hear how it sounds
 
 ## Troubleshooting
 
-### Setup will not let me past the engines step
+### Setup will not let me past the first step
 
-AI Radio needs both an AI engine and a text-to-speech engine, and neither can be created from here. Set up a plugin that provides the missing one first, as described under [AI and text-to-speech engines](/ha-plugin/#ai-and-text-to-speech-engines), then add AI Radio again.
+AI Radio needs both an AI engine and a text-to-speech engine, and neither can be created here. Set up a plugin that provides the missing one first, as described under [AI and text-to-speech engines](/ha-plugin/#ai-and-text-to-speech-engines), then add AI Radio again.
 
 ### I cannot find the engine pickers in the plugin's settings
 
@@ -219,17 +246,16 @@ The engine it was using has gone. This usually means the entity behind it was re
 
 Check the text-to-speech engine works at its source. With Home Assistant, test the entity there first, then check that the [Home Assistant plugin](/ha-plugin/) is still connected in Music Assistant.
 
-### Live playback will not start
+If the host has **Advanced text-to-speech options** set, try removing them. A key the engine does not understand can make it reject the clip.
 
-Make sure the selected player is enabled, available, and not hidden. If the show has no default playback device, select one before pressing **Play**.
+### A show will not start
+
+The show needs a player, and that player has to be enabled and available. If the show has no default playback device, pick one before pressing **Play**.
+
+### The AI DJ is on but never speaks
+
+Check the queue is actually playing. The DJ fills the gaps between tracks, so it has nothing to do while the queue is stopped. If a show is on air on that queue, the show has taken it over and the menu will say so.
 
 ### Weather segments are empty or skipped
 
-Confirm that **Weather city** and **Weather country** are configured in the AI Radio plugin settings. Weather is currently provided by Open-Meteo.
-
-### A customized show warns that it will be simplified on save
-
-Some advanced station configurations cannot be represented perfectly in the simple show editor. Saving rewrites the show into the simplified segment format used by the UI.
-
-
-</details>
+Check the weather city and country are set in the plugin settings, and that **Weather Provider** has not been set to Disabled.


### PR DESCRIPTION
The page described a version of AI Radio that no longer exists. Checked against the server at `a90dbd3` (the 2.10.0rc5 line) and the frontend at `8b99e33`, and rewrote it.

## Removed, because the code no longer does it

**Generate and save as playlist.** Nothing in the plugin creates a playlist any more. Playlists are only read as a music source, and `start_run` raises `AI Radio requires a target player` without one. The page gave this a row in the run table, a whole `## Generated playlists` section, and a tip. The frontend has no such action either.

**Talkativeness.** No trace of it in the plugin. The create dialog asks for a host instead.

**Dynamic Batch Size and Clear Queue on Dynamic Start.** Neither exists. The queue is now cleared unconditionally on start, and shuffle is forced off on it, so the old "turn it off to append the show after the current queue" was describing something that cannot happen.

## Added, because the code does it and the page never said so

**The AI DJ.** A sticky per-queue host, armed from the queue menu under **Enable AI Radio DJ** and turned off with **Off** in the same submenu. It injects spoken breaks into a queue you are already playing, persists across restarts, and is taken over by a show if one starts on that queue. It is the fastest way to hear what a host sounds like, so it now sits right after the show sections.

**Hosts as their own thing.** A host holds the voice, the language, the personality and the segments, and can front several shows. Segments moved here from the show, which is the biggest structural change on the page.

**Play as AI Radio**, on a playlist's context menu, which opens the AI Radio page with that playlist filled in.

**Shuffle Playlist Tracks** on a show, and the three advanced plugin settings that were missing: Weather Provider, Weather Request Timeout and Spoken Clip Loudness Boost.

## Corrected

- The setup step is **Set up AI Radio**, not "Choose the AI Radio engines". The old name appeared three times, including in troubleshooting
- Setup also collects the weather location now, so weather works without a trip to the settings screen
- The manifest says `"stage": "alpha"`, so the note says alpha rather than beta
- Removed a stray `</details>` that had been on the last line since the page was created

## Unchanged

The four bundled hosts, all six placeholders, the six timing options, the three web search modes, the engine prerequisites, one run at a time, Source Playtime Cap and the Reconfigure route for changing engines all matched the code and are kept.

Advanced material is in collapsed sections so the page stays readable for a first-time reader. Site builds clean, and the inbound anchor from `ha-plugin.md` still resolves.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U42bRfm14UaFLyHtTjHt1o)_