### PR TITLE
Update plugin docs for the new Connected players setup

### DIFF
--- a/src/content/docs/plugins/airplay-receiver.md
+++ b/src/content/docs/plugins/airplay-receiver.md
@@ -18,7 +18,7 @@ Music Assistant has the ability to add <a href="https://www.apple.com/au/airplay
 ## Configuration
 
 1. Add the plugin via **Settings → Plugins → Add a plugin**. The plugin is added once and serves all your players.
-2. Under **Connected players**, select every player that should appear as an AirPlay device. Each selected player is advertised as its own AirPlay receiver, and the audio always plays on the player whose receiver you picked. The selection can be changed later in the plugin settings.
+2. Under **Connected players**, select every player that should appear as an AirPlay device. Each selected player is advertised as its own AirPlay receiver, and the audio always plays on the player whose receiver you picked in the sending app. The selection can be changed later in the plugin settings.
 3. Optionally change **Advertised device name**, which controls how the receivers are named after their player: `Player name | Music Assistant` (the default), `Player name only`, or `Music Assistant | Player name`. Renaming a player renames its receiver.
 
 ## Known Issues / Notes
@@ -26,4 +26,4 @@ Music Assistant has the ability to add <a href="https://www.apple.com/au/airplay
 - To use AirPlay, all devices must be connected to the same network
 - Due to buffering a delay of approximately 5 seconds is normal when playing, pausing and resuming
 - Using a HA Media Player as a connected player is not supported
-- When upgrading from an earlier version, where the plugin was added once per player, those copies are merged into a single configuration automatically
+- When upgrading from an earlier version (where the plugin was added once per player), the per-player copies are merged into a single configuration automatically

--- a/src/content/docs/plugins/airplay-receiver.md
+++ b/src/content/docs/plugins/airplay-receiver.md
@@ -17,10 +17,13 @@ Music Assistant has the ability to add <a href="https://www.apple.com/au/airplay
 
 ## Configuration
 
-To make each player appear as an AirPlay target, this plugin needs to be added individually for each player via **Settings → Plugins → Add a plugin**
+1. Add the plugin via **Settings → Plugins → Add a plugin**. The plugin is added once and serves all your players.
+2. Under **Connected players**, select every player that should appear as an AirPlay device. Each selected player is advertised as its own AirPlay receiver, and the audio always plays on the player whose receiver you picked. The selection can be changed later in the plugin settings.
+3. Optionally change **Advertised device name**, which controls how the receivers are named after their player: `Player name | Music Assistant` (the default), `Player name only`, or `Music Assistant | Player name`. Renaming a player renames its receiver.
 
 ## Known Issues / Notes
 
 - To use AirPlay, all devices must be connected to the same network
 - Due to buffering a delay of approximately 5 seconds is normal when playing, pausing and resuming
-- Using a HA Media Player as the `Connected Music Assistant Player` is not supported
+- Using a HA Media Player as a connected player is not supported
+- When upgrading from an earlier version, where the plugin was added once per player, those copies are merged into a single configuration automatically

--- a/src/content/docs/plugins/airplay-receiver.md
+++ b/src/content/docs/plugins/airplay-receiver.md
@@ -17,7 +17,7 @@ Music Assistant has the ability to add <a href="https://www.apple.com/au/airplay
 
 ## Configuration
 
-1. Add the plugin via **Settings → Plugins → Add a plugin**. The plugin is added once and serves all your players.
+1. Add the plugin via **Settings → Plugins → Add a plugin**. The plugin only needs to be added once.
 2. Under **Connected players**, select every player that should appear as an AirPlay device. Each selected player is advertised as its own AirPlay receiver, and the audio always plays on the player whose receiver you picked in the sending app. The selection can be changed later in the plugin settings.
 3. Optionally change **Advertised device name**, which controls how the receivers are named after their player: `Player name | Music Assistant` (the default), `Player name only`, or `Music Assistant | Player name`. Renaming a player renames its receiver.
 
@@ -25,5 +25,3 @@ Music Assistant has the ability to add <a href="https://www.apple.com/au/airplay
 
 - To use AirPlay, all devices must be connected to the same network
 - Due to buffering a delay of approximately 5 seconds is normal when playing, pausing and resuming
-- Using a HA Media Player as a connected player is not supported
-- When upgrading from an earlier version (where the plugin was added once per player), the per-player copies are merged into a single configuration automatically

