### PR TITLE
Add version badge component and fetch latest release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ dist/
 
 # Generated at build time
 /src/data/allowed-referrers.json
+/src/data/latest-release.json
 
 # Blog post drafts
 /create-blog-post/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -329,6 +329,7 @@ export default defineConfig({
         Footer: "./src/components/Footer.astro",
         ThemeProvider: "./src/components/ThemeProvider.astro",
         ThemeSelect: "./src/components/ThemeSelect.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
       },
     }),
     mdx(),

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "0.0.1",
   "scripts": {
     "fetch-allowed-referrers": "node ./scripts/fetch-allowed-referrers.mjs",
-    "predev": "npm run fetch-allowed-referrers",
+    "fetch-latest-release": "node ./scripts/fetch-latest-release.mjs",
+    "predev": "npm run fetch-allowed-referrers && npm run fetch-latest-release",
     "dev": "astro dev --host",
-    "prestart": "npm run fetch-allowed-referrers",
+    "prestart": "npm run fetch-allowed-referrers && npm run fetch-latest-release",
     "start": "astro dev --host",
-    "prebuild": "npm run fetch-allowed-referrers",
+    "prebuild": "npm run fetch-allowed-referrers && npm run fetch-latest-release",
     "build": "astro build",
     "preview": "astro preview --host",
     "astro": "astro"

--- a/scripts/fetch-latest-release.mjs
+++ b/scripts/fetch-latest-release.mjs
@@ -1,0 +1,30 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_URL =
+  "https://api.github.com/repos/music-assistant/server/releases/latest";
+const OUTPUT = fileURLToPath(
+  new URL("../src/data/latest-release.json", import.meta.url),
+);
+
+async function main() {
+  const response = await fetch(SOURCE_URL, {
+    headers: {
+      "User-Agent": "music-assistant.io-build",
+      Accept: "application/vnd.github+json",
+    },
+  });
+  if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+  const data = await response.json();
+  if (typeof data.tag_name !== "string" || !data.tag_name)
+    throw new Error("payload has no tag_name");
+  const release = { version: data.tag_name, url: data.html_url };
+  await mkdir(dirname(OUTPUT), { recursive: true });
+  await writeFile(OUTPUT, JSON.stringify(release, null, 2) + "\n");
+  console.log(`[latest-release] wrote version ${release.version}`);
+}
+
+main().catch((e) =>
+  console.warn(`[latest-release] fetch failed, keeping committed file. ${e}`),
+);

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,0 +1,49 @@
+---
+import Default from "@astrojs/starlight/components/SiteTitle.astro";
+import latestRelease from "../data/latest-release.json";
+
+const { version, url } = latestRelease as { version?: string; url?: string };
+---
+
+<Default {...Astro.props}><slot /></Default>
+{
+  version && url && (
+    <a
+      href={url}
+      class="version-badge"
+      title={`Music Assistant ${version}`}
+      translate="no"
+    >
+      {version}
+    </a>
+  )
+}
+
+<style>
+  :global(.title-wrapper) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .version-badge {
+    padding: 0 4px;
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 15px;
+    height: 15px;
+    letter-spacing: 0.4px;
+    color: var(--sl-color-black);
+    background-color: var(--sl-color-bg-accent);
+    border-radius: 4px;
+    text-decoration: none;
+    white-space: nowrap;
+    transition:
+      background-color 0.3s ease-in-out,
+      color 0.3s ease-in-out;
+  }
+  .version-badge:hover {
+    background-color: var(--sl-color-accent-low);
+    color: var(--sl-color-text);
+  }
+</style>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -1,8 +1,26 @@
 ---
 import Default from "@astrojs/starlight/components/SiteTitle.astro";
+import { getCollection } from "astro:content";
 import latestRelease from "../data/latest-release.json";
 
-const { version, url } = latestRelease as { version?: string; url?: string };
+const { version, url: githubUrl } = latestRelease as {
+  version?: string;
+  url?: string;
+};
+
+// Link the badge to our own announcement post rather than the GitHub release,
+// since that's more useful to visitors. Blog posts are only published per
+// minor version, so just take the most recent one tagged "release" rather
+// than trying to match it to the exact (possibly patch-level) version above.
+const releasePosts = await getCollection(
+  "docs",
+  (entry) =>
+    entry.id.startsWith("blog/") && (entry.data.tags ?? []).includes("release"),
+);
+const latestPost = releasePosts.sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+)[0];
+const url = latestPost ? `/${latestPost.id}/` : githubUrl;
 ---
 
 <Default {...Astro.props}><slot /></Default>

--- a/src/components/SiteTitle.astro
+++ b/src/components/SiteTitle.astro
@@ -56,6 +56,8 @@ const url = latestPost ? `/${latestPost.id}/` : githubUrl;
     border-radius: 4px;
     text-decoration: none;
     white-space: nowrap;
+    align-self: end;
+    transform: translateY(-10px);
     transition:
       background-color 0.3s ease-in-out,
       color 0.3s ease-in-out;


### PR DESCRIPTION
On build of this website, fetch the latest Music Assistant version from `https://api.github.com/repos/music-assistant/server/releases/latest` and use that number in the badge (badge links to the latest 'release' tagged blog post).

The GitHub release page is the source of truth for the current version number and when it is updated, this website will need to rebuild to show the updated version number in the tag - in most cases this is fine due to the frequent activity on the repo.

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [ ] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
