### PR TITLE
Document the free-text Features rows, and tidy the Login Method values

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,25 @@ and a rough one is much better than leaving your source out of a language its li
 for. If you cannot find a flag at all, add the category without one, say so on the pull request
 and somebody will sort it out.
 
+### What to put in the free-text rows
+
+Most rows in the `Features` table are Yes or No. Three carry free text and are shown in the
+comparison exactly as you write them, so keep them in the same form as the other pages.
+
+**Maximum Stream Quality.** Give the codec and the ceiling: `FLAC 192kHz 24 bit`, `MP3 320kbps`,
+`AAC 256kbps`. The build reads this to decide whether the source is shown as Hi-Res, CD or Lossy.
+A bare codec name like `MP3` is accepted, but it does not say what the maximum is, which is the
+whole point of the column, so give the bitrate. Where the quality genuinely varies, use
+`Lossy variable bitrate` or `Varies by station`.
+
+**Login Method.** One of `None`, `Password`, `OAuth`, `Cookie` or `Token`. Where more than one
+works, join them with `or` and put the easiest first, as in `None or Password`. Add a bracketed
+qualifier only where it changes what the user has to do, as in `Cookie (ARL)`. Do not describe the
+credential itself: signing in with an email address and a password is still `Password`.
+
+**Media Types Supported.** A comma separated list drawn from Artists, Albums, Tracks, Playlists,
+Radio, Podcasts and Audiobooks. Step 4 above explains how these map onto the tile categories.
+
 ## Adding a player provider
 
 Four things, and the build will tell you if you miss either of the last two.

--- a/src/content/docs/music-providers/local-files.md
+++ b/src/content/docs/music-providers/local-files.md
@@ -23,7 +23,7 @@ When streaming sources are also available in MA linking will only occur when the
 | Similar Artists Support                         |            No                      |
 | Similar Tracks Support                          |            Yes with Sonic Similarity Plugin                      | 
 | Maximum Stream Quality | FLAC 192kHz 24 bit |
-| Login Method | Password or None |
+| Login Method | None or Password |
 
 ### Other
 

--- a/src/content/docs/music-providers/musicme.md
+++ b/src/content/docs/music-providers/musicme.md
@@ -31,7 +31,7 @@ This source signs Music Assistant in to your MusicMe account and makes the catal
 | Similar Artists Support                         |            No                      |
 | Similar Tracks Support                          |            No                     | 
 | Maximum Stream Quality | AAC 320kbps |
-| Login Method | Email + Password |
+| Login Method | Password |
 
 ### Other
 

--- a/src/content/docs/music-providers/pocketcasts.md
+++ b/src/content/docs/music-providers/pocketcasts.md
@@ -24,7 +24,7 @@ Music Assistant becomes another of those devices, reading from and writing back 
 | Similar Artists Support                         |            No                      |
 | Similar Tracks Support                          |            No                      | 
 | Maximum Stream Quality | Varies by feed |
-| Login Method | Email & Password |
+| Login Method | Password |
 
 ### Other
 

--- a/src/data/player-capabilities.ts
+++ b/src/data/player-capabilities.ts
@@ -70,7 +70,7 @@ export const CAPABILITY_COLUMNS: CapabilityColumn[] = [
     id: "syncCorrection",
     label: "Sync Adjust",
     help: "A per-player delay can be applied to pull a player that runs ahead of or behind the rest of its group back into line.",
-    href: "/player-support/airplay/#player-settings",
+    href: "/player-support/airplay/#protocol-settings",
   },
   {
     id: "crossfade",


### PR DESCRIPTION
## What does this change?

Three rows of the `Features` table are free text rather than Yes or No, and are printed into the comparison on [I Want To Listen To](https://music-assistant.io/faq/listen-to/) exactly as written. Nothing said what belongs in them, so this adds a `What to put in the free-text rows` section to `CONTRIBUTING.md`.

- **Maximum Stream Quality.** Give the codec and the ceiling. A bare `MP3` builds fine and resolves to Lossy, but says nothing about the maximum, which is what the column is for. `Lossy variable bitrate` and `Varies by station` are the established forms where it genuinely varies.
- **Login Method.** `None`, `Password`, `OAuth`, `Cookie` or `Token`, joined with `or` where more than one works, easiest first. A bracketed qualifier only where it changes what the user has to do, as in `Cookie (ARL)`.
- **Media Types Supported.** A comma separated list from the standard terms.

It also normalises three pages that said the same thing in different words, which is what prompted the question:

| Page | Was | Now |
|:--|:--|:--|
| `musicme` | `Email + Password` | `Password` |
| `pocketcasts` | `Email & Password` | `Password` |
| `local-files` | `Password or None` | `None or Password` |

That leaves `Password` on 15 pages, `None` on 15, `OAuth` on 3, `Token` on 2 and `None or Password` on 2. The remaining one-off values describe something the five-value set genuinely does not cover, such as `Device Flow / QR Code / Token`, and are left alone.

Finally, `player-capabilities.ts` pointed the Sync Adjust column at `/player-support/airplay/#player-settings`. That heading no longer exists after the AirPlay page was reorganised, so the link landed at the top of the page. The setting it refers to is under **Protocol Settings**. This was the only broken internal link on the site.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

Not applicable, no source or provider added.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL)_