### PR TITLE
Retire the Local Audio Out provider page

### DIFF
--- a/src/content/docs/faq/stream-to.mdx
+++ b/src/content/docs/faq/stream-to.mdx
@@ -35,7 +35,7 @@ already own, a phone, a browser, or something you have yet to buy.
 
 ## My Local HA or MA  Device
 
-The native solution is to use the [Local Audio Addon](https://github.com/music-assistant/local-audio-addon) which will create a Sendspin player for each soundcard.
+The native solution is the [Local Audio app](/player-support/local-audio/), which turns the machine it runs on into a Sendspin player.
 
 Alternatively for HA, you can install the <a href="https://github.com/pssc/ha-addon-squeezelite" target="_blank" rel="noopener noreferrer">squeezelite app</a> which will then allow streaming over an audio connection from the HA host to your speaker or amplifier.
 

--- a/src/content/docs/player-support/local-audio.md
+++ b/src/content/docs/player-support/local-audio.md
@@ -1,47 +1,21 @@
 ---
-title: "Local Audio Out"
-description: A description of the Local Audio Out Player Provider
+title: "Local Audio Out (retired)"
+description: The Local Audio Out player provider has been retired in favour of the Local Audio app
 ---
 
 # Local Audio Out <img src="/assets/icons/loudness-analysis-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
-Music Assistant can play audio directly through soundcards attached to the machine the server runs on, such as USB DACs, built-in audio outputs and HDMI audio. Each detected output device is added as its own player. This is useful for turning the server into a player, for example a small computer connected to an amplifier or a pair of powered speakers.
+> [!CAUTION]
+> **This provider has been retired.** It can no longer be added, and where one is already configured it fails to load with a notice pointing here. The only thing left to do with it is press **Remove** in its settings.
+
+Playing to soundcards, USB DACs and built-in audio outputs on the machine Music Assistant runs on is now the job of the **Local Audio** app, which runs alongside Music Assistant rather than inside it.
+
+## The Local Audio app
+
+The app plays to the audio hardware of the machine it runs on and appears in Music Assistant as a [Sendspin](/player-support/sendspin/) player, found over mDNS on its own. There is no provider to add in Music Assistant.
+
+- **On Home Assistant**, install **Local Audio** from the Music Assistant app repository, the same one Music Assistant itself comes from. Choose the output it plays through in the app's own **Audio** panel; nothing in its configuration picks an output.
+- **Anywhere else**, run the container with Docker Compose. Both it and the app are built from <a href="https://github.com/music-assistant/local-audio-addon" target="_blank" rel="noopener noreferrer">music-assistant/local-audio-addon</a>, whose README covers the environment variables and how to name an ALSA output.
 
 > [!NOTE]
-> This provider is in an early (alpha) stage of development. Basic playback works but some features are still limited and behaviour may change between releases.
-
-## Features
-
-- Attached soundcards are auto detected when the provider is loaded
-- Each output device is added as a separate player
-- Playback between multiple Local Audio players is synchronized, so they can be grouped together
-- On Linux with PulseAudio or PipeWire, each output (sink) is added as a player at its native sample rate and bit depth, so no unnecessary resampling takes place
-- On Linux with PulseAudio or PipeWire, multi-channel soundcards (5.1/7.1) are automatically split into separate stereo players per speaker pair (front, rear, side, center/subwoofer), plus a "multichannel stereo" player that plays to all outputs at once. Each of these players has its own independent volume control
-
-## Requirements
-
-- The soundcard must be attached to, and usable from, the environment where the Music Assistant server runs. When the server runs in a container, the audio devices must be made available to that container (for a manual Docker install this means passing through /dev/snd)
-- This provider uses the Sendspin provider under the hood for timing and synchronization, so Sendspin must remain enabled
-- The PulseAudio/PipeWire backend requires pactl (from pulseaudio-utils) and the PulseAudio client libraries to be installed on the host
-
-## Configuration
-
-1. In Music Assistant, go to **Settings → Player Providers**, click **Add a player provider** and select `Local Audio Out`.
-2. The soundcards attached to the machine running the MA server are detected automatically and each output appears as its own player.
-
-## Settings
-
-For information about the settings seen in the MA UI refer to the [Player Provider Settings](/settings/player-provider/) and [Individual Player Settings](/settings/individual-player/) pages. Specific settings available for this provider are:
-
-- <b>Audio backend</b> *(Linux only)*. The default is Auto (PulseAudio/PipeWire if available, else ALSA). PulseAudio / PipeWire plays through the system sound server and supports virtual sinks and multi-channel soundcards. ALSA (direct) talks to the hardware directly and can be used for devices that PulseAudio or PipeWire cannot handle correctly
-
-## Known Issues / Notes
-
-- Devices that cannot be opened, for example because another program or sound server is using them, are skipped during discovery. If an expected player is missing, make sure the device is not in use elsewhere and reload the provider
-- On Linux, plugging in or removing a USB audio device reloads the provider automatically. Any playback on local audio players is briefly interrupted while this happens
-- On the PulseAudio/PipeWire backend, the sample rate and bit depth of each player follow the sound server configuration and the device's native capabilities; they cannot be set per player in MA. On the ALSA direct backend and macOS, audio is played in stereo at 44.1 kHz / 16 bit
-- On the ALSA direct backend, the hardware mixer is not controlled by MA and volume is applied in software. Set the card's mixer controls to 100% once using alsamixer and save them with alsactl store so they persist across reboots
-- On the ALSA direct backend only real hardware devices are listed; virtual ALSA devices (such as dmix and surround) are excluded
-- The volume slider uses an audio taper curve, meaning each step changes the loudness by the same amount instead of the volume being overly sensitive at the bottom of the range
-- A player never starts up muted: the volume level is remembered across restarts, but the mute state is intentionally not
-- While the provider is active, its PulseAudio sinks stay in the RUNNING state. This is intentional: the audio streams are kept open so that grouped players start perfectly in sync
+> The app is experimental. It works, but it has not been through wide testing on real hardware.

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -66,6 +66,7 @@ Several client types can connect to Music Assistant via Sendspin:
 | **Web Browser** | The built-in Music Assistant web player uses Sendspin for local playback |
 | **[Google Cast (Sendspin mode)](/player-support/google-cast/)** | Experimental Sendspin mode for Chromecast devices |
 | **<a href="https://esphome.github.io/home-assistant-voice-pe/" target="_blank" rel="noopener noreferrer">Home Assistant Voice PE</a>** | Built into recent Voice PE firmware. Update the device with the official installer, choosing a pre-release build if the current stable one does not show up as a player |
+| **[Local Audio](/player-support/local-audio/)** | Plays to the soundcard, USB DAC or built-in output of the machine it runs on. Deploys as a Home Assistant App or with Docker Compose |
 | **<a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>** | Bridges Bluetooth speakers as MA players, with multi-device support, multiroom sync and a web dashboard. Deploys as a Home Assistant App, Docker, or LXC |
 | **<a href="https://www.sendspin-audio.com/code/" target="_blank" rel="noopener noreferrer"> Various Sendspin Clients</a>** | Clients are becoming available for various platforms |
 

--- a/src/data/player-capabilities.ts
+++ b/src/data/player-capabilities.ts
@@ -120,10 +120,9 @@ export const CAPABILITY_NOTES: string[] = [
 // slug here only while its capabilities are genuinely unknown, and take it out
 // again once they are.
 export const KNOWN_UNCHARTED: string[] = [
-  // Alexa controls the device rather than streaming to it, and Local Audio Out
-  // is new; neither has published capability data.
+  // Alexa controls the device rather than streaming to it, so it has no
+  // published capability data.
   "player-support/alexa",
-  "player-support/local-audio",
 ];
 
 export const PLAYER_CAPABILITIES: PlayerCapabilities[] = [

--- a/src/data/players.ts
+++ b/src/data/players.ts
@@ -174,12 +174,6 @@ export const PLAYERS: TileItem[] = [
     categories: ["voice"],
   },
   {
-    name: "Local Audio Out",
-    slug: "player-support/local-audio",
-    icon: "/assets/icons/loudness-analysis-icon.svg",
-    categories: ["software"],
-  },
-  {
     name: "Marantz",
     nameHidden: true,
     via: { label: "HEOS", icon: "/assets/icons/heos-icon.svg" },
@@ -322,7 +316,6 @@ export const PLAYER_PROVIDERS: PlayerProvider[] = [
   { name: "Google Cast", slug: "player-support/google-cast", icon: "/assets/icons/google-cast-logo.svg" },
   { name: "HEOS", slug: "player-support/heos", icon: "/assets/icons/heos-icon.svg" },
   { name: "Home Assistant", slug: "player-support/home-assistant", icon: "/assets/icons/ha-logo.png" },
-  { name: "Local Audio Out", slug: "player-support/local-audio", icon: "/assets/icons/loudness-analysis-icon.svg" },
   { name: "MSX Bridge", slug: "player-support/msx-bridge", icon: "/assets/icons/msx-bridge-icon.svg" },
   { name: "Music Player Daemon (MPD)", slug: "player-support/music-player-daemon", icon: "/assets/icons/mpd-icon.svg" },
   { name: "MusicCast", slug: "player-support/musiccast", icon: "/assets/icons/musiccast-icon.svg" },
@@ -350,6 +343,9 @@ export const PLAYERS_PAGE = {
   // Pages under player-support/ that intentionally have no tile.
   knownUnlisted: [
     "player-support", // the overview page
+    // Retired provider. The page stays because the server still points at it,
+    // but there is nothing left to stream to.
+    "player-support/local-audio",
   ],
   groups: PLAYER_GROUPS,
   items: PLAYERS,


### PR DESCRIPTION
Server PR music-assistant/server#5965 retires the built-in `local_audio` provider: it refuses to load and points users at this page. Against `beta`, since the retirement has not shipped.

The page is rewritten in place rather than deleted — the provider manifest still sets `documentation` to `/player-support/local-audio/`, so the URL has to keep resolving. It is now a retirement notice plus a short section on the replacement, the Local Audio app: a Sendspin client that runs outside Music Assistant. Down from 47 lines to 21.

The add-on details are checked against `local_audio/config.yaml` and the READMEs in both `music-assistant/home-assistant-addon` and `music-assistant/local-audio-addon`, not taken on trust.

Also:

- `faq/stream-to.mdx` claimed the add-on "will create a Sendspin player for each soundcard". It does not — there is one player, and the output is picked in the app's Audio panel or named as an ALSA device. Fixed, and pointed at the page.
- Dropped the tile and the `PLAYER_PROVIDERS` entry, so a retired provider no longer shows up as something to stream to. `knownUnlisted` and `KNOWN_UNCHARTED` adjusted to match.

Two things worth a reviewer's eye:

- **One addition beyond the brief**: a Local Audio row in the Supported Clients table on the Sendspin page. It is one line and easy to drop if you would rather not have it.
- **The 2.9 blog post is left alone.** It announces Local Audio Out, but it is a historical release note rather than a claim about the current release.

There is no `/assets/player-provider-summary.png` any more — the summary is the generated capability table, which never listed Local Audio Out because it was in `KNOWN_UNCHARTED`. So nothing to regenerate.

`pnpm install` and `pnpm build` both pass; 174 pages, unchanged. There is no `fetch-allowed-referrers` prestep in this repo — `build` is plain `astro build`.