### PR TITLE
Add Mobile MA (native iOS app) to community extensions

### DIFF
--- a/src/content/docs/community-extensions.md
+++ b/src/content/docs/community-extensions.md
@@ -76,3 +76,16 @@ A responsive cover wall for the Home Assistant Sections view that displays your 
 HOMEii Flow is a premium, minimalist music app experience for Music Assistant, fully responsive and optimized for **Desktop, Tablet, and Mobile**. It features a high-end UI with glassmorphism effects, dynamic backgrounds, and a specialized Studio Mode for a seamless experience across all your devices.
 
 <img src="https://raw.githubusercontent.com/r11a/homeii-music-flow/main/HOMEii%20Flow%20Main.png" alt="HOMEii Flow - Responsive UI for Mobile, Tablet and Desktop" style="width: 600px;"  loading="lazy" />
+
+
+*********************************
+
+
+## [Mobile MA – Native iOS App for Music Assistant](https://www.mobile-ma.app/en/)
+
+<img width="1600" height="900" alt="mobile-ma-community" src="https://github.com/user-attachments/assets/c88230ec-819c-4e1b-9b5b-a33a088b4d8b" />
+
+Mobile MA is a native SwiftUI app for iPhone and iPad that turns your device into a full remote and player for Music Assistant. Control every player and multiroom group, browse your library, podcasts and radio, and stream straight to your iPhone via Sendspin – at home over LAN or on the go through WebRTC remote access, without a VPN or cloud account. Comes with CarPlay, an Apple Watch remote, a companion Apple TV app, Siri and widgets. Free on the App Store with an optional one-time Unlimited upgrade (no subscription). Requires Music Assistant 2.9 or newer.
+
+[Mobile MA – native iOS app for Music Assistant](https://www.mobile-ma.app/en/)
+


### PR DESCRIPTION
Adds Mobile MA to the Community Extensions page.

Mobile MA is an unofficial, native SwiftUI client for Music Assistant (iPhone, iPad, Apple Watch, Apple TV, CarPlay) with Sendspin local playback and WebRTC remote access. It is available on the App Store; website: https://www.mobile-ma.app/en/

The entry follows the existing format (linked heading, one paragraph, one image) and is placed at the end of the list. The app is free with an optional one-time purchase; this is stated transparently in the description.

I'm the developer of the app – happy to adjust the wording or the placement if the page should stay HA-card-only.

<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

<!-- A sentence or two. Link the server pull request if there is one. -->

## Checklist

- [ ] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