--- a/src/content/docs/plugins/ariacast-receiver.md
+++ b/src/content/docs/plugins/ariacast-receiver.md
@@ -28,5 +28,5 @@ The **AriaCast Receiver** plugin allows for streaming of high-quality audio wire
 - **No Audio Playback**: If the app shows as connected but no audio is playing, try disconnecting and reconnecting from the Android app to reset the stream.
 - **Only One Sender at a Time**: The receiver accepts a single AriaCast sender at once. A second device attempting to connect while one is already streaming will be rejected until the first one disconnects.
 - **Startup Issues**: If the plugin fails to start (for example because port `12889` is already in use), check the Music Assistant logs for details.
-- **Asks for a player after upgrading**: older versions offered an `Auto` option for the connected player, which no longer exists. Hit **Reconfigure** on the plugin and select a player.
+- **Asks for a player after upgrading**: Older versions offered an `Auto` option for the connected player, which no longer exists. Click **Reconfigure** on the plugin and select a player.
 

--- a/src/content/docs/plugins/ariacast-receiver.md
+++ b/src/content/docs/plugins/ariacast-receiver.md
@@ -28,5 +28,4 @@ The **AriaCast Receiver** plugin allows for streaming of high-quality audio wire
 - **No Audio Playback**: If the app shows as connected but no audio is playing, try disconnecting and reconnecting from the Android app to reset the stream.
 - **Only One Sender at a Time**: The receiver accepts a single AriaCast sender at once. A second device attempting to connect while one is already streaming will be rejected until the first one disconnects.
 - **Startup Issues**: If the plugin fails to start (for example because port `12889` is already in use), check the Music Assistant logs for details.
-- **Asks for a player after upgrading**: Older versions offered an `Auto` option for the connected player, which no longer exists. Click **Reconfigure** on the plugin and select a player.
 

--- a/src/content/docs/plugins/ariacast-receiver.md
+++ b/src/content/docs/plugins/ariacast-receiver.md
@@ -13,9 +13,7 @@ The **AriaCast Receiver** plugin allows for streaming of high-quality audio wire
 
 ## Configuration
 1. Add the **AriaCast Receiver** plugin via **Settings → Plugins → Add a plugin**.
