### PR TITLE
Let the build survive a failed release lookup

### DIFF
--- a/scripts/fetch-latest-release.mjs
+++ b/scripts/fetch-latest-release.mjs
@@ -1,4 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -25,6 +26,19 @@ async function main() {
   console.log(`[latest-release] wrote version ${release.version}`);
 }
 
-main().catch((e) =>
-  console.warn(`[latest-release] fetch failed, keeping committed file. ${e}`),
-);
+// The file is not committed, so a build starting from a fresh clone has
+// nothing to fall back on and Astro cannot resolve the import. Write an empty
+// object instead: SiteTitle.astro only renders the badge when it finds both a
+// version and a url, so the build succeeds and the badge is simply left off.
+// An existing file is kept, so a local dev server carries on showing whatever
+// it last fetched.
+main().catch(async (e) => {
+  console.warn(`[latest-release] fetch failed. ${e}`);
+  if (existsSync(OUTPUT)) {
+    console.warn("[latest-release] keeping the file already on disk");
+    return;
+  }
+  await mkdir(dirname(OUTPUT), { recursive: true });
+  await writeFile(OUTPUT, "{}\n");
+  console.warn("[latest-release] wrote an empty file so the build can proceed");
+});


### PR DESCRIPTION
## What does this change?

Fixes the build failure on #1014.

`prebuild` runs `scripts/fetch-latest-release.mjs`, which fetches the latest server release from the GitHub API and writes `src/data/latest-release.json`. When the fetch fails it warns:

```
[latest-release] fetch failed, keeping committed file.
```

But there is no committed file to keep. `src/data/latest-release.json` is in `.gitignore` at line 175. So the script exits 0, the build carries on, and Astro dies at:

```
Could not resolve "../data/latest-release.json" from "src/components/SiteTitle.astro"
```

Netlify always builds from a fresh clone, so that file is never present at the start of a deploy. Every build therefore depends on one unauthenticated GitHub API call succeeding. Unauthenticated calls are rate limited per IP and Netlify builds come from shared addresses, so this fails intermittently and cannot be fixed by retriggering.

The catch now writes `{}` when no file exists. `SiteTitle.astro` already renders the badge only `when version && url`, so the page builds and the version badge is simply left off. A file already on disk is kept, so a local dev server carries on showing whatever it last fetched.

Verified by making the fetch fail and building: the script writes the empty file, the build completes, and the badge is absent rather than the deploy dying.

Committing the JSON instead would also work, but the badge would then show a stale version whenever the fetch failed, which is worse than showing nothing.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

Not applicable.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QK5GNg9GuNKa1xNxw2adVL)_