### PR TITLE
Document the MilkDrop colour tint setting

### DIFF
--- a/src/content/docs/plugins/milkdrop-visualizer.md
+++ b/src/content/docs/plugins/milkdrop-visualizer.md
@@ -35,6 +35,7 @@ This plugin renders a <a href="https://github.com/jberg/butterchurn" target="_bl
 - <b>Switch preset on downbeat.</b> Automatically change preset on a downbeat, using Music Assistant's beat analysis. Takes precedence over a fixed preset.
 - <b>Minimum time between switches.</b> How long a preset stays on screen before a downbeat may switch it.
 - <b>Blur</b> and <b>opacity</b> are adjusted per user from the visualizer menu in the fullscreen player.
+- <b>Colour tint.</b> The visuals are tinted toward the current track's artwork colour. This is on by default and can be turned off in the plugin's advanced configuration settings.
 
 Favourite the preset currently showing with the star next to the preset picker in the fullscreen player.
 


### PR DESCRIPTION
## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

Documents the MilkDrop Visualizer colour tint: on by default, and can be turned off in the plugin's advanced configuration settings.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories
