### PR TITLE
Added Spotify Connect zeroconf static port doc

### DIFF
--- a/src/content/docs/plugins/spotify-connect.md
+++ b/src/content/docs/plugins/spotify-connect.md
@@ -26,6 +26,7 @@ The plugin can run on two different playback engines. You choose one while addin
 - Stopping playback in Music Assistant releases the device in the Spotify app; moving playback to another device in the Spotify app stops the MA player
 - Crossfade and loudness normalization are configurable in the plugin settings
 - With the Soloist engine you can choose how volume behaves: `Player volume only` (default, the audio always arrives untouched) or syncing the Spotify app's volume slider with the player volume
+- With the go-librespot engine, its network port for Spotify Connect discovery can be pinned to a fixed/static value in advanced settings, instead of a random/ephemeral one on every restart — useful behind a strict firewall or with Docker's host networking mode
 
 ## Configuration
 


### PR DESCRIPTION
<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

Adds documentation for optionally specifying a static port to Spotify Connect discovery.

Server PR: music-assistant/server#6109

## Checklist

- [X] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
