### PR TITLE
Document that Sendspin on Cast devices is experimental and off by default

### DIFF
--- a/src/content/docs/faq/groups.md
+++ b/src/content/docs/faq/groups.md
@@ -17,7 +17,7 @@ For temporary and permanent sync groups the [protocol linking](/usage/#streaming
 <a href="/assets/group-diagram.png"><img src="/assets/group-diagram.png" alt="Preview image" style="width: 800px;"  loading="lazy" /></a>
 
 > [!NOTE]
-> Sendspin bridging will only be indicated on some devices and even then its not guaranteed to work due to device firmware limitations. AirPlay - Sendspin bridges should always work
+> Sendspin bridging will only be indicated on some devices and even then its not guaranteed to work due to device firmware limitations. AirPlay - Sendspin bridges should always work. On Chromecast devices Sendspin is experimental and switched off by default, so it has to be turned on per speaker before that speaker can join a Sendspin group, see [Sendspin on Cast devices](/player-support/google-cast/#sendspin-on-cast-devices)
 
 ## Temporary Sync Group
 

--- a/src/content/docs/player-support/google-cast.md
+++ b/src/content/docs/player-support/google-cast.md
@@ -12,7 +12,7 @@ Music Assistant has full support for Google Cast based devices. This includes Go
 - Music Assistant supports playing to cast groups which are created in the Google Home app
 - When using Google cast groups then perfect sync across players in that group is possible
 - Any physical control buttons on the device should be supported as well as voice control
-- Cast speakers can be synchronised with other Sendspin clients (experimental)
+- Cast speakers can be synchronised with other Sendspin clients. This is experimental and off by default, see [Sendspin on Cast devices](#sendspin-on-cast-devices)
 
 ## Configuration
 
@@ -35,6 +35,14 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - <b>[Prefer low-latency WAV for live sources](/settings/individual-player/#prefer-low-latency-wav-for-live-sources).</b> On by default for Cast devices. Turn it off if the device cannot play continuous WAV streams
 - <b>[Enable queue flow mode](/settings/individual-player/#enable-queue-flow-mode).</b> On by default, as these devices handle one continuous stream more reliably than being fed tracks one at a time
 
+## Sendspin on Cast devices
+
+A Cast speaker can also be driven over [Sendspin](/player-support/sendspin/), which lets it play in sync alongside Sendspin, AirPlay and Sonos players in one group. This is experimental and switched off by default, so there is nothing to do here unless you want a Cast speaker in a mixed group.
+
+To turn it on, open the player's settings, find Sendspin in the **Output Protocols** section and tick **Enable this protocol on this player (experimental)**.
+
+Expect to do some tuning afterwards. Playback is rarely in sync straight away, so you will probably have to set **Static playback delay (ms)** for that speaker by hand until it lines up with the others. Some recent Cast firmwares cannot run Sendspin at all and there is no way to tell in advance, so you only find out the first time you play something. When that happens Music Assistant says so and stops offering Sendspin for that speaker. The standard Cast protocol is unaffected and keeps working.
+
 ## Known Issues / Notes
 
 - Cast speakers do not support crossfading of audio. If you want crossfade and/or full gapless support, enable the "[flow mode](/faq/tech-info/#track-queueing)" in the player's advanced settings. Enabling flow mode may solve playback issues however it might come with the side effect of disabling actual physical buttons and/or display of metadata on the device itself
@@ -45,7 +53,7 @@ In addition to the [Individual Player Settings](/settings/individual-player/) an
 - Cast Groups containing only a stereo pair will not work
 - Problems have been reported with battery powered devices. The most likely working configuration in the individual player settings is queue flow mode on (generic settings), with `Profile 2 - no content length`, Output Codec MP3, and sample rates set to 44.1 kHz and 48 kHz at 16 bit (advanced settings)
 - MA serves all audio streams over a plain HTTP URL. Any device or software that requires HTTPS URLs will not work. For example, the Android app Castreceiver does not work
-- Google has removed functionality that enables Sendspin to work with some devices. If a message is heard that Sendspin does not work with the device then navigate to the player settings, OutPut Protocols section and disable Sendspin
+- Google has removed functionality that Sendspin needs on some devices. If a message says Sendspin does not work with the device, Music Assistant stops offering Sendspin for that speaker and will not offer it again. There is nothing to do, playback continues over the standard Cast protocol
 
 ## Troubleshooting playback problems
 

--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -64,7 +64,7 @@ Several client types can connect to Music Assistant via Sendspin:
 | Client | Description |
 |--------|-------------|
 | **Web Browser** | The built-in Music Assistant web player uses Sendspin for local playback |
-| **[Google Cast (Sendspin mode)](/player-support/google-cast/)** | Experimental Sendspin mode for Chromecast devices |
+| **[Google Cast (Sendspin mode)](/player-support/google-cast/)** | Experimental Sendspin mode for Chromecast devices, off by default. See [Sendspin on Cast devices](/player-support/google-cast/#sendspin-on-cast-devices) |
 | **<a href="https://esphome.github.io/home-assistant-voice-pe/" target="_blank" rel="noopener noreferrer">Home Assistant Voice PE</a>** | Built into recent Voice PE firmware. Update the device with the official installer, choosing a pre-release build if the current stable one does not show up as a player |
 | **[Local Audio](/player-support/local-audio/)** | Plays to the soundcard, USB DAC or built-in output of the machine it runs on. Deploys as a Home Assistant App or with Docker Compose |
 | **<a href="https://github.com/trudenboy/sendspin-bt-bridge" target="_blank" rel="noopener noreferrer">Sendspin Bluetooth Bridge</a>** | Bridges Bluetooth speakers as MA players, with multi-device support, multiroom sync and a web dashboard. Deploys as a Home Assistant App, Docker, or LXC |

--- a/src/content/docs/settings/individual-player.md
+++ b/src/content/docs/settings/individual-player.md
@@ -37,7 +37,7 @@ Some players (e.g. [MusicCast](/player-support/musiccast/) have [unique control 
 
 - <b>Preferred Output Protocol.</b> Choose from the list of available protocols
 
-Each available protocol then has its own configuration section. Protocols can be disabled except for the native protocol of the device. The [Audio Pipeline](/audiopipeline/) view shows which protocol a player is actually using and what the audio quality is at each stage.
+Each available protocol then has its own configuration section. Protocols can be disabled except for the native protocol of the device. A protocol whose toggle says *(experimental)* is switched off until you turn it on yourself, with a warning above the toggle explaining what to expect. The [Audio Pipeline](/audiopipeline/) view shows which protocol a player is actually using and what the audio quality is at each stage.
 
 ### Settings shared by most protocols
 


### PR DESCRIPTION
## What does this change?

Sendspin on Cast devices is now experimental and switched off by default, so the docs said a few things that no longer hold. Follows server PR https://github.com/music-assistant/server/pull/6081, which is being backported to stable, so this targets `main`.

The main correction is in the Google Cast known issues, which told users to go and disable Sendspin themselves when a device reports it cannot run it. Music Assistant now does that for them and stops offering it for that speaker.

- New "Sendspin on Cast devices" section on the Google Cast page: what it is for, where the toggle is, and that the playback delay usually needs setting by hand
- Google Cast features list and known issues updated to match
- Sendspin page notes in the client table that Cast mode is off by default
- Groups FAQ note says a Cast speaker has to be turned on before it can join a Sendspin group
- Individual player settings explains what an *(experimental)* protocol toggle means

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers
