### PR TITLE
Rename Sendspin page heading to Sendspin

### DIFF
--- a/src/content/docs/player-support/sendspin.md
+++ b/src/content/docs/player-support/sendspin.md
@@ -2,7 +2,7 @@
 title: "Sendspin"
 ---
 
-# Sendspin-audio Provider  <img src="/assets/icons/sendspin-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
+# Sendspin <img src="/assets/icons/sendspin-icon.svg" alt="Preview image" style="width: 70px; float: right;"  loading="lazy" />
 
 <a href="https://www.sendspin-audio.com/" target="_blank" rel="noopener noreferrer">Sendspin</a> is Music Assistant's own way of sending audio to a player. It keeps several devices playing in sync with each other, closely enough that the same track can play in more than one room without any echo between them.
 


### PR DESCRIPTION
## What does this change?

The Sendspin player-support page had the heading `Sendspin-audio Provider`. It is now just `Sendspin`, which matches the sibling pages (AirPlay, Google Cast, Snapcast) and the page's own frontmatter title. The page anchor changes from `#sendspin-audio-provider--` to `#sendspin`; nothing in the repository linked to the old anchor.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [x] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhFCMwqFjQ6o2PKKWAZSjP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhFCMwqFjQ6o2PKKWAZSjP)_