-2. Configure the playback settings:
-   - **Connected Player**: Select a specific player or set to "Auto" to use the currently active player.
-   - **AriaCast Device Name**: The name shown to AriaCast senders when they discover this receiver on the network. Defaults to "Music Assistant" if left empty.
+2. Choose the **Connected Music Assistant Player** that AriaCast audio should play on. The receiver announces itself to AriaCast senders under this player's name.
 
 ## Usage
 1. Install the [AriaCast Android app](https://github.com/AriaCast/AriaCast-app/releases/latest).
@@ -30,4 +28,5 @@ The **AriaCast Receiver** plugin allows for streaming of high-quality audio wire
 - **No Audio Playback**: If the app shows as connected but no audio is playing, try disconnecting and reconnecting from the Android app to reset the stream.
 - **Only One Sender at a Time**: The receiver accepts a single AriaCast sender at once. A second device attempting to connect while one is already streaming will be rejected until the first one disconnects.
 - **Startup Issues**: If the plugin fails to start (for example because port `12889` is already in use), check the Music Assistant logs for details.
+- **Asks for a player after upgrading**: older versions offered an `Auto` option for the connected player, which no longer exists. Hit **Reconfigure** on the plugin and select a player.
 

--- a/src/content/docs/plugins/spotify-connect.md
+++ b/src/content/docs/plugins/spotify-connect.md
@@ -22,7 +22,7 @@ The plugin can run on two different playback engines. You choose one while addin
 
 - Any MA player can be exposed as a Spotify Connect device, including groups
 - Every connected player appears as its own device in the Spotify app, named after the player
-- Playback can also be started from Music Assistant itself (from the player's source menu, or browse to `Live Inputs`), which resumes your last Spotify session on the device
+- Playback can also be started from Music Assistant itself (from the player's source menu, or by browsing to `Live Inputs`), which resumes your last Spotify session on the device
 - Stopping playback in Music Assistant releases the device in the Spotify app; moving playback to another device in the Spotify app stops the MA player
 - Crossfade and loudness normalization are configurable in the plugin settings
 - With the Soloist engine you can choose how volume behaves: `Player volume only` (default, the audio always arrives untouched) or syncing the Spotify app's volume slider with the player volume
@@ -35,10 +35,10 @@ The plugin can run on two different playback engines. You choose one while addin
 4. Optionally change **Advertised device name**, which controls how the devices are named after their player: `Player name | Music Assistant` (the default), `Player name only`, or `Music Assistant | Player name`. Renaming a player renames its device.
 
 > [!NOTE]
-> It is inadvisable to try and configure a Home Assistant player. Use only native Music Assistant players
+> Do not select Home Assistant players under **Connected players**. Use only native Music Assistant players
 
 > [!NOTE]
-> Upgrading from an earlier version? The plugin used to be added once per player; those copies are merged into a single configuration automatically, with your players preselected under **Connected players**. Every device gets a fresh identity in the Spotify app, so you may need to pick your player in the app's device list once again (an existing Soloist setup is carried over where possible). Home Assistant automations that referenced a per-player instance id such as `spotify_connect--xxxx` should now use plain `spotify_connect`.
+> Upgrading from an earlier version? The plugin used to be added once per player; those copies are merged into a single configuration automatically, with your players preselected under **Connected players**. Every device gets a fresh identity in the Spotify app, so you will need to pick your player in the app's device list once again (an existing Soloist setup is carried over where possible). Home Assistant automations that referenced a per-player instance id such as `spotify_connect--xxxx` should now use plain `spotify_connect`.
 
 ## Usage
 

--- a/src/content/docs/plugins/spotify-connect.md
+++ b/src/content/docs/plugins/spotify-connect.md
@@ -37,9 +37,6 @@ The plugin can run on two different playback engines. You choose one while addin
 > [!NOTE]
 > Home Assistant players are supported but not recommended — your mileage may vary. Native Music Assistant players work best.
 
-> [!NOTE]
-> Upgrading from an earlier version? Every device gets a fresh identity in the Spotify app, so you will need to pick your player in the app's device list once again. Home Assistant automations that referenced a per-player instance id such as `spotify_connect--xxxx` should now use plain `spotify_connect`.
-
 ## Usage
 
 1. Open the Spotify app on your phone, tablet or computer. The device must be on the same network as the Music Assistant server.

--- a/src/content/docs/plugins/spotify-connect.md
+++ b/src/content/docs/plugins/spotify-connect.md
@@ -29,16 +29,16 @@ The plugin can run on two different playback engines. You choose one while addin
 
 ## Configuration
 
-1. In Music Assistant, go to **Settings → Plugins**, click **Add a plugin** and select `Spotify Connect`. The plugin is added once and serves all your players.
+1. In Music Assistant, go to **Settings → Plugins**, click **Add a plugin** and select `Spotify Connect`. The plugin only needs to be added once.
 2. Choose the playback engine. For Soloist, the setup walks you through Spotify's terms and creating the API key.
-3. Under **Connected players**, select every player that should appear in the Spotify app. Each selected player is advertised as its own Spotify Connect device, and the audio always plays on the player whose device you picked in the app. The selection can be changed later in the plugin settings.
+3. When the setup has finished, open the plugin's settings. Under **Connected players**, select every player that should appear in the Spotify app. Each selected player is advertised as its own Spotify Connect device, and the audio always plays on the player whose device you picked in the app.
 4. Optionally change **Advertised device name**, which controls how the devices are named after their player: `Player name | Music Assistant` (the default), `Player name only`, or `Music Assistant | Player name`. Renaming a player renames its device.
 
 > [!NOTE]
-> Do not select Home Assistant players under **Connected players**. Use only native Music Assistant players
+> Home Assistant players are supported but not recommended — your mileage may vary. Native Music Assistant players work best.
 
 > [!NOTE]
-> Upgrading from an earlier version? The plugin used to be added once per player; those copies are merged into a single configuration automatically, with your players preselected under **Connected players**. Every device gets a fresh identity in the Spotify app, so you will need to pick your player in the app's device list once again (an existing Soloist setup is carried over where possible). Home Assistant automations that referenced a per-player instance id such as `spotify_connect--xxxx` should now use plain `spotify_connect`.
+> Upgrading from an earlier version? Every device gets a fresh identity in the Spotify app, so you will need to pick your player in the app's device list once again. Home Assistant automations that referenced a per-player instance id such as `spotify_connect--xxxx` should now use plain `spotify_connect`.
 
 ## Usage
 
@@ -51,5 +51,4 @@ The plugin can run on two different playback engines. You choose one while addin
 - To use Spotify Connect, all devices must be connected to the same network. Refer to the <a href="https://support.spotify.com/us/article/spotify-connect/" target="_blank" rel="noopener noreferrer">Spotify Connect Support Article</a> for more information (Note that any reference in that article to accessing devices from different WiFi networks isn't supported)
 - Depending on the player's own buffering there can be a short delay between an action in the Spotify app and hearing the result, and the Spotify app's progress can run slightly ahead of the audio
 - Spotify's delivered encoding and quality are not visible to Music Assistant. The signal path therefore shows the decoded PCM audio as it arrives from the playback engine (44.1 kHz/32-bit with Soloist) — not the quality of Spotify's source
-- Using a HA Media Player as a connected player is not supported
 - In complex network setups, if playback problems are experienced, the BIND TO option in the [Streams Settings](/settings/core/#generic) may need to be set

--- a/src/content/docs/plugins/spotify-connect.md
+++ b/src/content/docs/plugins/spotify-connect.md
@@ -21,32 +21,35 @@ The plugin can run on two different playback engines. You choose one while addin
 ## Features
 
 - Any MA player can be exposed as a Spotify Connect device, including groups
-- The name shown in the Spotify app is configurable per player
-- Playback can also be started from Music Assistant itself (browse to `Live Inputs`), which resumes your last Spotify session on the device
+- Every connected player appears as its own device in the Spotify app, named after the player
+- Playback can also be started from Music Assistant itself (from the player's source menu, or browse to `Live Inputs`), which resumes your last Spotify session on the device
 - Stopping playback in Music Assistant releases the device in the Spotify app; moving playback to another device in the Spotify app stops the MA player
 - Crossfade and loudness normalization are configurable in the plugin settings
 - With the Soloist engine you can choose how volume behaves: `Player volume only` (default, the audio always arrives untouched) or syncing the Spotify app's volume slider with the player volume
 
 ## Configuration
 
-1. In Music Assistant, go to **Settings → Plugins**, click **Add a plugin** and select `Spotify Connect`.
+1. In Music Assistant, go to **Settings → Plugins**, click **Add a plugin** and select `Spotify Connect`. The plugin is added once and serves all your players.
 2. Choose the playback engine. For Soloist, the setup walks you through Spotify's terms and creating the API key.
-3. Choose the Music Assistant player that should receive the Spotify audio, and the name to display in the Spotify app. Alternatively, set the player to `Auto` to send audio to whichever player is currently playing, or the first available player if none is playing.
-4. Repeat for each player you want to appear in the Spotify app; a separate instance of the plugin is added per player.
+3. Under **Connected players**, select every player that should appear in the Spotify app. Each selected player is advertised as its own Spotify Connect device, and the audio always plays on the player whose device you picked in the app. The selection can be changed later in the plugin settings.
+4. Optionally change **Advertised device name**, which controls how the devices are named after their player: `Player name | Music Assistant` (the default), `Player name only`, or `Music Assistant | Player name`. Renaming a player renames its device.
 
 > [!NOTE]
 > It is inadvisable to try and configure a Home Assistant player. Use only native Music Assistant players
+
+> [!NOTE]
+> Upgrading from an earlier version? The plugin used to be added once per player; those copies are merged into a single configuration automatically, with your players preselected under **Connected players**. Every device gets a fresh identity in the Spotify app, so you may need to pick your player in the app's device list once again (an existing Soloist setup is carried over where possible). Home Assistant automations that referenced a per-player instance id such as `spotify_connect--xxxx` should now use plain `spotify_connect`.
 
 ## Usage
 
 1. Open the Spotify app on your phone, tablet or computer. The device must be on the same network as the Music Assistant server.
 2. Start playing something, then open Spotify's device picker (the speaker icon).
-3. Select the Music Assistant player by the name you configured. The audio will now play through that player.
+3. Select the Music Assistant player by its name. The audio will now play through that player.
 
 ## Known Issues / Notes
 
 - To use Spotify Connect, all devices must be connected to the same network. Refer to the <a href="https://support.spotify.com/us/article/spotify-connect/" target="_blank" rel="noopener noreferrer">Spotify Connect Support Article</a> for more information (Note that any reference in that article to accessing devices from different WiFi networks isn't supported)
 - Depending on the player's own buffering there can be a short delay between an action in the Spotify app and hearing the result, and the Spotify app's progress can run slightly ahead of the audio
 - Spotify's delivered encoding and quality are not visible to Music Assistant. The signal path therefore shows the decoded PCM audio as it arrives from the playback engine (44.1 kHz/32-bit with Soloist) — not the quality of Spotify's source
-- Using a HA Media Player as the `Connected Music Assistant Player` is not supported
+- Using a HA Media Player as a connected player is not supported
 - In complex network setups, if playback problems are experienced, the BIND TO option in the [Streams Settings](/settings/core/#generic) may need to be set

--- a/src/content/docs/plugins/yandex-ynison.md
+++ b/src/content/docs/plugins/yandex-ynison.md
@@ -75,4 +75,4 @@ You can add the plugin more than once, one for each player you want to appear in
 - The connection to Yandex is a long-lived one and will drop and re-establish itself from time to time. This is normal and handled for you.
 - Announcements interrupt playback. It picks up again afterwards on players that support it.
 - Each copy of the plugin uses one Yandex account. Add more copies for more players, but they each still use a single account.
-- After upgrading from a version that offered `Auto` for the connected player, the plugin asks you to pick a player once — hit **Reconfigure** and select one.
+- After upgrading from a version that offered `Auto` for the connected player, the plugin asks you to pick a player once — click **Reconfigure** and select one.

--- a/src/content/docs/plugins/yandex-ynison.md
+++ b/src/content/docs/plugins/yandex-ynison.md
@@ -52,8 +52,8 @@ Set up the [Yandex Music](/music-providers/yandex-music/) source first. This plu
 2. For **Yandex Music source**, either:
    - pick your existing **Yandex Music** source, so the plugin can use the sign-in you already have (recommended, and it stays signed in on its own), or
    - pick **Use own token (manual entry)** and paste a token from [Yandex](https://oauth.yandex.ru/authorize?response_type=token&client_id=23cabbbdc6cd418abb4b39c32c41195d).
-3. Choose the **Connected Music Assistant Player** that should play the music when this device is picked in the Yandex Music app. `Auto` will use whichever player is already playing.
-4. Save. The name you gave under **Device name in Yandex Music** now appears in the Yandex Music app when you go to choose a speaker.
+3. Choose the **Connected Music Assistant Player** that should play the music when this device is picked in the Yandex Music app.
+4. Save. The player now shows up in the Yandex Music app, under its own name, when you go to choose a speaker.
 
 You can add the plugin more than once, one for each player you want to appear in the app.
 
@@ -61,11 +61,10 @@ You can add the plugin more than once, one for each player you want to appear in
 
 - **Yandex Music source** — use the sign-in from an existing Yandex Music source, or paste your own token instead.
 - **Yandex Music Token** — only appears if you chose to paste your own. A token entered here will expire and have to be replaced by hand.
-- **Connected Music Assistant Player** — the player that music will come out of. `Auto` picks whichever player is already playing, or the first available one if none is.
+- **Connected Music Assistant Player** — the player that music will come out of. Its name is also what the device is called in the Yandex Music app; renaming the player renames the device.
 - **Allow manual player switching** — with this on, picking this plugin as the source on any Music Assistant player moves playback to that player. With it off, playback stays on the player set above.
 - **Output sample rate** (advanced) — `Auto` uses 44.1 kHz for compressed music and 48 kHz for lossless, which suits almost everyone. Options: `Auto`, `44100`, `48000`, `96000`.
 - **Output bit depth** (advanced) — `Auto` uses 16 bit for compressed music and 24 bit for lossless. Options: `Auto`, `16`, `24`.
-- **Device name in Yandex Music** (advanced) — the name this device is given in the Yandex Music app.
 
 ## Known Issues / Notes
 
@@ -76,3 +75,4 @@ You can add the plugin more than once, one for each player you want to appear in
 - The connection to Yandex is a long-lived one and will drop and re-establish itself from time to time. This is normal and handled for you.
 - Announcements interrupt playback. It picks up again afterwards on players that support it.
 - Each copy of the plugin uses one Yandex account. Add more copies for more players, but they each still use a single account.
+- After upgrading from a version that offered `Auto` for the connected player, the plugin asks you to pick a player once — hit **Reconfigure** and select one.

--- a/src/content/docs/plugins/yandex-ynison.md
+++ b/src/content/docs/plugins/yandex-ynison.md
@@ -75,4 +75,3 @@ You can add the plugin more than once, one for each player you want to appear in
 - The connection to Yandex is a long-lived one and will drop and re-establish itself from time to time. This is normal and handled for you.
 - Announcements interrupt playback. It picks up again afterwards on players that support it.
 - Each copy of the plugin uses one Yandex account. Add more copies for more players, but they each still use a single account.
-- After upgrading from a version that offered `Auto` for the connected player, the plugin asks you to pick a player once — click **Reconfigure** and select one.


### PR DESCRIPTION
## What does this change?

Documents the reworked setup of the AudioSource plugins from music-assistant/server#6026 (released with 2.10):

- **Spotify Connect** and **AirPlay Receiver** are now added once; a **Connected players** multi-select advertises each selected player as its own device, named after the player via the **Advertised device name** template. The per-player instances and the free-form name field are gone.
- **AriaCast Receiver** and **Yandex Music Connect (Ynison)** now require a connected player (the `Auto` option is gone) and advertise it under the player's own name.
- Spotify Connect can now also be started from the player's source menu (music-assistant/frontend#2660).

Tracked in music-assistant/backlog#77.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories