### PR TITLE
Say where screenshots go, not just icons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -324,6 +324,9 @@ have is white, put it on a dark rounded plate, as several existing icons do.
 Keep PNGs small. They are served as they are, with no resizing, and they are displayed at about
 48 pixels on the tile pages.
 
+Screenshots and any other pictures go in `public/assets/screenshots/` and are referenced as
+`/assets/screenshots/<name>`, not in `src/assets`.
+
 ## Editing an `.mdx` page
 
 Most pages are `.md`. A few are `.mdx` because they use components. MDX is stricter than


### PR DESCRIPTION
The Icons section told contributors where icons go but nothing said where other pictures belong, so they sometimes end up in `src/assets`.

One sentence added at the end of that section:

> Screenshots and any other pictures go in `public/assets/screenshots/` and are referenced as `/assets/screenshots/<name>`, not in `src/assets`.

Site builds clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U42bRfm14UaFLyHtTjHt1o)_