### PR TITLE
Document AmpliPi controller discovery during setup

### DIFF
--- a/src/content/docs/player-support/amplipi.md
+++ b/src/content/docs/player-support/amplipi.md
@@ -20,13 +20,15 @@ Music Assistant has support for the <a href="https://www.amplipi.com/" target="_
 ## Configuration
 
 1. In Music Assistant, go to **Settings → Player Providers**, click **Add a player provider** and select `AmpliPi`.
-2. Enter the hostname or IP address of your AmpliPi controller in the `Host` setting (AmpliPi controllers are not discovered automatically). See Settings below for the details.
+2. Confirm the `Host` setting. Controllers on your local network are found automatically and the field is prefilled with the first one that is not set up yet; if yours was not found, enter its hostname or IP address. See Settings below for the details.
 
 ## Settings
 
 In addition to the [Player Provider Settings](/settings/player-provider/) when setting up this provider the following settings are available:
 
-- <b>Host.</b> The hostname or IP address of the AmpliPi controller (e.g. `amplipi.local` or `192.168.1.50`). A full URL may also be provided. This is asked when you add the provider and is required, as AmpliPi controllers are not auto-discovered
+- <b>Host.</b> The hostname or IP address of the AmpliPi controller (e.g. `amplipi.local` or `192.168.1.50`). A full URL may also be provided. This is asked when you add the provider and is required. Controllers on the local network are discovered over mDNS and the field is prefilled with the first one not yet set up in Music Assistant, so normally you only need to confirm it. Enter the address by hand when the controller is on another subnet or reachable only through a custom DNS name
+
+Each controller can be set up only once: adding a controller that is already configured is refused. To change its address, reconfigure the existing provider instance instead.
 
 Each zone on the controller becomes its own player. AmpliPi zones use the standard [Individual Player Settings](/settings/individual-player/), including the [settings shared by most protocols](/settings/individual-player/#settings-shared-by-most-protocols).
 


### PR DESCRIPTION
<!--
Thanks for contributing. The checklist below is short but the build enforces most
of it, so ticking it off saves a round trip.

Full guide: https://github.com/music-assistant/music-assistant.io/blob/beta/CONTRIBUTING.md
-->

## What does this change?

This updates the documentation regarding AmpliPi controller autodisccovery per https://github.com/music-assistant/server/pull/6206.

## Checklist

- [x] Correct branch: `main` if this fixes something already on the live site, `beta` if it adds anything new
- [ ] Any new page has a sidebar entry in `astro.config.mjs`, except music sources and player providers

### Only if you are adding a music source or a player provider

<!-- Plugins, metadata providers and audio analysis providers do not need these. -->

- [ ] File named after the source or provider, since the menu is sorted by filename
- [ ] Icon added to `public/assets/icons/`, and it is visible against a white background
- [ ] Entry added to `src/data/music-sources.ts` or `src/data/players.ts`, with categories

---

Once this is open, scroll down to the checks and wait for **Deploy Preview**. If it is green,
click the link to see your change on the site. If it is red, click `Details`, read the error at
the bottom of the log and push a fix to the same branch. There is no need to open a new pull
request.
